### PR TITLE
Wrap make test in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: cpp
 
 addons.apt.packages: 
+ - build-essential
  - gfortran
+ - libblas-dev
  - liblapack-dev
 
 compiler:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: cpp
 addons:
   apt:
     packages: 
-    - build-essential
     - gfortran
     - libblas-dev
     - liblapack-dev
@@ -14,4 +13,3 @@ compiler:
 
 script: 
  - make MNK="2 3, 23" test
- - grep "diff" samples/cp2k/cp2k-perf.txt | grep -v "diff=0.000" 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: cpp
 
-addons.apt.packages: 
- - build-essential
- - gfortran
- - libblas-dev
- - liblapack-dev
+addons:
+  apt:
+    packages: 
+    - build-essential
+    - gfortran
+    - libblas-dev
+    - liblapack-dev
 
 compiler:
   - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: C
+
+before_install: 
+- sudo apt-get update -qq
+ - sudo apt-get install -y liblapack-dev
+ - sudo apt-get install -y build-essentials
+ - sudo apt-get install -y gfortran 
+
+script: 
+ - make MNK="2 3, 23" test
+ - grep "diff" samples/cp2k/cp2k-perf.txt | grep -v "diff=0.000" 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,5 @@ compiler:
 
 script: 
  - make MNK="2 3, 23" test
+ - cd samples/cp2k/
+ - bash test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ before_install:
 - sudo apt-get update -qq
  - sudo apt-get install -y liblapack-dev
  - sudo apt-get install -y build-essentials
- - sudo apt-get install -y gfortran 
 
 script: 
  - make MNK="2 3, 23" test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
-language: C
+language: cpp
+
+compiler:
+  - clang
+  - gcc
 
 before_install: 
  - sudo apt-get update -qq
  - sudo apt-get install -y liblapack-dev
- - sudo apt-get install -y build-essentials
 
 script: 
  - make MNK="2 3, 23" test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: C
 
 before_install: 
-- sudo apt-get update -qq
+ - sudo apt-get update -qq
  - sudo apt-get install -y liblapack-dev
  - sudo apt-get install -y build-essentials
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: cpp
 
+addons.apt.packages: 
+ - gfortran
+ - liblapack-dev
+
 compiler:
   - clang
   - gcc
-
-before_install: 
- - sudo apt-get update -qq
- - sudo apt-get install -y liblapack-dev
 
 script: 
  - make MNK="2 3, 23" test

--- a/samples/cp2k/test.sh
+++ b/samples/cp2k/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+if [ `grep "diff" cp2k-perf.txt | grep -v -c "diff=0.000"` -eq 0 ]; then
+  exit 0
+else
+  exit 1
+fi


### PR DESCRIPTION
Nothing too exciting.  `grep` returns `1` when no lines are found, which travis considers a fail (while its our succeed).  `test.sh` just wraps the grep to invert that output.

Closes #11 