### PR TITLE
fix cut and sed issues on Mac plus spellcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ROW_MAJOR ?= 0
 # and (3,3,3). This way a heterogeneous set can be generated e.g., "1 2, 3" generates (1,1,1), (1,1,2),
 # (1,2,1), (1,2,2), (2,1,1), (2,1,2) (2,2,1) out of the first group, and a (3,3,3) for the second group
 # To generate a series of square matrices one can specify e.g., make MNK=$(echo $(seq -s, 1 5))
-# Alternative to MNK, index sets can be specified spearately according to a loop nest relationship
+# Alternative to MNK, index sets can be specified separately according to a loop nest relationship
 # (M(N(K))) using M, N, and K separately. Please consult the documentation for further details.
 MNK ?= 0
 

--- a/src/generator_driver.c
+++ b/src/generator_driver.c
@@ -42,7 +42,7 @@ void print_help() {
   printf("Usage (sparse*dense=dense, dense*sparse=dense):\n");
   printf("    sparse\n");
   printf("    filename to append\n");
-  printf("    rountine name\n");
+  printf("    routine name\n");
   printf("    M\n");
   printf("    N\n");
   printf("    K\n");
@@ -61,7 +61,7 @@ void print_help() {
   printf("Usage (dense*dense=dense):\n");
   printf("    dense\n");
   printf("    filename to append\n");
-  printf("    rountine name\n");
+  printf("    routine name\n");
   printf("    M\n");
   printf("    N\n");
   printf("    K\n");


### PR DESCRIPTION
1) i fixed two spelling errors in comments because i am OCD about grammar (but not capitalization, as you can see)
2) Mac (and other non-Linux systems) have lame cut/sed that do not like some of the options used.  make them work on Mac with non-standard cut and modification to sed invocation.