### PR TITLE
adds specfem sample

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -754,6 +754,20 @@ smm_mic: lib_mic
 		DEPSTATIC=$(STATIC) SYM=$(SYM) DBG=$(DBG) IPO=$(IPO) MIC=1 TRACE=$(TRACE) \
 		EFLAGS=$(EFLAGS) ELDFLAGS=$(ELDFLAGS) ECXXFLAGS=$(ECXXFLAGS) ECFLAGS=$(ECFLAGS) EFCFLAGS=$(EFCFLAGS)
 
+# added for specfem sample
+# will need option: make MNK="5 25" ..
+.PHONY: specfem
+specfem: lib_hst
+	@cd $(SPLDIR)/specfem && $(MAKE) --no-print-directory \
+		DEPSTATIC=$(STATIC) SYM=$(SYM) DBG=$(DBG) IPO=$(IPO) SSE=$(SSE) AVX=$(AVX) OFFLOAD=$(OFFLOAD) TRACE=$(TRACE) \
+		EFLAGS=$(EFLAGS) ELDFLAGS=$(ELDFLAGS) ECXXFLAGS=$(ECXXFLAGS) ECFLAGS=$(ECFLAGS) EFCFLAGS=$(EFCFLAGS)
+
+.PHONY: specfem_mic
+specfem_mic: lib_mic
+	@cd $(SPLDIR)/specfem && $(MAKE) --no-print-directory \
+		DEPSTATIC=$(STATIC) SYM=$(SYM) DBG=$(DBG) IPO=$(IPO) MIC=1 TRACE=$(TRACE) \
+		EFLAGS=$(EFLAGS) ELDFLAGS=$(ELDFLAGS) ECXXFLAGS=$(ECXXFLAGS) ECFLAGS=$(ECFLAGS) EFCFLAGS=$(EFCFLAGS)
+
 .PHONY: drytest
 drytest: $(SPLDIR)/cp2k/cp2k-perf.sh $(SPLDIR)/smm/smmf-perf.sh \
 	$(SPLDIR)/nek/axhm-perf.sh $(SPLDIR)/nek/grad-perf.sh $(SPLDIR)/nek/rstr-perf.sh

--- a/samples/specfem/Makefile
+++ b/samples/specfem/Makefile
@@ -1,0 +1,175 @@
+# Export all variables to sub-make processes.
+#.EXPORT_ALL_VARIABLES: #export
+
+# Automatically disable parallel builds
+# depending on the version of GNU Make.
+# MAKE_PARALLEL=0: disable explicitly
+# MAKE_PARALLEL=1: enable explicitly
+ifeq (0,$(MAKE_PARALLEL))
+.NOTPARALLEL:
+else ifeq (,$(MAKE_PARALLEL))
+ifneq (3.82,$(firstword $(sort $(MAKE_VERSION) 3.82)))
+.NOTPARALLEL:
+endif
+endif
+
+ROOTDIR = $(abspath $(dir $(firstword $(MAKEFILE_LIST))))
+DEPDIR = ../..
+SRCDIR = $(ROOTDIR)
+INCDIR = .
+BLDDIR = build
+OUTDIR = .
+
+CXXFLAGS = $(NULL)
+CFLAGS = $(NULL)
+DFLAGS = $(NULL)
+IFLAGS = -I$(INCDIR) -I$(DEPDIR)/include
+
+BLAS = 1
+OMP = 1
+SYM = 1
+
+# include common Makefile artifacts
+include $(DEPDIR)/Makefile.inc
+
+OUTNAME := $(shell basename $(ROOTDIR))
+HEADERS := $(shell ls -1 $(INCDIR)/*.h   2> /dev/null | tr "\n" " ") \
+           $(shell ls -1 $(INCDIR)/*.hpp 2> /dev/null | tr "\n" " ") \
+           $(shell ls -1 $(INCDIR)/*.hxx 2> /dev/null | tr "\n" " ") \
+           $(shell ls -1 $(INCDIR)/*.hh  2> /dev/null | tr "\n" " ") \
+           $(shell ls -1 $(SRCDIR)/*.h   2> /dev/null | tr "\n" " ") \
+           $(shell ls -1 $(SRCDIR)/*.hpp 2> /dev/null | tr "\n" " ") \
+           $(shell ls -1 $(SRCDIR)/*.hxx 2> /dev/null | tr "\n" " ") \
+           $(shell ls -1 $(SRCDIR)/*.hh  2> /dev/null | tr "\n" " ")
+CPPSRCS := $(shell ls -1 $(SRCDIR)/*.cpp 2> /dev/null | tr "\n" " ")
+CXXSRCS := $(shell ls -1 $(SRCDIR)/*.cxx 2> /dev/null | tr "\n" " ")
+CCXSRCS := $(shell ls -1 $(SRCDIR)/*.cc  2> /dev/null | tr "\n" " ")
+CSOURCS := $(shell ls -1 $(SRCDIR)/*.c   2> /dev/null | tr "\n" " ")
+FXXSRCS := $(shell ls -1 $(SRCDIR)/*.f   2> /dev/null | tr "\n" " ")
+F77SRCS := $(shell ls -1 $(SRCDIR)/*.F   2> /dev/null | tr "\n" " ")
+F90SRCS := $(shell ls -1 $(SRCDIR)/*.f90 2> /dev/null | tr "\n" " ") \
+           $(shell ls -1 $(SRCDIR)/*.F90 2> /dev/null | tr "\n" " ")
+
+CPPOBJS := $(patsubst %,$(BLDDIR)/%,$(notdir $(CPPSRCS:.cpp=-cpp.o)))
+CXXOBJS := $(patsubst %,$(BLDDIR)/%,$(notdir $(CXXSRCS:.cxx=-cxx.o)))
+CCXOBJS := $(patsubst %,$(BLDDIR)/%,$(notdir $(CCXSRCS:.cc=-cc.o)))
+COBJCTS := $(patsubst %,$(BLDDIR)/%,$(notdir $(CSOURCS:.c=-c.o)))
+FXXOBJS := $(patsubst %,$(BLDDIR)/%,$(notdir $(FXXSRCS:.f=-f.o)))
+F77OBJS := $(patsubst %,$(BLDDIR)/%,$(notdir $(F77SRCS:.F=-f77.o)))
+F90OBJS := $(patsubst %,$(BLDDIR)/%,$(notdir $(F90SRCS:.f90=-f90.o)))
+F90OBJS := $(patsubst %,$(BLDDIR)/%,$(notdir $(F90SRCS:.F90=-f90.o)))
+
+SOURCES := $(CPPSRCS) $(CXXSRCS) $(CCXSRCS) $(CSOURCS)
+OBJECTS := $(CPPOBJS) $(CXXOBJS) $(CCXOBJS) $(COBJCTS)
+FTNSRCS := $(FXXSRCS) $(F77SRCS) $(F90SRCS)
+MODULES := $(addsuffix .mod,$(basename $(FTNSRCS))) $(addsuffix .modmic,$(basename $(FTNSRCS)))
+FTNOBJS := $(FXXOBJS) $(F77OBJS) $(F90OBJS)
+XFILES := $(OUTDIR)/$(OUTNAME)
+
+# specfem example specific
+MODULES += my_libxsmm.mod constants.mod specfem_par.mod my_libxsmm.modmic constants.modmic specfem_par.modmic
+DFLAGS += -DFORCE_VECTORIZATION
+
+# OpenMP directives support
+ifneq (0,$(OMP))
+DFLAGS += -DUSE_OPENMP
+endif
+
+# fixes library paths: substitutes path name from ../mkl/lib/intel64/.. to ../mkl/lib/mic/..
+ifneq (0,$(MIC))
+ifneq (0,$(MPSS))
+lib_intel := mkl/lib/intel64
+lib_mic := mkl/lib/mic
+LDFLAGS_MIC = $(subst $(lib_intel),$(lib_mic),$(LDFLAGS))
+endif
+endif
+
+##
+## targets
+##
+
+.PHONY: all
+all: $(XFILES)
+
+$(OUTDIR)/specfem: $(OUTDIR)/.make $(FTNOBJS)
+ifneq (0,$(MIC))
+ifneq (0,$(MPSS))
+	@echo ""
+	@echo "building MIC version"
+	@echo ""
+	$(FC) -o $@ -mmic $(FTNOBJS) $(call libdir,$(LIBNAME)f.$(LIBEXT)) $(call libdir,$(LIBNAME).$(LIBEXT)) $(FCMTFLAGS) $(SLDFLAGS) $(LDFLAGS_MIC) $(FLDFLAGS) $(ELDFLAGS)
+endif
+endif
+ifeq (0,$(MIC))
+ifeq (0,$(MPSS))
+	@echo ""
+	@echo "building host version"
+	@echo ""
+	$(FC) -o $@ $(FTNOBJS) $(call libdir,$(LIBNAME)f.$(LIBEXT)) $(call libdir,$(LIBNAME).$(LIBEXT)) $(FCMTFLAGS) $(SLDFLAGS) $(LDFLAGS) $(FLDFLAGS) $(ELDFLAGS)
+endif
+endif
+
+.PHONY: clean-minimal
+clean-minimal:
+	@rm -f $(OBJECTS) $(FTNOBJS) $(MODULES)
+	@rm -f fit.log *.dat
+	@rm -f *__genmod.*
+
+.PHONY: clean
+clean: clean-minimal
+ifneq ($(abspath $(BLDDIR)),$(ROOTDIR))
+ifneq ($(abspath $(BLDDIR)),$(abspath .))
+	@rm -rf $(BLDDIR)
+endif
+endif
+
+.PHONY: realclean
+realclean: clean
+ifneq ($(abspath $(OUTDIR)),$(ROOTDIR))
+ifneq ($(abspath $(OUTDIR)),$(abspath .))
+	@rm -rf $(OUTDIR)
+else
+	@rm -f $(XFILES)
+endif
+else
+	@rm -f $(XFILES)
+endif
+	@rm -f $(MODULES) $(ROOTDIR)/specfem-perf.sh
+	@rm -f *.gcno *.gcda *.gcov
+	@rm -f $(OUTDIR)/libxsmm.$(DLIBEXT)
+	@rm -f $(OUTDIR)/*.bin
+	@rm -f .make .state
+
+
+
+##
+## dependencies
+##
+$(BLDDIR)/compute_forces_Dev-f90.o: $(BLDDIR)/specfem-f90.o
+$(BLDDIR)/compute_forces_noDev-f90.o: $(BLDDIR)/specfem-f90.o
+$(BLDDIR)/compute_forces_xsmm_dispatch-f90.o: $(BLDDIR)/specfem-f90.o
+$(BLDDIR)/compute_forces_xsmm_prefetch-f90.o: $(BLDDIR)/specfem-f90.o
+$(BLDDIR)/compute_forces_xsmm_static-f90.o: $(BLDDIR)/specfem-f90.o
+
+
+##
+## rules
+##
+ifneq (0,$(MIC))
+ifneq (0,$(MPSS))
+$(BLDDIR)/%-f90.o: $(SRCDIR)/%.f90 .state $(BLDDIR)/.make $(ROOTDIR)/Makefile $(DEPDIR)/Makefile.inc $(LIBNAME).$(LIBEXT)
+	$(FC) $(FCMTFLAGS) $(FCFLAGS) $(DFLAGS) $(IFLAGS) -mmic -c $< -o $@
+
+$(BLDDIR)/%-f90.o: $(SRCDIR)/%.F90 .state $(BLDDIR)/.make $(ROOTDIR)/Makefile $(DEPDIR)/Makefile.inc $(LIBNAME).$(LIBEXT)
+	$(FC) $(FCMTFLAGS) $(FCFLAGS) $(DFLAGS) $(IFLAGS) -mmic -c $< -o $@
+endif
+endif
+ifeq (0,$(MIC))
+ifeq (0,$(MPSS))
+$(BLDDIR)/%-f90.o: $(SRCDIR)/%.f90 .state $(BLDDIR)/.make $(ROOTDIR)/Makefile $(DEPDIR)/Makefile.inc $(LIBNAME).$(LIBEXT)
+	$(FC) $(FCMTFLAGS) $(FCFLAGS) $(DFLAGS) $(IFLAGS) $(TARGET) -c $< -o $@
+
+$(BLDDIR)/%-f90.o: $(SRCDIR)/%.F90 .state $(BLDDIR)/.make $(ROOTDIR)/Makefile $(DEPDIR)/Makefile.inc $(LIBNAME).$(LIBEXT)
+	$(FC) $(FCMTFLAGS) $(FCFLAGS) $(DFLAGS) $(IFLAGS) $(TARGET) -c $< -o $@
+endif
+endif

--- a/samples/specfem/README.md
+++ b/samples/specfem/README.md
@@ -1,0 +1,194 @@
+# SPECFEM Sample
+
+This sample contains a dummy example from a spectral-element stiffness kernel taken from [SPECFEM3D_GLOBE](https://github.com/geodynamics/specfem3d_globe).
+
+It is based on a 4th-order, spectral-element stiffness kernel for simulations of elastic wave propagation through the Earth. Matrix sizes used are (25,5), (5,25) and (5,5) determined by different cut-planes through a three dimensional (5,5,5)-element with a total of 125 GLL points.
+
+
+## Usage Step-by-Step
+
+This example needs the LIBXSMM library to be built with static kernels, using MNK="5 25" (for matrix size (5,25), (25,5) and (5,5)).
+
+1. In LIBXSMM root directory, compile the library with:
+  - general default compilation:
+    ```
+    make MNK="5 25" ALPHA=1 BETA=0
+    ```
+
+  additional compilation examples are:
+
+  - compilation using only single precision version & aggressive optimization:
+    ```
+    make MNK="5 25" ALPHA=1 BETA=0 PRECISION=1 OPT=3
+    ```
+
+  - for Sandy Bridge CPUs:
+    ```
+    make MNK="5 25" ALPHA=1 BETA=0 PRECISION=1 OPT=3 AVX=1
+    ```
+
+  - for Haswell CPUs:
+    ```
+    make MNK="5 25" ALPHA=1 BETA=0 PRECISION=1 OPT=3 AVX=2
+    ```
+
+  - for Knights Corner (KNC) (and also creating Sandy Bridge version):
+    ```
+    make MNK="5 25" ALPHA=1 BETA=0 PRECISION=1 OPT=3 AVX=1 \
+    OFFLOAD=1 MIC=1
+    ```
+
+  - installing libraries into a sub-directory workstation/:
+    ```
+    make MNK="5 25" ALPHA=1 BETA=0 PRECISION=1 OPT=3 AVX=1 \
+    OFFLOAD=1 MIC=1 \
+    PREFIX=workstation/ install-minimal
+    ```
+
+2. Compile this example code by typing:
+  - for default CPU host:
+    ```
+    cd sample/specfem
+    make
+    ```
+
+  - for Knights Corner (KNC):
+    ```
+    cd sample/specfem
+    make MIC=1
+    ```
+
+  - additionally, adding some specific fortran compiler flags, for example:
+    ```
+    cd sample/specfem
+    make FCFLAGS="-O3 -fopenmp" ..
+    ```
+
+Note that steps 1 & 2 could be shortened:
+  - by specifying a "specfem" make target in the LIBXSMM root directory:
+    ```
+    make MNK="5 25" ALPHA=1 BETA=0 PRECISION=1 OPT=3 AVX=1 specfem
+    ```
+  - for Knights Corner, this would need two steps:
+    ```
+    make MNK="5 25" ALPHA=1 BETA=0 PRECISION=1 OPT=3 AVX=1 OFFLOAD=1 MIC=1
+    make OPT=3 specfem_mic
+    ```
+
+Run the performance test:
+  - for default CPU host:
+    ```
+    ./specfem.sh
+    ```
+
+  - for Knights Corner (KNC):
+    ```
+    ./specfem.sh -mic
+    ```
+
+## Results
+
+Using Intel Compiler suite: icpc 15.0.2, icc 15.0.2, and ifort 15.0.2
+
+### Sandy Bridge - Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+
+- library compilation by (root directory):
+  ```
+  make MNK="5 25" ALPHA=1 BETA=0 PRECISION=1 OPT=3 AVX=1          ```
+
+- single threaded example run:
+  ```
+  cd sample/specfem
+  make; OMP_NUM_THREADS=1 ./specfem.sh
+  ```
+
+  Output:
+  ```
+   ==============================================
+   average over           15 repetitions
+    timing with Deville loops    =   0.1269
+    timing with unrolled loops   =   0.1737 / speedup =   -36.87 %
+    timing with LIBXSMM dispatch =   0.1697 / speedup =   -33.77 %
+    timing with LIBXSMM prefetch =   0.1611 / speedup =   -26.98 %
+    timing with LIBXSMM static   =   0.1392 / speedup =    -9.70 %
+   ==============================================
+   ```
+
+
+
+### Haswell - Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz
+
+- library compilation by (root directory):
+  ```
+  make MNK="5 25" ALPHA=1 BETA=0 PRECISION=1 OPT=3 AVX=2    ```
+
+- single threaded example run:
+  ```
+  cd sample/specfem
+  make; OMP_NUM_THREADS=1 ./specfem.sh
+  ```
+
+  Output:
+  ```
+   ==============================================
+   average over           15 repetitions
+    timing with Deville loops    =   0.1028
+    timing with unrolled loops   =   0.1385 / speedup =   -34.73 %
+    timing with LIBXSMM dispatch =   0.1408 / speedup =   -37.02 %
+    timing with LIBXSMM prefetch =   0.1327 / speedup =   -29.07 %
+    timing with LIBXSMM static   =   0.1151 / speedup =   -11.93 %
+   ==============================================
+   ```
+
+- multi-threaded example run:
+  ```
+  cd sample/specfem
+  make OPT=3; OMP_NUM_THREADS=24 ./specfem.sh
+  ```
+
+  Output:
+  ```
+  OpenMP information:
+    number of threads =           24
+
+  ..
+
+   ==============================================
+   average over           15 repetitions
+    timing with Deville loops    =   0.0064
+    timing with unrolled loops   =   0.0349 / speedup =  -446.71 %
+    timing with LIBXSMM dispatch =   0.0082 / speedup =   -28.34 %
+    timing with LIBXSMM prefetch =   0.0076 / speedup =   -19.59 %
+    timing with LIBXSMM static   =   0.0068 / speedup =    -5.78 %
+   ==============================================
+   ```
+
+
+### Knights Corner - Intel Xeon Phi B1PRQ-5110P/5120D
+
+- library compilation by (root directory):
+  ```
+  make MNK="5 25" ALPHA=1 BETA=0 PRECISION=1 OPT=3 OFFLOAD=1 MIC=1
+  ```
+
+- multi-threaded example run:
+  ```
+  cd sample/specfem
+  make FCFLAGS="-O3 -fopenmp -warn" OPT=3 MIC=1; ./specfem.sh -mic
+  ```
+
+  Output:
+  ```
+  OpenMP information:
+    number of threads =          236
+
+  ..
+
+   ==============================================
+   average over           15 repetitions
+    timing with Deville loops    =   0.0164
+    timing with unrolled loops   =   0.6982 / speedup = -4162.10 %
+    timing with LIBXSMM dispatch =   0.0170 / speedup =    -3.89 %
+    timing with LIBXSMM static   =   0.0149 / speedup =     9.22 %
+   ==============================================
+   ```

--- a/samples/specfem/compute_forces_Dev.F90
+++ b/samples/specfem/compute_forces_Dev.F90
@@ -1,0 +1,416 @@
+!=====================================================================
+!
+!          S p e c f e m 3 D  G l o b e  V e r s i o n  7 . 0
+!          --------------------------------------------------
+!
+!     Main historical authors: Dimitri Komatitsch and Jeroen Tromp
+!                        Princeton University, USA
+!                and CNRS / University of Marseille, France
+!                 (there are currently many more authors!)
+! (c) Princeton University and CNRS / University of Marseille, April 2014
+!
+! This program is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 2 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License along
+! with this program; if not, write to the Free Software Foundation, Inc.,
+! 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+!
+!=====================================================================
+
+! we switch between vectorized and non-vectorized version by using pre-processor flag FORCE_VECTORIZATION
+! and macros INDEX_IJK, DO_LOOP_IJK, ENDDO_LOOP_IJK defined in config.fh
+#include "config.fh"
+
+!-------------------------------------------------------------------
+!
+! compute forces routine
+!
+!-------------------------------------------------------------------
+
+
+  subroutine compute_forces_Dev()
+
+! default: fortran-loops using Deville matrix routines for small matrix-matrix cut-planes in all three x/y/z-directions
+
+  use specfem_par
+  use my_libxsmm
+
+  implicit none
+
+  ! Deville
+  ! manually inline the calls to the Deville et al. (2002) routines
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ) :: &
+    tempx1,tempx2,tempx3,tempy1,tempy2,tempy3,tempz1,tempz2,tempz3
+
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ) :: &
+    newtempx1,newtempx2,newtempx3,newtempy1,newtempy2,newtempy3,newtempz1,newtempz2,newtempz3
+
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ) :: dummyx_loc,dummyy_loc,dummyz_loc
+
+  real(kind=CUSTOM_REAL) :: fac1,fac2,fac3
+
+  ! for gravity
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ,NDIM) :: rho_s_H
+
+  integer :: num_elements,ispec_p
+  integer :: ispec,iglob
+#ifdef FORCE_VECTORIZATION
+  integer :: ijk_spec,ip,iglob_p,ijk
+#else
+  integer :: i,j,k
+#endif
+
+! ****************************************************
+!   big loop over all spectral elements in the solid
+! ****************************************************
+
+!  computed_elements = 0
+  if (iphase == 1) then
+    ! outer elements (halo region)
+    num_elements = nspec_outer
+  else
+    ! inner elements
+    num_elements = nspec_inner
+  endif
+
+#ifdef USE_OPENMP
+!$OMP PARALLEL DEFAULT(NONE) &
+!$OMP SHARED( &
+!$OMP num_elements,iphase,phase_ispec_inner, &
+!$OMP hprime_xxT,hprime_xx,hprimewgll_xx,hprimewgll_xxT, &
+!$OMP wgllwgll_xy_3D, wgllwgll_xz_3D, wgllwgll_yz_3D, &
+#ifdef FORCE_VECTORIZATION
+!$OMP ibool_inv_tbl, ibool_inv_st, num_globs, phase_iglob, &
+#endif
+!$OMP ibool, &
+!$OMP displ,accel, &
+!$OMP sum_terms ) &
+!$OMP PRIVATE( ispec,ispec_p,iglob, &
+#ifdef FORCE_VECTORIZATION
+!$OMP ijk_spec,ip,iglob_p, &
+!$OMP ijk, &
+#else
+!$OMP i,j,k, &
+#endif
+!$OMP fac1,fac2,fac3, &
+!$OMP tempx1,tempx2,tempx3,tempy1,tempy2,tempy3,tempz1,tempz2,tempz3, &
+!$OMP newtempx1,newtempx2,newtempx3,newtempy1,newtempy2,newtempy3,newtempz1,newtempz2,newtempz3, &
+!$OMP dummyx_loc,dummyy_loc,dummyz_loc, &
+!$OMP rho_s_H )
+#endif
+  ! loops over all spectral-elements
+#ifdef USE_OPENMP
+!$OMP DO SCHEDULE(GUIDED)
+#endif
+  do ispec_p = 1,num_elements
+
+    ! only compute elements which belong to current phase (inner or outer elements)
+    ispec = phase_ispec_inner(ispec_p,iphase)
+
+    DO_LOOP_IJK
+      iglob = ibool(INDEX_IJK,ispec)
+      dummyx_loc(INDEX_IJK) = displ(1,iglob)
+      dummyy_loc(INDEX_IJK) = displ(2,iglob)
+      dummyz_loc(INDEX_IJK) = displ(3,iglob)
+    ENDDO_LOOP_IJK
+
+    ! subroutines adapted from Deville, Fischer and Mund, High-order methods
+    ! for incompressible fluid flow, Cambridge University Press (2002),
+    ! pages 386 and 389 and Figure 8.3.1
+
+    ! computes 1. matrix multiplication for tempx1,..
+    call mxm5_3comp_singleA(hprime_xx,m1,dummyx_loc,dummyy_loc,dummyz_loc,tempx1,tempy1,tempz1,m2)
+    ! computes 2. matrix multiplication for tempx2,..
+    call mxm5_3comp_3dmat_singleB(dummyx_loc,dummyy_loc,dummyz_loc,m1,hprime_xxT,m1,tempx2,tempy2,tempz2,NGLLX)
+    ! computes 3. matrix multiplication for tempx3,..
+    call mxm5_3comp_singleB(dummyx_loc,dummyy_loc,dummyz_loc,m2,hprime_xxT,tempx3,tempy3,tempz3,m1)
+
+    call compute_element_dummy(ispec,ibool,tempx1,tempx2,tempx3,tempy1,tempy2,tempy3,tempz1,tempz2,tempz3, &
+                               dummyx_loc,dummyy_loc,dummyz_loc,rho_s_H)
+
+    ! subroutines adapted from Deville, Fischer and Mund, High-order methods
+    ! for incompressible fluid flow, Cambridge University Press (2002),
+    ! pages 386 and 389 and Figure 8.3.1
+
+    ! computes 1. matrix multiplication for newtempx1,..
+    call mxm5_3comp_singleA(hprimewgll_xxT,m1,tempx1,tempy1,tempz1,newtempx1,newtempy1,newtempz1,m2)
+    ! computes 2. matrix multiplication for tempx2,..
+    call mxm5_3comp_3dmat_singleB(tempx2,tempy2,tempz2,m1,hprimewgll_xx,m1,newtempx2,newtempy2,newtempz2,NGLLX)
+    ! computes 3. matrix multiplication for newtempx3,..
+    call mxm5_3comp_singleB(tempx3,tempy3,tempz3,m2,hprimewgll_xx,newtempx3,newtempy3,newtempz3,m1)
+
+    ! sums contributions
+    DO_LOOP_IJK
+      fac1 = wgllwgll_yz_3D(INDEX_IJK)
+      fac2 = wgllwgll_xz_3D(INDEX_IJK)
+      fac3 = wgllwgll_xy_3D(INDEX_IJK)
+      sum_terms(1,INDEX_IJK,ispec) = - (fac1*newtempx1(INDEX_IJK) + fac2*newtempx2(INDEX_IJK) + fac3*newtempx3(INDEX_IJK))
+      sum_terms(2,INDEX_IJK,ispec) = - (fac1*newtempy1(INDEX_IJK) + fac2*newtempy2(INDEX_IJK) + fac3*newtempy3(INDEX_IJK))
+      sum_terms(3,INDEX_IJK,ispec) = - (fac1*newtempz1(INDEX_IJK) + fac2*newtempz2(INDEX_IJK) + fac3*newtempz3(INDEX_IJK))
+    ENDDO_LOOP_IJK
+
+    ! adds gravity terms
+    if (GRAVITY_VAL) then
+#ifdef FORCE_VECTORIZATION
+      do ijk = 1,NDIM*NGLLCUBE
+        sum_terms(ijk,1,1,1,ispec) = sum_terms(ijk,1,1,1,ispec) + rho_s_H(ijk,1,1,1)
+      enddo
+#else
+      do k = 1,NGLLZ
+        do j = 1,NGLLY
+          do i = 1,NGLLX
+            sum_terms(1,i,j,k,ispec) = sum_terms(1,i,j,k,ispec) + rho_s_H(i,j,k,1)
+            sum_terms(2,i,j,k,ispec) = sum_terms(2,i,j,k,ispec) + rho_s_H(i,j,k,2)
+            sum_terms(3,i,j,k,ispec) = sum_terms(3,i,j,k,ispec) + rho_s_H(i,j,k,3)
+          enddo
+        enddo
+      enddo
+#endif
+    endif
+
+    ! updates acceleration
+#ifdef FORCE_VECTORIZATION
+    ! update will be done later at the very end..
+#else
+    ! updates for non-vectorization case
+
+! note: Critical OpenMP here might degrade performance,
+!       especially for a larger number of threads (>8).
+!       Using atomic operations can partially help.
+#ifndef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+#ifdef USE_OPENMP
+!$OMP CRITICAL
+#endif
+#endif
+! we can force vectorization using a compiler directive here because we know that there is no dependency
+! inside a given spectral element, since all the global points of a local elements are different by definition
+! (only common points between different elements can be the same)
+! IBM, Portland PGI, and Intel and Cray syntax (Intel and Cray are the same)
+!IBM* ASSERT (NODEPS)
+!pgi$ ivdep
+!DIR$ IVDEP
+    DO_LOOP_IJK
+      iglob = ibool(INDEX_IJK,ispec)
+#ifdef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+#ifdef USE_OPENMP
+!$OMP ATOMIC
+#endif
+#endif
+      accel(1,iglob) = accel(1,iglob) + sum_terms(1,INDEX_IJK,ispec)
+#ifdef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+#ifdef USE_OPENMP
+!$OMP ATOMIC
+#endif
+#endif
+      accel(2,iglob) = accel(2,iglob) + sum_terms(2,INDEX_IJK,ispec)
+#ifdef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+#ifdef USE_OPENMP
+!$OMP ATOMIC
+#endif
+#endif
+      accel(3,iglob) = accel(3,iglob) + sum_terms(3,INDEX_IJK,ispec)
+    ENDDO_LOOP_IJK
+#ifndef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+#ifdef USE_OPENMP
+!$OMP END CRITICAL
+#endif
+#endif
+#endif
+
+  enddo ! ispec
+#ifdef USE_OPENMP
+!$OMP enddo
+#endif
+
+  ! updates acceleration
+#ifdef FORCE_VECTORIZATION
+  ! updates for vectorized case
+  ! loops over all global nodes in this phase (inner/outer)
+#ifdef USE_OPENMP
+!$OMP DO
+#endif
+  do iglob_p = 1,num_globs(iphase)
+    ! global node index
+    iglob = phase_iglob(iglob_p,iphase)
+    ! loops over valence points
+    do ip = ibool_inv_st(iglob_p,iphase),ibool_inv_st(iglob_p+1,iphase)-1
+      ! local 1D index from array ibool
+      ijk_spec = ibool_inv_tbl(ip,iphase)
+
+      ! do NOT use array syntax ":" for the three statements below otherwise most compilers
+      ! will not be able to vectorize the outer loop
+      accel(1,iglob) = accel(1,iglob) + sum_terms(1,ijk_spec,1,1,1)
+      accel(2,iglob) = accel(2,iglob) + sum_terms(2,ijk_spec,1,1,1)
+      accel(3,iglob) = accel(3,iglob) + sum_terms(3,ijk_spec,1,1,1)
+    enddo
+  enddo
+#ifdef USE_OPENMP
+!$OMP enddo
+#endif
+#endif
+
+#ifdef USE_OPENMP
+!$OMP END PARALLEL
+#endif
+
+  contains
+
+!--------------------------------------------------------------------------------------------
+!
+! matrix-matrix multiplications
+!
+! subroutines adapted from Deville, Fischer and Mund, High-order methods
+! for incompressible fluid flow, Cambridge University Press (2002),
+! pages 386 and 389 and Figure 8.3.1
+!
+!--------------------------------------------------------------------------------------------
+!
+! note: the matrix-matrix multiplications are used for very small matrices ( 5 x 5 x 5 elements);
+!       thus, calling external optimized libraries for these multiplications are in general slower
+!
+! please leave the routines here to help compilers inlining the code
+
+  subroutine mxm5_3comp_singleA(A,n1,B1,B2,B3,C1,C2,C3,n3)
+
+! 3 different arrays for x/y/z-components, 2-dimensional arrays (25,5)/(5,25), same B matrix for all 3 component arrays
+
+!  use constants,only: CUSTOM_REAL
+
+  implicit none
+
+  integer,intent(in) :: n1,n3
+  real(kind=CUSTOM_REAL),dimension(n1,5),intent(in) :: A
+  real(kind=CUSTOM_REAL),dimension(5,n3),intent(in) :: B1,B2,B3
+  real(kind=CUSTOM_REAL),dimension(n1,n3),intent(out) :: C1,C2,C3
+
+  ! local parameters
+  integer :: i,j
+
+  ! matrix-matrix multiplication
+  do j = 1,n3
+!dir$ ivdep
+    do i = 1,n1
+      C1(i,j) =  A(i,1) * B1(1,j) &
+               + A(i,2) * B1(2,j) &
+               + A(i,3) * B1(3,j) &
+               + A(i,4) * B1(4,j) &
+               + A(i,5) * B1(5,j)
+
+      C2(i,j) =  A(i,1) * B2(1,j) &
+               + A(i,2) * B2(2,j) &
+               + A(i,3) * B2(3,j) &
+               + A(i,4) * B2(4,j) &
+               + A(i,5) * B2(5,j)
+
+      C3(i,j) =  A(i,1) * B3(1,j) &
+               + A(i,2) * B3(2,j) &
+               + A(i,3) * B3(3,j) &
+               + A(i,4) * B3(4,j) &
+               + A(i,5) * B3(5,j)
+    enddo
+  enddo
+
+  end subroutine mxm5_3comp_singleA
+
+
+!--------------------------------------------------------------------------------------------
+
+  subroutine mxm5_3comp_singleB(A1,A2,A3,n1,B,C1,C2,C3,n3)
+
+! 3 different arrays for x/y/z-components, 2-dimensional arrays (25,5)/(5,25), same B matrix for all 3 component arrays
+
+!  use constants,only: CUSTOM_REAL
+
+  implicit none
+
+  integer,intent(in) :: n1,n3
+  real(kind=CUSTOM_REAL),dimension(n1,5),intent(in) :: A1,A2,A3
+  real(kind=CUSTOM_REAL),dimension(5,n3),intent(in) :: B
+  real(kind=CUSTOM_REAL),dimension(n1,n3),intent(out) :: C1,C2,C3
+
+  ! local parameters
+  integer :: i,j
+
+  ! matrix-matrix multiplication
+  do j = 1,n3
+!dir$ ivdep
+    do i = 1,n1
+      C1(i,j) =  A1(i,1) * B(1,j) &
+               + A1(i,2) * B(2,j) &
+               + A1(i,3) * B(3,j) &
+               + A1(i,4) * B(4,j) &
+               + A1(i,5) * B(5,j)
+
+      C2(i,j) =  A2(i,1) * B(1,j) &
+               + A2(i,2) * B(2,j) &
+               + A2(i,3) * B(3,j) &
+               + A2(i,4) * B(4,j) &
+               + A2(i,5) * B(5,j)
+
+      C3(i,j) =  A3(i,1) * B(1,j) &
+               + A3(i,2) * B(2,j) &
+               + A3(i,3) * B(3,j) &
+               + A3(i,4) * B(4,j) &
+               + A3(i,5) * B(5,j)
+    enddo
+  enddo
+
+  end subroutine mxm5_3comp_singleB
+
+
+!--------------------------------------------------------------------------------------------
+
+  subroutine mxm5_3comp_3dmat_singleB(A1,A2,A3,n1,B,n2,C1,C2,C3,n3)
+
+! 3 different arrays for x/y/z-components, 3-dimensional arrays (5,5,5), same B matrix for all 3 component arrays
+
+!  use constants,only: CUSTOM_REAL
+
+  implicit none
+
+  integer,intent(in) :: n1,n2,n3
+  real(kind=CUSTOM_REAL),dimension(n1,5,n3),intent(in) :: A1,A2,A3
+  real(kind=CUSTOM_REAL),dimension(5,n2),intent(in) :: B
+  real(kind=CUSTOM_REAL),dimension(n1,n2,n3),intent(out) :: C1,C2,C3
+
+  ! local parameters
+  integer :: i,j,k
+
+  ! matrix-matrix multiplication
+  do k = 1,n3
+    do j = 1,n2
+!dir$ ivdep
+      do i = 1,n1
+        C1(i,j,k) =  A1(i,1,k) * B(1,j) &
+                   + A1(i,2,k) * B(2,j) &
+                   + A1(i,3,k) * B(3,j) &
+                   + A1(i,4,k) * B(4,j) &
+                   + A1(i,5,k) * B(5,j)
+
+        C2(i,j,k) =  A2(i,1,k) * B(1,j) &
+                   + A2(i,2,k) * B(2,j) &
+                   + A2(i,3,k) * B(3,j) &
+                   + A2(i,4,k) * B(4,j) &
+                   + A2(i,5,k) * B(5,j)
+
+        C3(i,j,k) =  A3(i,1,k) * B(1,j) &
+                   + A3(i,2,k) * B(2,j) &
+                   + A3(i,3,k) * B(3,j) &
+                   + A3(i,4,k) * B(4,j) &
+                   + A3(i,5,k) * B(5,j)
+      enddo
+    enddo
+  enddo
+
+  end subroutine mxm5_3comp_3dmat_singleB
+
+  end subroutine compute_forces_Dev
+

--- a/samples/specfem/compute_forces_noDev.F90
+++ b/samples/specfem/compute_forces_noDev.F90
@@ -1,0 +1,364 @@
+!=====================================================================
+!
+!          S p e c f e m 3 D  G l o b e  V e r s i o n  7 . 0
+!          --------------------------------------------------
+!
+!     Main historical authors: Dimitri Komatitsch and Jeroen Tromp
+!                        Princeton University, USA
+!                and CNRS / University of Marseille, France
+!                 (there are currently many more authors!)
+! (c) Princeton University and CNRS / University of Marseille, April 2014
+!
+! This program is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 2 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License along
+! with this program; if not, write to the Free Software Foundation, Inc.,
+! 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+!
+!=====================================================================
+
+
+!-------------------------------------------------------------------
+!
+! compute forces routine
+!
+!-------------------------------------------------------------------
+
+
+  subroutine compute_forces_noDev()
+
+! fortran-loops (without Deville routines) using unrolling of the inner-most loop (over 5)
+
+  use specfem_par
+  use my_libxsmm
+
+  implicit none
+
+  ! local parameters
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ) :: &
+    tempx1,tempx2,tempx3,tempy1,tempy2,tempy3,tempz1,tempz2,tempz3
+
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ) :: &
+    newtempx1,newtempx2,newtempx3,newtempy1,newtempy2,newtempy3,newtempz1,newtempz2,newtempz3
+
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ) :: dummyx_loc,dummyy_loc,dummyz_loc
+
+  real(kind=CUSTOM_REAL) :: fac1,fac2,fac3
+
+  ! for gravity
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ,NDIM) :: rho_s_H
+
+  integer :: num_elements,ispec_p
+  integer :: ispec,iglob
+  integer :: i,j,k
+
+! ****************************************************
+!   big loop over all spectral elements in the solid
+! ****************************************************
+
+!  computed_elements = 0
+  if (iphase == 1) then
+    ! outer elements (halo region)
+    num_elements = nspec_outer
+  else
+    ! inner elements
+    num_elements = nspec_inner
+  endif
+
+#ifdef USE_OPENMP
+!$OMP PARALLEL DEFAULT(NONE) &
+!$OMP SHARED( &
+!$OMP num_elements,iphase,phase_ispec_inner, &
+!$OMP hprime_xxT,hprimewgll_xx, &
+!$OMP wgllwgll_xy_3D, wgllwgll_xz_3D, wgllwgll_yz_3D, &
+!$OMP ibool, &
+!$OMP displ,accel, &
+!$OMP sum_terms ) &
+!$OMP PRIVATE( ispec,ispec_p,iglob, &
+!$OMP i,j,k, &
+!$OMP fac1,fac2,fac3, &
+!$OMP tempx1,tempx2,tempx3,tempy1,tempy2,tempy3,tempz1,tempz2,tempz3, &
+!$OMP newtempx1,newtempx2,newtempx3,newtempy1,newtempy2,newtempy3,newtempz1,newtempz2,newtempz3, &
+!$OMP dummyx_loc,dummyy_loc,dummyz_loc, &
+!$OMP rho_s_H )
+#endif
+
+  ! loops over all spectral-elements
+#ifdef USE_OPENMP
+!$OMP DO SCHEDULE(GUIDED)
+#endif
+  do ispec_p = 1,num_elements
+
+    ! only compute elements which belong to current phase (inner or outer elements)
+    ispec = phase_ispec_inner(ispec_p,iphase)
+
+    do k = 1,NGLLZ
+      do j = 1,NGLLY
+        do i = 1,NGLLX
+          iglob = ibool(i,j,k,ispec)
+          dummyx_loc(i,j,k) = displ(1,iglob)
+          dummyy_loc(i,j,k) = displ(2,iglob)
+          dummyz_loc(i,j,k) = displ(3,iglob)
+        enddo
+      enddo
+    enddo
+
+    ! uses loop unrolling for NGLLX == NGLLY == NGLLZ == 5
+    do k = 1,NGLLZ
+      do j = 1,NGLLY
+        do i = 1,NGLLX
+          ! general NGLLX == NGLLY == NGLLZ
+          !tempx1l = 0._CUSTOM_REAL
+          !tempx2l = 0._CUSTOM_REAL
+          !tempx3l = 0._CUSTOM_REAL
+          !tempy1l = 0._CUSTOM_REAL
+          !tempy2l = 0._CUSTOM_REAL
+          !tempy3l = 0._CUSTOM_REAL
+          !tempz1l = 0._CUSTOM_REAL
+          !tempz2l = 0._CUSTOM_REAL
+          !tempz3l = 0._CUSTOM_REAL
+          !do l = 1,NGLLX
+          !  tempx1l = tempx1l + dummyx_loc(l,j,k)*hprime_xx(i,l)
+          !  tempy1l = tempy1l + dummyy_loc(l,j,k)*hprime_xx(i,l)
+          !  tempz1l = tempz1l + dummyz_loc(l,j,k)*hprime_xx(i,l)
+          !  !!! can merge these loops because NGLLX = NGLLY = NGLLZ
+          !  tempx2l = tempx2l + dummyx_loc(i,l,k)*hprime_yy(j,l)
+          !  tempy2l = tempy2l + dummyy_loc(i,l,k)*hprime_yy(j,l)
+          !  tempz2l = tempz2l + dummyz_loc(i,l,k)*hprime_yy(j,l)
+          !  !!! can merge these loops because NGLLX = NGLLY = NGLLZ
+          !  tempx3l = tempx3l + dummyx_loc(i,j,l)*hprime_zz(k,l)
+          !  tempy3l = tempy3l + dummyy_loc(i,j,l)*hprime_zz(k,l)
+          !  tempz3l = tempz3l + dummyz_loc(i,j,l)*hprime_zz(k,l)
+          !enddo
+
+          ! unrolled
+          tempx1(i,j,k) = dummyx_loc(1,j,k)*hprime_xxT(1,i) &
+                        + dummyx_loc(2,j,k)*hprime_xxT(2,i) &
+                        + dummyx_loc(3,j,k)*hprime_xxT(3,i) &
+                        + dummyx_loc(4,j,k)*hprime_xxT(4,i) &
+                        + dummyx_loc(5,j,k)*hprime_xxT(5,i)
+          tempy1(i,j,k) = dummyy_loc(1,j,k)*hprime_xxT(1,i) &
+                        + dummyy_loc(2,j,k)*hprime_xxT(2,i) &
+                        + dummyy_loc(3,j,k)*hprime_xxT(3,i) &
+                        + dummyy_loc(4,j,k)*hprime_xxT(4,i) &
+                        + dummyy_loc(5,j,k)*hprime_xxT(5,i)
+          tempz1(i,j,k) = dummyz_loc(1,j,k)*hprime_xxT(1,i) &
+                        + dummyz_loc(2,j,k)*hprime_xxT(2,i) &
+                        + dummyz_loc(3,j,k)*hprime_xxT(3,i) &
+                        + dummyz_loc(4,j,k)*hprime_xxT(4,i) &
+                        + dummyz_loc(5,j,k)*hprime_xxT(5,i)
+          !!! can merge these loops because NGLLX = NGLLY = NGLLZ
+          tempx2(i,j,k) = dummyx_loc(i,1,k)*hprime_xxT(1,j) &
+                        + dummyx_loc(i,2,k)*hprime_xxT(2,j) &
+                        + dummyx_loc(i,3,k)*hprime_xxT(3,j) &
+                        + dummyx_loc(i,4,k)*hprime_xxT(4,j) &
+                        + dummyx_loc(i,5,k)*hprime_xxT(5,j)
+          tempy2(i,j,k) = dummyy_loc(i,1,k)*hprime_xxT(1,j) &
+                        + dummyy_loc(i,2,k)*hprime_xxT(2,j) &
+                        + dummyy_loc(i,3,k)*hprime_xxT(3,j) &
+                        + dummyy_loc(i,4,k)*hprime_xxT(4,j) &
+                        + dummyy_loc(i,5,k)*hprime_xxT(5,j)
+          tempz2(i,j,k) = dummyz_loc(i,1,k)*hprime_xxT(1,j) &
+                        + dummyz_loc(i,2,k)*hprime_xxT(2,j) &
+                        + dummyz_loc(i,3,k)*hprime_xxT(3,j) &
+                        + dummyz_loc(i,4,k)*hprime_xxT(4,j) &
+                        + dummyz_loc(i,5,k)*hprime_xxT(5,j)
+          !!! can merge these loops because NGLLX = NGLLY = NGLLZ
+          tempx3(i,j,k) = dummyx_loc(i,j,1)*hprime_xxT(1,k) &
+                        + dummyx_loc(i,j,2)*hprime_xxT(2,k) &
+                        + dummyx_loc(i,j,3)*hprime_xxT(3,k) &
+                        + dummyx_loc(i,j,4)*hprime_xxT(4,k) &
+                        + dummyx_loc(i,j,5)*hprime_xxT(5,k)
+          tempy3(i,j,k) = dummyy_loc(i,j,1)*hprime_xxT(1,k) &
+                        + dummyy_loc(i,j,2)*hprime_xxT(2,k) &
+                        + dummyy_loc(i,j,3)*hprime_xxT(3,k) &
+                        + dummyy_loc(i,j,4)*hprime_xxT(4,k) &
+                        + dummyy_loc(i,j,5)*hprime_xxT(5,k)
+          tempz3(i,j,k) = dummyz_loc(i,j,1)*hprime_xxT(1,k) &
+                        + dummyz_loc(i,j,2)*hprime_xxT(2,k) &
+                        + dummyz_loc(i,j,3)*hprime_xxT(3,k) &
+                        + dummyz_loc(i,j,4)*hprime_xxT(4,k) &
+                        + dummyz_loc(i,j,5)*hprime_xxT(5,k)
+        enddo
+      enddo
+    enddo
+
+    call compute_element_dummy(ispec,ibool,tempx1,tempx2,tempx3,tempy1,tempy2,tempy3,tempz1,tempz2,tempz3, &
+                               dummyx_loc,dummyy_loc,dummyz_loc,rho_s_H)
+
+    ! uses loop unrolling for NGLLX == NGLLY == NGLLZ == 5
+    do k = 1,NGLLZ
+      do j = 1,NGLLY
+        do i = 1,NGLLX
+          ! general NGLLX == NGLLY == NGLLZ
+          !tempx1l = 0._CUSTOM_REAL
+          !tempx2l = 0._CUSTOM_REAL
+          !tempx3l = 0._CUSTOM_REAL
+          !tempy1l = 0._CUSTOM_REAL
+          !tempy2l = 0._CUSTOM_REAL
+          !tempy3l = 0._CUSTOM_REAL
+          !tempz1l = 0._CUSTOM_REAL
+          !tempz2l = 0._CUSTOM_REAL
+          !tempz3l = 0._CUSTOM_REAL
+          !do l = 1,NGLLX
+          !  fac1 = hprimewgll_xx(l,i)
+          !  tempx1l = tempx1l + tempx1(l,j,k)*fac1
+          !  tempy1l = tempy1l + tempy1(l,j,k)*fac1
+          !  tempz1l = tempz1l + tempz1(l,j,k)*fac1
+          !  !!! can merge these loops because NGLLX = NGLLY = NGLLZ
+          !  fac2 = hprimewgll_yy(l,j)
+          !  tempx2l = tempx2l + tempx2(i,l,k)*fac2
+          !  tempy2l = tempy2l + tempy2(i,l,k)*fac2
+          !  tempz2l = tempz2l + tempz2(i,l,k)*fac2
+          !  !!! can merge these loops because NGLLX = NGLLY = NGLLZ
+          !  fac3 = hprimewgll_zz(l,k)
+          !  tempx3l = tempx3l + tempx3(i,j,l)*fac3
+          !  tempy3l = tempy3l + tempy3(i,j,l)*fac3
+          !  tempz3l = tempz3l + tempz3(i,j,l)*fac3
+          !enddo
+
+          ! unrolled
+          newtempx1(i,j,k) = tempx1(1,j,k)*hprimewgll_xx(1,i) &
+                           + tempx1(2,j,k)*hprimewgll_xx(2,i) &
+                           + tempx1(3,j,k)*hprimewgll_xx(3,i) &
+                           + tempx1(4,j,k)*hprimewgll_xx(4,i) &
+                           + tempx1(5,j,k)*hprimewgll_xx(5,i)
+          newtempy1(i,j,k) = tempy1(1,j,k)*hprimewgll_xx(1,i) &
+                           + tempy1(2,j,k)*hprimewgll_xx(2,i) &
+                           + tempy1(3,j,k)*hprimewgll_xx(3,i) &
+                           + tempy1(4,j,k)*hprimewgll_xx(4,i) &
+                           + tempy1(5,j,k)*hprimewgll_xx(5,i)
+          newtempz1(i,j,k) = tempz1(1,j,k)*hprimewgll_xx(1,i) &
+                           + tempz1(2,j,k)*hprimewgll_xx(2,i) &
+                           + tempz1(3,j,k)*hprimewgll_xx(3,i) &
+                           + tempz1(4,j,k)*hprimewgll_xx(4,i) &
+                           + tempz1(5,j,k)*hprimewgll_xx(5,i)
+          !!! can merge these loops because NGLLX = NGLLY = NGLLZ
+          newtempx2(i,j,k) = tempx2(i,1,k)*hprimewgll_xx(1,j) &
+                           + tempx2(i,2,k)*hprimewgll_xx(2,j) &
+                           + tempx2(i,3,k)*hprimewgll_xx(3,j) &
+                           + tempx2(i,4,k)*hprimewgll_xx(4,j) &
+                           + tempx2(i,5,k)*hprimewgll_xx(5,j)
+          newtempy2(i,j,k) = tempy2(i,1,k)*hprimewgll_xx(1,j) &
+                           + tempy2(i,2,k)*hprimewgll_xx(2,j) &
+                           + tempy2(i,3,k)*hprimewgll_xx(3,j) &
+                           + tempy2(i,4,k)*hprimewgll_xx(4,j) &
+                           + tempy2(i,5,k)*hprimewgll_xx(5,j)
+          newtempz2(i,j,k) = tempz2(i,1,k)*hprimewgll_xx(1,j) &
+                           + tempz2(i,2,k)*hprimewgll_xx(2,j) &
+                           + tempz2(i,3,k)*hprimewgll_xx(3,j) &
+                           + tempz2(i,4,k)*hprimewgll_xx(4,j) &
+                           + tempz2(i,5,k)*hprimewgll_xx(5,j)
+          !!! can merge these loops because NGLLX = NGLLY = NGLLZ
+          newtempx3(i,j,k) = tempx3(i,j,1)*hprimewgll_xx(1,k) &
+                           + tempx3(i,j,2)*hprimewgll_xx(2,k) &
+                           + tempx3(i,j,3)*hprimewgll_xx(3,k) &
+                           + tempx3(i,j,4)*hprimewgll_xx(4,k) &
+                           + tempx3(i,j,5)*hprimewgll_xx(5,k)
+          newtempy3(i,j,k) = tempy3(i,j,1)*hprimewgll_xx(1,k) &
+                           + tempy3(i,j,2)*hprimewgll_xx(2,k) &
+                           + tempy3(i,j,3)*hprimewgll_xx(3,k) &
+                           + tempy3(i,j,4)*hprimewgll_xx(4,k) &
+                           + tempy3(i,j,5)*hprimewgll_xx(5,k)
+          newtempz3(i,j,k) = tempz3(i,j,1)*hprimewgll_xx(1,k) &
+                           + tempz3(i,j,2)*hprimewgll_xx(2,k) &
+                           + tempz3(i,j,3)*hprimewgll_xx(3,k) &
+                           + tempz3(i,j,4)*hprimewgll_xx(4,k) &
+                           + tempz3(i,j,5)*hprimewgll_xx(5,k)
+        enddo
+      enddo
+    enddo
+
+    ! sums contributions
+    do k = 1,NGLLZ
+      do j = 1,NGLLY
+        do i = 1,NGLLX
+          fac1 = wgllwgll_yz_3D(i,j,k)
+          fac2 = wgllwgll_xz_3D(i,j,k)
+          fac3 = wgllwgll_xy_3D(i,j,k)
+          sum_terms(1,i,j,k,ispec) = - (fac1*newtempx1(i,j,k) + fac2*newtempx2(i,j,k) + fac3*newtempx3(i,j,k))
+          sum_terms(2,i,j,k,ispec) = - (fac1*newtempy1(i,j,k) + fac2*newtempy2(i,j,k) + fac3*newtempy3(i,j,k))
+          sum_terms(3,i,j,k,ispec) = - (fac1*newtempz1(i,j,k) + fac2*newtempz2(i,j,k) + fac3*newtempz3(i,j,k))
+        enddo
+      enddo
+    enddo
+
+    ! adds gravity terms
+    if (GRAVITY_VAL) then
+      do k = 1,NGLLZ
+        do j = 1,NGLLY
+          do i = 1,NGLLX
+            sum_terms(1,i,j,k,ispec) = sum_terms(1,i,j,k,ispec) + rho_s_H(i,j,k,1)
+            sum_terms(2,i,j,k,ispec) = sum_terms(2,i,j,k,ispec) + rho_s_H(i,j,k,2)
+            sum_terms(3,i,j,k,ispec) = sum_terms(3,i,j,k,ispec) + rho_s_H(i,j,k,3)
+          enddo
+        enddo
+      enddo
+    endif
+
+    ! updates acceleration
+    ! updates for non-vectorization case
+
+! note: Critical OpenMP here might degrade performance,
+!       especially for a larger number of threads (>8).
+!       Using atomic operations can partially help.
+#ifndef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+#ifdef USE_OPENMP
+!$OMP CRITICAL
+#endif
+#endif
+! we can force vectorization using a compiler directive here because we know that there is no dependency
+! inside a given spectral element, since all the global points of a local elements are different by definition
+! (only common points between different elements can be the same)
+! IBM, Portland PGI, and Intel and Cray syntax (Intel and Cray are the same)
+!IBM* ASSERT (NODEPS)
+!pgi$ ivdep
+!DIR$ IVDEP
+    do k = 1,NGLLZ
+      do j = 1,NGLLY
+        do i = 1,NGLLX
+          iglob = ibool(i,j,k,ispec)
+#ifdef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+#ifdef USE_OPENMP
+!$OMP ATOMIC
+#endif
+#endif
+          accel(1,iglob) = accel(1,iglob) + sum_terms(1,i,j,k,ispec)
+#ifdef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+#ifdef USE_OPENMP
+!$OMP ATOMIC
+#endif
+#endif
+          accel(2,iglob) = accel(2,iglob) + sum_terms(2,i,j,k,ispec)
+#ifdef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+#ifdef USE_OPENMP
+!$OMP ATOMIC
+#endif
+#endif
+          accel(3,iglob) = accel(3,iglob) + sum_terms(3,i,j,k,ispec)
+        enddo
+      enddo
+    enddo
+#ifndef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+#ifdef USE_OPENMP
+!$OMP END CRITICAL
+#endif
+#endif
+
+  enddo ! ispec
+#ifdef USE_OPENMP
+!$OMP enddo
+
+!$OMP END PARALLEL
+#endif
+
+  end subroutine compute_forces_noDev
+

--- a/samples/specfem/compute_forces_xsmm_dispatch.F90
+++ b/samples/specfem/compute_forces_xsmm_dispatch.F90
@@ -1,0 +1,480 @@
+!=====================================================================
+!
+!          S p e c f e m 3 D  G l o b e  V e r s i o n  7 . 0
+!          --------------------------------------------------
+!
+!     Main historical authors: Dimitri Komatitsch and Jeroen Tromp
+!                        Princeton University, USA
+!                and CNRS / University of Marseille, France
+!                 (there are currently many more authors!)
+! (c) Princeton University and CNRS / University of Marseille, April 2014
+!
+! This program is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 2 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License along
+! with this program; if not, write to the Free Software Foundation, Inc.,
+! 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+!
+!=====================================================================
+
+! we switch between vectorized and non-vectorized version by using pre-processor flag FORCE_VECTORIZATION
+! and macros INDEX_IJK, DO_LOOP_IJK, ENDDO_LOOP_IJK defined in config.fh
+#include "config.fh"
+
+!-------------------------------------------------------------------
+!
+! compute forces routine
+!
+!-------------------------------------------------------------------
+
+  subroutine compute_forces_with_xsmm()
+
+! uses LIBXSMM dispatched functions
+! (based on Deville version compute_forces_Dev.F90)
+
+  use specfem_par
+  use my_libxsmm
+
+  implicit none
+
+  ! Deville
+  ! manually inline the calls to the Deville et al. (2002) routines
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ) :: &
+    tempx1,tempx2,tempx3,tempy1,tempy2,tempy3,tempz1,tempz2,tempz3
+
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ) :: &
+    newtempx1,newtempx2,newtempx3,newtempy1,newtempy2,newtempy3,newtempz1,newtempz2,newtempz3
+
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ) :: dummyx_loc,dummyy_loc,dummyz_loc
+
+  real(kind=CUSTOM_REAL) :: fac1,fac2,fac3
+
+  ! for gravity
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ,NDIM) :: rho_s_H
+
+  integer :: num_elements,ispec_p
+  integer :: ispec,iglob
+#ifdef FORCE_VECTORIZATION
+  integer :: ijk_spec,ip,iglob_p,ijk
+#else
+  integer :: i,j,k
+#endif
+
+! ****************************************************
+!   big loop over all spectral elements in the solid
+! ****************************************************
+
+!  computed_elements = 0
+  if (iphase == 1) then
+    ! outer elements (halo region)
+    num_elements = nspec_outer
+  else
+    ! inner elements
+    num_elements = nspec_inner
+  endif
+
+#ifdef USE_OPENMP
+!$OMP PARALLEL DEFAULT(NONE) &
+!$OMP SHARED( &
+!$OMP num_elements,iphase,phase_ispec_inner, &
+!$OMP hprime_xxT,hprime_xx,hprimewgll_xx,hprimewgll_xxT, &
+!$OMP wgllwgll_xy_3D, wgllwgll_xz_3D, wgllwgll_yz_3D, &
+#ifdef FORCE_VECTORIZATION
+!$OMP ibool_inv_tbl, ibool_inv_st, num_globs, phase_iglob, &
+#endif
+!$OMP ibool, &
+!$OMP displ,accel, &
+!$OMP sum_terms ) &
+!$OMP PRIVATE( ispec,ispec_p,iglob, &
+#ifdef FORCE_VECTORIZATION
+!$OMP ijk_spec,ip,iglob_p, &
+!$OMP ijk, &
+#else
+!$OMP i,j,k, &
+#endif
+!$OMP fac1,fac2,fac3, &
+!$OMP tempx1,tempx2,tempx3,tempy1,tempy2,tempy3,tempz1,tempz2,tempz3, &
+!$OMP newtempx1,newtempx2,newtempx3,newtempy1,newtempy2,newtempy3,newtempz1,newtempz2,newtempz3, &
+!$OMP dummyx_loc,dummyy_loc,dummyz_loc, &
+!$OMP rho_s_H )
+#endif
+
+  ! loops over all spectral-elements
+#ifdef USE_OPENMP
+!$OMP DO SCHEDULE(GUIDED)
+#endif
+  do ispec_p = 1,num_elements
+
+    ! only compute elements which belong to current phase (inner or outer elements)
+    ispec = phase_ispec_inner(ispec_p,iphase)
+
+    DO_LOOP_IJK
+      iglob = ibool(INDEX_IJK,ispec)
+      dummyx_loc(INDEX_IJK) = displ(1,iglob)
+      dummyy_loc(INDEX_IJK) = displ(2,iglob)
+      dummyz_loc(INDEX_IJK) = displ(3,iglob)
+    ENDDO_LOOP_IJK
+
+    ! subroutines adapted from Deville, Fischer and Mund, High-order methods
+    ! for incompressible fluid flow, Cambridge University Press (2002),
+    ! pages 386 and 389 and Figure 8.3.1
+
+    ! computes 1. matrix multiplication for tempx1,..
+    call mxm5_3comp_singleA(hprime_xx,m1,dummyx_loc,dummyy_loc,dummyz_loc,tempx1,tempy1,tempz1,m2)
+    ! computes 2. matrix multiplication for tempx2,..
+    call mxm5_3comp_3dmat_singleB(dummyx_loc,dummyy_loc,dummyz_loc,m1,hprime_xxT,m1,tempx2,tempy2,tempz2,NGLLX)
+    ! computes 3. matrix multiplication for tempx3,..
+    call mxm5_3comp_singleB(dummyx_loc,dummyy_loc,dummyz_loc,m2,hprime_xxT,tempx3,tempy3,tempz3,m1)
+
+    call compute_element_dummy(ispec,ibool,tempx1,tempx2,tempx3,tempy1,tempy2,tempy3,tempz1,tempz2,tempz3, &
+                               dummyx_loc,dummyy_loc,dummyz_loc,rho_s_H)
+
+    ! subroutines adapted from Deville, Fischer and Mund, High-order methods
+    ! for incompressible fluid flow, Cambridge University Press (2002),
+    ! pages 386 and 389 and Figure 8.3.1
+
+    ! computes 1. matrix multiplication for newtempx1,..
+    call mxm5_3comp_singleA(hprimewgll_xxT,m1,tempx1,tempy1,tempz1,newtempx1,newtempy1,newtempz1,m2)
+    ! computes 2. matrix multiplication for tempx2,..
+    call mxm5_3comp_3dmat_singleB(tempx2,tempy2,tempz2,m1,hprimewgll_xx,m1,newtempx2,newtempy2,newtempz2,NGLLX)
+    ! computes 3. matrix multiplication for newtempx3,..
+    call mxm5_3comp_singleB(tempx3,tempy3,tempz3,m2,hprimewgll_xx,newtempx3,newtempy3,newtempz3,m1)
+
+    ! sums contributions
+    DO_LOOP_IJK
+      fac1 = wgllwgll_yz_3D(INDEX_IJK)
+      fac2 = wgllwgll_xz_3D(INDEX_IJK)
+      fac3 = wgllwgll_xy_3D(INDEX_IJK)
+      sum_terms(1,INDEX_IJK,ispec) = - (fac1*newtempx1(INDEX_IJK) + fac2*newtempx2(INDEX_IJK) + fac3*newtempx3(INDEX_IJK))
+      sum_terms(2,INDEX_IJK,ispec) = - (fac1*newtempy1(INDEX_IJK) + fac2*newtempy2(INDEX_IJK) + fac3*newtempy3(INDEX_IJK))
+      sum_terms(3,INDEX_IJK,ispec) = - (fac1*newtempz1(INDEX_IJK) + fac2*newtempz2(INDEX_IJK) + fac3*newtempz3(INDEX_IJK))
+    ENDDO_LOOP_IJK
+
+    ! adds gravity terms
+    if (GRAVITY_VAL) then
+#ifdef FORCE_VECTORIZATION
+      do ijk = 1,NDIM*NGLLCUBE
+        sum_terms(ijk,1,1,1,ispec) = sum_terms(ijk,1,1,1,ispec) + rho_s_H(ijk,1,1,1)
+      enddo
+#else
+      do k = 1,NGLLZ
+        do j = 1,NGLLY
+          do i = 1,NGLLX
+            sum_terms(1,i,j,k,ispec) = sum_terms(1,i,j,k,ispec) + rho_s_H(i,j,k,1)
+            sum_terms(2,i,j,k,ispec) = sum_terms(2,i,j,k,ispec) + rho_s_H(i,j,k,2)
+            sum_terms(3,i,j,k,ispec) = sum_terms(3,i,j,k,ispec) + rho_s_H(i,j,k,3)
+          enddo
+        enddo
+      enddo
+#endif
+    endif
+
+    ! updates acceleration
+#ifdef FORCE_VECTORIZATION
+    ! update will be done later at the very end..
+#else
+    ! updates for non-vectorization case
+
+! note: Critical OpenMP here might degrade performance,
+!       especially for a larger number of threads (>8).
+!       Using atomic operations can partially help.
+#ifndef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+#ifdef USE_OPENMP
+!$OMP CRITICAL
+#endif
+#endif
+! we can force vectorization using a compiler directive here because we know that there is no dependency
+! inside a given spectral element, since all the global points of a local elements are different by definition
+! (only common points between different elements can be the same)
+! IBM, Portland PGI, and Intel and Cray syntax (Intel and Cray are the same)
+!IBM* ASSERT (NODEPS)
+!pgi$ ivdep
+!DIR$ IVDEP
+    DO_LOOP_IJK
+      iglob = ibool(INDEX_IJK,ispec)
+#ifdef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+#ifdef USE_OPENMP
+!$OMP ATOMIC
+#endif
+#endif
+      accel(1,iglob) = accel(1,iglob) + sum_terms(1,INDEX_IJK,ispec)
+#ifdef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+#ifdef USE_OPENMP
+!$OMP ATOMIC
+#endif
+#endif
+      accel(2,iglob) = accel(2,iglob) + sum_terms(2,INDEX_IJK,ispec)
+#ifdef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+#ifdef USE_OPENMP
+!$OMP ATOMIC
+#endif
+#endif
+      accel(3,iglob) = accel(3,iglob) + sum_terms(3,INDEX_IJK,ispec)
+    ENDDO_LOOP_IJK
+#ifndef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+#ifdef USE_OPENMP
+!$OMP END CRITICAL
+#endif
+#endif
+#endif
+
+  enddo ! ispec
+#ifdef USE_OPENMP
+!$OMP enddo
+#endif
+
+  ! updates acceleration
+#ifdef FORCE_VECTORIZATION
+  ! updates for vectorized case
+  ! loops over all global nodes in this phase (inner/outer)
+#ifdef USE_OPENMP
+!$OMP DO
+#endif
+  do iglob_p = 1,num_globs(iphase)
+    ! global node index
+    iglob = phase_iglob(iglob_p,iphase)
+    ! loops over valence points
+    do ip = ibool_inv_st(iglob_p,iphase),ibool_inv_st(iglob_p+1,iphase)-1
+      ! local 1D index from array ibool
+      ijk_spec = ibool_inv_tbl(ip,iphase)
+
+      ! do NOT use array syntax ":" for the three statements below otherwise most compilers
+      ! will not be able to vectorize the outer loop
+      accel(1,iglob) = accel(1,iglob) + sum_terms(1,ijk_spec,1,1,1)
+      accel(2,iglob) = accel(2,iglob) + sum_terms(2,ijk_spec,1,1,1)
+      accel(3,iglob) = accel(3,iglob) + sum_terms(3,ijk_spec,1,1,1)
+    enddo
+  enddo
+#ifdef USE_OPENMP
+!$OMP enddo
+#endif
+#endif
+
+#ifdef USE_OPENMP
+!$OMP END PARALLEL
+#endif
+
+  contains
+
+!--------------------------------------------------------------------------------------------
+!
+! matrix-matrix multiplications
+!
+! subroutines adapted from Deville, Fischer and Mund, High-order methods
+! for incompressible fluid flow, Cambridge University Press (2002),
+! pages 386 and 389 and Figure 8.3.1
+!
+!--------------------------------------------------------------------------------------------
+!
+! note: the matrix-matrix multiplications are used for very small matrices ( 5 x 5 x 5 elements);
+!       thus, calling external optimized libraries for these multiplications are in general slower
+!
+! please leave the routines here to help compilers inlining the code
+
+  subroutine mxm5_3comp_singleA(A,n1,B1,B2,B3,C1,C2,C3,n3)
+
+! 3 different arrays for x/y/z-components, 2-dimensional arrays (25,5)/(5,25), same B matrix for all 3 component arrays
+
+#ifdef XSMM
+  use my_libxsmm,only: USE_XSMM_FUNCTION,libxsmm_call,xmm1
+  ! debug timing
+  !use my_libxsmm,only: libxsmm_timer_tick,libxsmm_timer_duration
+#endif
+
+  implicit none
+
+  integer,intent(in) :: n1,n3
+  real(kind=CUSTOM_REAL),dimension(n1,5),intent(in) :: A
+  real(kind=CUSTOM_REAL),dimension(5,n3),intent(in) :: B1,B2,B3
+  real(kind=CUSTOM_REAL),dimension(n1,n3),intent(out) :: C1,C2,C3
+
+  ! local parameters
+  integer :: i,j
+
+#ifdef XSMM
+  ! debug timing
+  !double precision :: duration
+  !integer(kind=8) :: start
+
+  ! debug timing
+  !start = libxsmm_timer_tick()
+
+  ! matrix-matrix multiplication C = alpha A * B + beta C
+  ! with A(n1,n2) 5x5-matrix, B(n2,n3) 5x25-matrix and C(n1,n3) 5x25-matrix
+  if (USE_XSMM_FUNCTION) then
+    call libxsmm_call(xmm1, A, B1, C1)
+    call libxsmm_call(xmm1, A, B2, C2)
+    call libxsmm_call(xmm1, A, B3, C3)
+
+    ! debug timing
+    !duration = libxsmm_timer_duration(start, libxsmm_timer_tick())
+    !print *,'duration: ',duration
+
+    ! debug
+    !do j = 1,n3
+    !  do i = 1,n1
+    !    print *,i,j,'debug xsmm',C1(i,j),C2(i,j),C1(i,j) - C2(i,j)
+    !  enddo
+    !enddo
+    !stop 'test stop'
+
+    return
+  endif
+#endif
+
+  ! matrix-matrix multiplication
+  do j = 1,n3
+!dir$ ivdep
+    do i = 1,n1
+      C1(i,j) =  A(i,1) * B1(1,j) &
+               + A(i,2) * B1(2,j) &
+               + A(i,3) * B1(3,j) &
+               + A(i,4) * B1(4,j) &
+               + A(i,5) * B1(5,j)
+
+      C2(i,j) =  A(i,1) * B2(1,j) &
+               + A(i,2) * B2(2,j) &
+               + A(i,3) * B2(3,j) &
+               + A(i,4) * B2(4,j) &
+               + A(i,5) * B2(5,j)
+
+      C3(i,j) =  A(i,1) * B3(1,j) &
+               + A(i,2) * B3(2,j) &
+               + A(i,3) * B3(3,j) &
+               + A(i,4) * B3(4,j) &
+               + A(i,5) * B3(5,j)
+    enddo
+  enddo
+
+  end subroutine mxm5_3comp_singleA
+
+
+!--------------------------------------------------------------------------------------------
+
+  subroutine mxm5_3comp_singleB(A1,A2,A3,n1,B,C1,C2,C3,n3)
+
+! 3 different arrays for x/y/z-components, 2-dimensional arrays (25,5)/(5,25), same B matrix for all 3 component arrays
+
+#ifdef XSMM
+  use my_libxsmm,only: USE_XSMM_FUNCTION,libxsmm_call,xmm2
+#endif
+
+  implicit none
+
+  integer,intent(in) :: n1,n3
+  real(kind=CUSTOM_REAL),dimension(n1,5),intent(in) :: A1,A2,A3
+  real(kind=CUSTOM_REAL),dimension(5,n3),intent(in) :: B
+  real(kind=CUSTOM_REAL),dimension(n1,n3),intent(out) :: C1,C2,C3
+
+  ! local parameters
+  integer :: i,j
+
+#ifdef XSMM
+  ! matrix-matrix multiplication C = alpha A * B + beta C
+  ! with A(n1,n2) 25x5-matrix, B(n2,n3) 5x5-matrix and C(n1,n3) 25x5-matrix
+  if (USE_XSMM_FUNCTION) then
+    call libxsmm_call(xmm2, A1, B, C1)
+    call libxsmm_call(xmm2, A2, B, C2)
+    call libxsmm_call(xmm2, A3, B, C3)
+    return
+  endif
+#endif
+
+  ! matrix-matrix multiplication
+  do j = 1,n3
+!dir$ ivdep
+    do i = 1,n1
+      C1(i,j) =  A1(i,1) * B(1,j) &
+               + A1(i,2) * B(2,j) &
+               + A1(i,3) * B(3,j) &
+               + A1(i,4) * B(4,j) &
+               + A1(i,5) * B(5,j)
+
+      C2(i,j) =  A2(i,1) * B(1,j) &
+               + A2(i,2) * B(2,j) &
+               + A2(i,3) * B(3,j) &
+               + A2(i,4) * B(4,j) &
+               + A2(i,5) * B(5,j)
+
+      C3(i,j) =  A3(i,1) * B(1,j) &
+               + A3(i,2) * B(2,j) &
+               + A3(i,3) * B(3,j) &
+               + A3(i,4) * B(4,j) &
+               + A3(i,5) * B(5,j)
+    enddo
+  enddo
+
+  end subroutine mxm5_3comp_singleB
+
+
+!--------------------------------------------------------------------------------------------
+
+  subroutine mxm5_3comp_3dmat_singleB(A1,A2,A3,n1,B,n2,C1,C2,C3,n3)
+
+! 3 different arrays for x/y/z-components, 3-dimensional arrays (5,5,5), same B matrix for all 3 component arrays
+
+#ifdef XSMM
+  use my_libxsmm,only: USE_XSMM_FUNCTION,libxsmm_call,xmm3
+#endif
+
+  implicit none
+
+  integer,intent(in) :: n1,n2,n3
+  real(kind=CUSTOM_REAL),dimension(n1,5,n3),intent(in) :: A1,A2,A3
+  real(kind=CUSTOM_REAL),dimension(5,n2),intent(in) :: B
+  real(kind=CUSTOM_REAL),dimension(n1,n2,n3),intent(out) :: C1,C2,C3
+
+  ! local parameters
+  integer :: i,j,k
+
+#ifdef XSMM
+  ! matrix-matrix multiplication C = alpha A * B + beta C
+  ! with A(n1,n2,n4) 5x5x5-matrix, B(n2,n3) 5x5-matrix and C(n1,n3,n4) 5x5x5-matrix
+  if (USE_XSMM_FUNCTION) then
+    do k = 1,5
+      call libxsmm_call(xmm3, A1(:,:,k), B, C1(:,:,k))
+      call libxsmm_call(xmm3, A2(:,:,k), B, C2(:,:,k))
+      call libxsmm_call(xmm3, A3(:,:,k), B, C3(:,:,k))
+    enddo
+    return
+  endif
+#endif
+
+  ! matrix-matrix multiplication
+  do k = 1,n3
+    do j = 1,n2
+!dir$ ivdep
+      do i = 1,n1
+        C1(i,j,k) =  A1(i,1,k) * B(1,j) &
+                   + A1(i,2,k) * B(2,j) &
+                   + A1(i,3,k) * B(3,j) &
+                   + A1(i,4,k) * B(4,j) &
+                   + A1(i,5,k) * B(5,j)
+
+        C2(i,j,k) =  A2(i,1,k) * B(1,j) &
+                   + A2(i,2,k) * B(2,j) &
+                   + A2(i,3,k) * B(3,j) &
+                   + A2(i,4,k) * B(4,j) &
+                   + A2(i,5,k) * B(5,j)
+
+        C3(i,j,k) =  A3(i,1,k) * B(1,j) &
+                   + A3(i,2,k) * B(2,j) &
+                   + A3(i,3,k) * B(3,j) &
+                   + A3(i,4,k) * B(4,j) &
+                   + A3(i,5,k) * B(5,j)
+      enddo
+    enddo
+  enddo
+
+  end subroutine mxm5_3comp_3dmat_singleB
+
+  end subroutine compute_forces_with_xsmm
+

--- a/samples/specfem/compute_forces_xsmm_prefetch.F90
+++ b/samples/specfem/compute_forces_xsmm_prefetch.F90
@@ -1,0 +1,499 @@
+!=====================================================================
+!
+!          S p e c f e m 3 D  G l o b e  V e r s i o n  7 . 0
+!          --------------------------------------------------
+!
+!     Main historical authors: Dimitri Komatitsch and Jeroen Tromp
+!                        Princeton University, USA
+!                and CNRS / University of Marseille, France
+!                 (there are currently many more authors!)
+! (c) Princeton University and CNRS / University of Marseille, April 2014
+!
+! This program is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 2 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License along
+! with this program; if not, write to the Free Software Foundation, Inc.,
+! 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+!
+!=====================================================================
+
+! we switch between vectorized and non-vectorized version by using pre-processor flag FORCE_VECTORIZATION
+! and macros INDEX_IJK, DO_LOOP_IJK, ENDDO_LOOP_IJK defined in config.fh
+#include "config.fh"
+
+!-------------------------------------------------------------------
+!
+! compute forces routine
+!
+!-------------------------------------------------------------------
+
+  subroutine compute_forces_with_xsmm_prefetch()
+
+! uses LIBXSMM dispatched functions with prefetch versions
+! (based on Deville version compute_forces_Dev.F90)
+
+  use specfem_par
+  use my_libxsmm
+
+  implicit none
+
+  ! Deville
+  ! manually inline the calls to the Deville et al. (2002) routines
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ) :: &
+    tempx1,tempx2,tempx3,tempy1,tempy2,tempy3,tempz1,tempz2,tempz3
+
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ) :: &
+    newtempx1,newtempx2,newtempx3,newtempy1,newtempy2,newtempy3,newtempz1,newtempz2,newtempz3
+
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ) :: dummyx_loc,dummyy_loc,dummyz_loc
+
+  real(kind=CUSTOM_REAL) :: fac1,fac2,fac3
+
+  ! for gravity
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ,NDIM) :: rho_s_H
+
+  integer :: num_elements,ispec_p
+  integer :: ispec,iglob
+#ifdef FORCE_VECTORIZATION
+  integer :: ijk_spec,ip,iglob_p,ijk
+#else
+  integer :: i,j,k
+#endif
+
+! ****************************************************
+!   big loop over all spectral elements in the solid
+! ****************************************************
+
+!  computed_elements = 0
+  if (iphase == 1) then
+    ! outer elements (halo region)
+    num_elements = nspec_outer
+  else
+    ! inner elements
+    num_elements = nspec_inner
+  endif
+
+#ifdef USE_OPENMP
+!$OMP PARALLEL DEFAULT(NONE) &
+!$OMP SHARED( &
+!$OMP num_elements,iphase,phase_ispec_inner, &
+!$OMP hprime_xxT,hprime_xx,hprimewgll_xx,hprimewgll_xxT, &
+!$OMP wgllwgll_xy_3D, wgllwgll_xz_3D, wgllwgll_yz_3D, &
+#ifdef FORCE_VECTORIZATION
+!$OMP ibool_inv_tbl, ibool_inv_st, num_globs, phase_iglob, &
+#endif
+!$OMP ibool, &
+!$OMP displ,accel, &
+!$OMP sum_terms ) &
+!$OMP PRIVATE( ispec,ispec_p,iglob, &
+#ifdef FORCE_VECTORIZATION
+!$OMP ijk_spec,ip,iglob_p, &
+!$OMP ijk, &
+#else
+!$OMP i,j,k, &
+#endif
+!$OMP fac1,fac2,fac3, &
+!$OMP tempx1,tempx2,tempx3,tempy1,tempy2,tempy3,tempz1,tempz2,tempz3, &
+!$OMP newtempx1,newtempx2,newtempx3,newtempy1,newtempy2,newtempy3,newtempz1,newtempz2,newtempz3, &
+!$OMP dummyx_loc,dummyy_loc,dummyz_loc, &
+!$OMP rho_s_H )
+#endif
+
+  ! loops over all spectral-elements
+#ifdef USE_OPENMP
+!$OMP DO SCHEDULE(GUIDED)
+#endif
+  do ispec_p = 1,num_elements
+
+    ! only compute elements which belong to current phase (inner or outer elements)
+    ispec = phase_ispec_inner(ispec_p,iphase)
+
+    DO_LOOP_IJK
+      iglob = ibool(INDEX_IJK,ispec)
+      dummyx_loc(INDEX_IJK) = displ(1,iglob)
+      dummyy_loc(INDEX_IJK) = displ(2,iglob)
+      dummyz_loc(INDEX_IJK) = displ(3,iglob)
+    ENDDO_LOOP_IJK
+
+    ! subroutines adapted from Deville, Fischer and Mund, High-order methods
+    ! for incompressible fluid flow, Cambridge University Press (2002),
+    ! pages 386 and 389 and Figure 8.3.1
+
+    ! computes 1. matrix multiplication for tempx1,..
+    call mxm5_3comp_singleA(hprime_xx,m1,dummyx_loc,dummyy_loc,dummyz_loc,tempx1,tempy1,tempz1,m2)
+    ! computes 2. matrix multiplication for tempx2,..
+    call mxm5_3comp_3dmat_singleB(dummyx_loc,dummyy_loc,dummyz_loc,m1,hprime_xxT,m1,tempx2,tempy2,tempz2,NGLLX)
+    ! computes 3. matrix multiplication for tempx3,..
+    call mxm5_3comp_singleB(dummyx_loc,dummyy_loc,dummyz_loc,m2,hprime_xxT,tempx3,tempy3,tempz3,m1)
+
+    call compute_element_dummy(ispec,ibool,tempx1,tempx2,tempx3,tempy1,tempy2,tempy3,tempz1,tempz2,tempz3, &
+                               dummyx_loc,dummyy_loc,dummyz_loc,rho_s_H)
+
+    ! subroutines adapted from Deville, Fischer and Mund, High-order methods
+    ! for incompressible fluid flow, Cambridge University Press (2002),
+    ! pages 386 and 389 and Figure 8.3.1
+
+    ! computes 1. matrix multiplication for newtempx1,..
+    call mxm5_3comp_singleA(hprimewgll_xxT,m1,tempx1,tempy1,tempz1,newtempx1,newtempy1,newtempz1,m2)
+    ! computes 2. matrix multiplication for tempx2,..
+    call mxm5_3comp_3dmat_singleB(tempx2,tempy2,tempz2,m1,hprimewgll_xx,m1,newtempx2,newtempy2,newtempz2,NGLLX)
+    ! computes 3. matrix multiplication for newtempx3,..
+    call mxm5_3comp_singleB(tempx3,tempy3,tempz3,m2,hprimewgll_xx,newtempx3,newtempy3,newtempz3,m1)
+
+    ! sums contributions
+    DO_LOOP_IJK
+      fac1 = wgllwgll_yz_3D(INDEX_IJK)
+      fac2 = wgllwgll_xz_3D(INDEX_IJK)
+      fac3 = wgllwgll_xy_3D(INDEX_IJK)
+      sum_terms(1,INDEX_IJK,ispec) = - (fac1*newtempx1(INDEX_IJK) + fac2*newtempx2(INDEX_IJK) + fac3*newtempx3(INDEX_IJK))
+      sum_terms(2,INDEX_IJK,ispec) = - (fac1*newtempy1(INDEX_IJK) + fac2*newtempy2(INDEX_IJK) + fac3*newtempy3(INDEX_IJK))
+      sum_terms(3,INDEX_IJK,ispec) = - (fac1*newtempz1(INDEX_IJK) + fac2*newtempz2(INDEX_IJK) + fac3*newtempz3(INDEX_IJK))
+    ENDDO_LOOP_IJK
+
+    ! adds gravity terms
+    if (GRAVITY_VAL) then
+#ifdef FORCE_VECTORIZATION
+      do ijk = 1,NDIM*NGLLCUBE
+        sum_terms(ijk,1,1,1,ispec) = sum_terms(ijk,1,1,1,ispec) + rho_s_H(ijk,1,1,1)
+      enddo
+#else
+      do k = 1,NGLLZ
+        do j = 1,NGLLY
+          do i = 1,NGLLX
+            sum_terms(1,i,j,k,ispec) = sum_terms(1,i,j,k,ispec) + rho_s_H(i,j,k,1)
+            sum_terms(2,i,j,k,ispec) = sum_terms(2,i,j,k,ispec) + rho_s_H(i,j,k,2)
+            sum_terms(3,i,j,k,ispec) = sum_terms(3,i,j,k,ispec) + rho_s_H(i,j,k,3)
+          enddo
+        enddo
+      enddo
+#endif
+    endif
+
+    ! updates acceleration
+#ifdef FORCE_VECTORIZATION
+    ! update will be done later at the very end..
+#else
+    ! updates for non-vectorization case
+
+! note: Critical OpenMP here might degrade performance,
+!       especially for a larger number of threads (>8).
+!       Using atomic operations can partially help.
+#ifndef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+#ifdef USE_OPENMP
+!$OMP CRITICAL
+#endif
+#endif
+! we can force vectorization using a compiler directive here because we know that there is no dependency
+! inside a given spectral element, since all the global points of a local elements are different by definition
+! (only common points between different elements can be the same)
+! IBM, Portland PGI, and Intel and Cray syntax (Intel and Cray are the same)
+!IBM* ASSERT (NODEPS)
+!pgi$ ivdep
+!DIR$ IVDEP
+    DO_LOOP_IJK
+      iglob = ibool(INDEX_IJK,ispec)
+#ifdef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+#ifdef USE_OPENMP
+!$OMP ATOMIC
+#endif
+#endif
+      accel(1,iglob) = accel(1,iglob) + sum_terms(1,INDEX_IJK,ispec)
+#ifdef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+#ifdef USE_OPENMP
+!$OMP ATOMIC
+#endif
+#endif
+      accel(2,iglob) = accel(2,iglob) + sum_terms(2,INDEX_IJK,ispec)
+#ifdef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+#ifdef USE_OPENMP
+!$OMP ATOMIC
+#endif
+#endif
+      accel(3,iglob) = accel(3,iglob) + sum_terms(3,INDEX_IJK,ispec)
+    ENDDO_LOOP_IJK
+#ifndef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+#ifdef USE_OPENMP
+!$OMP END CRITICAL
+#endif
+#endif
+#endif
+
+  enddo ! ispec
+#ifdef USE_OPENMP
+!$OMP enddo
+#endif
+
+  ! updates acceleration
+#ifdef FORCE_VECTORIZATION
+  ! updates for vectorized case
+  ! loops over all global nodes in this phase (inner/outer)
+#ifdef USE_OPENMP
+!$OMP DO
+#endif
+  do iglob_p = 1,num_globs(iphase)
+    ! global node index
+    iglob = phase_iglob(iglob_p,iphase)
+    ! loops over valence points
+    do ip = ibool_inv_st(iglob_p,iphase),ibool_inv_st(iglob_p+1,iphase)-1
+      ! local 1D index from array ibool
+      ijk_spec = ibool_inv_tbl(ip,iphase)
+
+      ! do NOT use array syntax ":" for the three statements below otherwise most compilers
+      ! will not be able to vectorize the outer loop
+      accel(1,iglob) = accel(1,iglob) + sum_terms(1,ijk_spec,1,1,1)
+      accel(2,iglob) = accel(2,iglob) + sum_terms(2,ijk_spec,1,1,1)
+      accel(3,iglob) = accel(3,iglob) + sum_terms(3,ijk_spec,1,1,1)
+    enddo
+  enddo
+#ifdef USE_OPENMP
+!$OMP enddo
+#endif
+#endif
+
+#ifdef USE_OPENMP
+!$OMP END PARALLEL
+#endif
+
+  contains
+
+!--------------------------------------------------------------------------------------------
+!
+! matrix-matrix multiplications
+!
+! subroutines adapted from Deville, Fischer and Mund, High-order methods
+! for incompressible fluid flow, Cambridge University Press (2002),
+! pages 386 and 389 and Figure 8.3.1
+!
+!--------------------------------------------------------------------------------------------
+!
+! note: the matrix-matrix multiplications are used for very small matrices ( 5 x 5 x 5 elements);
+!       thus, calling external optimized libraries for these multiplications are in general slower
+!
+! please leave the routines here to help compilers inlining the code
+
+  subroutine mxm5_3comp_singleA(A,n1,B1,B2,B3,C1,C2,C3,n3)
+
+! 3 different arrays for x/y/z-components, 2-dimensional arrays (25,5)/(5,25), same B matrix for all 3 component arrays
+
+#ifdef XSMM
+  use my_libxsmm,only: USE_XSMM_FUNCTION_PREFETCH,libxsmm_call,xmm1
+  use my_libxsmm,only: xmm1p,C_LOC
+  ! debug timing
+  !use my_libxsmm,only: libxsmm_timer_tick,libxsmm_timer_duration
+#endif
+
+  implicit none
+
+  integer,intent(in) :: n1,n3
+
+  real(kind=CUSTOM_REAL),dimension(n1,5),intent(in),target :: A
+  real(kind=CUSTOM_REAL),dimension(5,n3),intent(in),target :: B1,B2,B3
+  real(kind=CUSTOM_REAL),dimension(n1,n3),intent(out),target :: C1,C2,C3
+
+  ! local parameters
+  integer :: i,j
+
+#ifdef XSMM
+  ! debug timing
+  !double precision :: duration
+  !integer(kind=8) :: start
+
+  ! debug timing
+  !start = libxsmm_timer_tick()
+
+  ! matrix-matrix multiplication C = alpha A * B + beta C
+  ! with A(n1,n2) 5x5-matrix, B(n2,n3) 5x25-matrix and C(n1,n3) 5x25-matrix
+  if (USE_XSMM_FUNCTION_PREFETCH) then
+    ! prefetch version
+    call libxsmm_call(xmm1p, a=C_LOC(A), b=C_LOC(B1), c=C_LOC(C1), pa=C_LOC(A), pb=C_LOC(B2), pc=C_LOC(C2)) ! with prefetch
+    call libxsmm_call(xmm1p, a=C_LOC(A), b=C_LOC(B2), c=C_LOC(C2), pa=C_LOC(A), pb=C_LOC(B3), pc=C_LOC(C3)) ! with prefetch
+    call libxsmm_call(xmm1, a=C_LOC(A), b=C_LOC(B3), c=C_LOC(C3))
+    !call libxsmm_call(xmm1p, a=C_LOC(A), b=C_LOC(B3), c=C_LOC(C3), pa=C_LOC(A), pb=C_LOC(B1), pc=C_LOC(C1)) ! with dummy prefetch
+
+    ! debug timing
+    !duration = libxsmm_timer_duration(start, libxsmm_timer_tick())
+    !print *,'duration: ',duration
+
+    ! debug
+    !do j = 1,n3
+    !  do i = 1,n1
+    !    print *,i,j,'debug xsmm',C1(i,j),C2(i,j),C1(i,j) - C2(i,j)
+    !  enddo
+    !enddo
+    !stop 'test stop'
+
+    return
+  endif
+#endif
+
+  ! matrix-matrix multiplication
+  do j = 1,n3
+!dir$ ivdep
+    do i = 1,n1
+      C1(i,j) =  A(i,1) * B1(1,j) &
+               + A(i,2) * B1(2,j) &
+               + A(i,3) * B1(3,j) &
+               + A(i,4) * B1(4,j) &
+               + A(i,5) * B1(5,j)
+
+      C2(i,j) =  A(i,1) * B2(1,j) &
+               + A(i,2) * B2(2,j) &
+               + A(i,3) * B2(3,j) &
+               + A(i,4) * B2(4,j) &
+               + A(i,5) * B2(5,j)
+
+      C3(i,j) =  A(i,1) * B3(1,j) &
+               + A(i,2) * B3(2,j) &
+               + A(i,3) * B3(3,j) &
+               + A(i,4) * B3(4,j) &
+               + A(i,5) * B3(5,j)
+    enddo
+  enddo
+
+  end subroutine mxm5_3comp_singleA
+
+
+!--------------------------------------------------------------------------------------------
+
+  subroutine mxm5_3comp_singleB(A1,A2,A3,n1,B,C1,C2,C3,n3)
+
+! 3 different arrays for x/y/z-components, 2-dimensional arrays (25,5)/(5,25), same B matrix for all 3 component arrays
+
+#ifdef XSMM
+  use my_libxsmm,only: USE_XSMM_FUNCTION_PREFETCH,libxsmm_call,xmm2
+  use my_libxsmm,only: xmm2p,C_LOC
+#endif
+
+  implicit none
+
+  integer,intent(in) :: n1,n3
+
+  real(kind=CUSTOM_REAL),dimension(n1,5),intent(in),target :: A1,A2,A3
+  real(kind=CUSTOM_REAL),dimension(5,n3),intent(in),target :: B
+  real(kind=CUSTOM_REAL),dimension(n1,n3),intent(out),target :: C1,C2,C3
+
+  ! local parameters
+  integer :: i,j
+
+#ifdef XSMM
+  ! matrix-matrix multiplication C = alpha A * B + beta C
+  ! with A(n1,n2) 25x5-matrix, B(n2,n3) 5x5-matrix and C(n1,n3) 25x5-matrix
+  if (USE_XSMM_FUNCTION_PREFETCH) then
+    ! prefetch version
+    call libxsmm_call(xmm2p, a=C_LOC(A1), b=C_LOC(B), c=C_LOC(C1), pa=C_LOC(A2), pb=C_LOC(B), pc=C_LOC(C2)) ! with prefetch
+    call libxsmm_call(xmm2p, a=C_LOC(A2), b=C_LOC(B), c=C_LOC(C2), pa=C_LOC(A3), pb=C_LOC(B), pc=C_LOC(C3)) ! with prefetch
+    call libxsmm_call(xmm2, a=C_LOC(A3), b=C_LOC(B), c=C_LOC(C3))
+    !call libxsmm_call(xmm2p, a=C_LOC(A3), b=C_LOC(B), c=C_LOC(C3), pa=C_LOC(A1), pb=C_LOC(B), pc=C_LOC(C1)) ! with dummy prefetch
+    return
+  endif
+#endif
+
+  ! matrix-matrix multiplication
+  do j = 1,n3
+!dir$ ivdep
+    do i = 1,n1
+      C1(i,j) =  A1(i,1) * B(1,j) &
+               + A1(i,2) * B(2,j) &
+               + A1(i,3) * B(3,j) &
+               + A1(i,4) * B(4,j) &
+               + A1(i,5) * B(5,j)
+
+      C2(i,j) =  A2(i,1) * B(1,j) &
+               + A2(i,2) * B(2,j) &
+               + A2(i,3) * B(3,j) &
+               + A2(i,4) * B(4,j) &
+               + A2(i,5) * B(5,j)
+
+      C3(i,j) =  A3(i,1) * B(1,j) &
+               + A3(i,2) * B(2,j) &
+               + A3(i,3) * B(3,j) &
+               + A3(i,4) * B(4,j) &
+               + A3(i,5) * B(5,j)
+    enddo
+  enddo
+
+  end subroutine mxm5_3comp_singleB
+
+
+!--------------------------------------------------------------------------------------------
+
+  subroutine mxm5_3comp_3dmat_singleB(A1,A2,A3,n1,B,n2,C1,C2,C3,n3)
+
+! 3 different arrays for x/y/z-components, 3-dimensional arrays (5,5,5), same B matrix for all 3 component arrays
+
+#ifdef XSMM
+  use my_libxsmm,only: USE_XSMM_FUNCTION_PREFETCH,libxsmm_call,xmm3
+  use my_libxsmm,only: xmm3p,C_LOC
+#endif
+
+  implicit none
+
+  integer,intent(in) :: n1,n2,n3
+
+  real(kind=CUSTOM_REAL),dimension(n1,5,n3),intent(in),target :: A1,A2,A3
+  real(kind=CUSTOM_REAL),dimension(5,n2),intent(in),target :: B
+  real(kind=CUSTOM_REAL),dimension(n1,n2,n3),intent(out),target :: C1,C2,C3
+
+  ! local parameters
+  integer :: i,j,k
+
+#ifdef XSMM
+  ! matrix-matrix multiplication C = alpha A * B + beta C
+  ! with A(n1,n2,n4) 5x5x5-matrix, B(n2,n3) 5x5-matrix and C(n1,n3,n4) 5x5x5-matrix
+  if (USE_XSMM_FUNCTION_PREFETCH) then
+    do k = 1,5
+      ! prefetch version
+      call libxsmm_call(xmm3p, a=C_LOC(A1(1,1,k)), b=C_LOC(B), c=C_LOC(C1(1,1,k)), &
+                              pa=C_LOC(A2(1,1,k)), pb=C_LOC(B), pc=C_LOC(C2(1,1,k))) ! with prefetch
+      call libxsmm_call(xmm3p, a=C_LOC(A2(1,1,k)), b=C_LOC(B), c=C_LOC(C2(1,1,k)), &
+                              pa=C_LOC(A3(1,1,k)), pb=C_LOC(B), pc=C_LOC(C3(1,1,k))) ! with prefetch
+
+      !if (k == 5) then
+        call libxsmm_call(xmm3, a=C_LOC(A3(1,1,k)), b=C_LOC(B), c=C_LOC(C3(1,1,k)))
+      !else
+      !  call libxsmm_call(xmm3p, a=C_LOC(A3(1,1,k)), b=C_LOC(B), c=C_LOC(C3(1,1,k)), &
+      !                        pa=C_LOC(A1(1,1,k+1)), pb=C_LOC(B), pc=C_LOC(C1(1,1,k+1))) ! with dummy prefetch
+      !endif
+    enddo
+    return
+  endif
+#endif
+
+  ! matrix-matrix multiplication
+  do k = 1,n3
+    do j = 1,n2
+!dir$ ivdep
+      do i = 1,n1
+        C1(i,j,k) =  A1(i,1,k) * B(1,j) &
+                   + A1(i,2,k) * B(2,j) &
+                   + A1(i,3,k) * B(3,j) &
+                   + A1(i,4,k) * B(4,j) &
+                   + A1(i,5,k) * B(5,j)
+
+        C2(i,j,k) =  A2(i,1,k) * B(1,j) &
+                   + A2(i,2,k) * B(2,j) &
+                   + A2(i,3,k) * B(3,j) &
+                   + A2(i,4,k) * B(4,j) &
+                   + A2(i,5,k) * B(5,j)
+
+        C3(i,j,k) =  A3(i,1,k) * B(1,j) &
+                   + A3(i,2,k) * B(2,j) &
+                   + A3(i,3,k) * B(3,j) &
+                   + A3(i,4,k) * B(4,j) &
+                   + A3(i,5,k) * B(5,j)
+      enddo
+    enddo
+  enddo
+
+  end subroutine mxm5_3comp_3dmat_singleB
+
+  end subroutine compute_forces_with_xsmm_prefetch
+

--- a/samples/specfem/compute_forces_xsmm_static.F90
+++ b/samples/specfem/compute_forces_xsmm_static.F90
@@ -1,0 +1,476 @@
+!=====================================================================
+!
+!          S p e c f e m 3 D  G l o b e  V e r s i o n  7 . 0
+!          --------------------------------------------------
+!
+!     Main historical authors: Dimitri Komatitsch and Jeroen Tromp
+!                        Princeton University, USA
+!                and CNRS / University of Marseille, France
+!                 (there are currently many more authors!)
+! (c) Princeton University and CNRS / University of Marseille, April 2014
+!
+! This program is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 2 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License along
+! with this program; if not, write to the Free Software Foundation, Inc.,
+! 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+!
+!=====================================================================
+
+! we switch between vectorized and non-vectorized version by using pre-processor flag FORCE_VECTORIZATION
+! and macros INDEX_IJK, DO_LOOP_IJK, ENDDO_LOOP_IJK defined in config.fh
+#include "config.fh"
+
+!-------------------------------------------------------------------
+!
+! compute forces routine
+!
+!-------------------------------------------------------------------
+
+  subroutine compute_forces_with_xsmm_static()
+
+! uses LIBXSMM static function calls (no dispatching, LIBXSMM compiled with: make MNK="5 25" ..)
+! (based on Deville version compute_forces_Dev.F90)
+
+  use specfem_par
+  use my_libxsmm
+
+  implicit none
+
+  ! Deville
+  ! manually inline the calls to the Deville et al. (2002) routines
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ) :: &
+    tempx1,tempx2,tempx3,tempy1,tempy2,tempy3,tempz1,tempz2,tempz3
+
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ) :: &
+    newtempx1,newtempx2,newtempx3,newtempy1,newtempy2,newtempy3,newtempz1,newtempz2,newtempz3
+
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ) :: dummyx_loc,dummyy_loc,dummyz_loc
+
+  real(kind=CUSTOM_REAL) :: fac1,fac2,fac3
+
+  ! for gravity
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ,NDIM) :: rho_s_H
+
+  integer :: num_elements,ispec_p
+  integer :: ispec,iglob
+#ifdef FORCE_VECTORIZATION
+  integer :: ijk_spec,ip,iglob_p,ijk
+#else
+  integer :: i,j,k
+#endif
+
+! ****************************************************
+!   big loop over all spectral elements in the solid
+! ****************************************************
+
+!  computed_elements = 0
+  if (iphase == 1) then
+    ! outer elements (halo region)
+    num_elements = nspec_outer
+  else
+    ! inner elements
+    num_elements = nspec_inner
+  endif
+
+#ifdef USE_OPENMP
+!$OMP PARALLEL DEFAULT(NONE) &
+!$OMP SHARED( &
+!$OMP num_elements,iphase,phase_ispec_inner, &
+!$OMP hprime_xxT,hprime_xx,hprimewgll_xx,hprimewgll_xxT, &
+!$OMP wgllwgll_xy_3D, wgllwgll_xz_3D, wgllwgll_yz_3D, &
+#ifdef FORCE_VECTORIZATION
+!$OMP ibool_inv_tbl, ibool_inv_st, num_globs, phase_iglob, &
+#endif
+!$OMP ibool, &
+!$OMP displ,accel, &
+!$OMP sum_terms ) &
+!$OMP PRIVATE( ispec,ispec_p,iglob, &
+#ifdef FORCE_VECTORIZATION
+!$OMP ijk_spec,ip,iglob_p, &
+!$OMP ijk, &
+#else
+!$OMP i,j,k, &
+#endif
+!$OMP fac1,fac2,fac3, &
+!$OMP tempx1,tempx2,tempx3,tempy1,tempy2,tempy3,tempz1,tempz2,tempz3, &
+!$OMP newtempx1,newtempx2,newtempx3,newtempy1,newtempy2,newtempy3,newtempz1,newtempz2,newtempz3, &
+!$OMP dummyx_loc,dummyy_loc,dummyz_loc, &
+!$OMP rho_s_H )
+#endif
+
+  ! loops over all spectral-elements
+#ifdef USE_OPENMP
+!$OMP DO SCHEDULE(GUIDED)
+#endif
+  do ispec_p = 1,num_elements
+
+    ! only compute elements which belong to current phase (inner or outer elements)
+    ispec = phase_ispec_inner(ispec_p,iphase)
+
+    DO_LOOP_IJK
+      iglob = ibool(INDEX_IJK,ispec)
+      dummyx_loc(INDEX_IJK) = displ(1,iglob)
+      dummyy_loc(INDEX_IJK) = displ(2,iglob)
+      dummyz_loc(INDEX_IJK) = displ(3,iglob)
+    ENDDO_LOOP_IJK
+
+    ! subroutines adapted from Deville, Fischer and Mund, High-order methods
+    ! for incompressible fluid flow, Cambridge University Press (2002),
+    ! pages 386 and 389 and Figure 8.3.1
+
+    ! computes 1. matrix multiplication for tempx1,..
+    call mxm5_3comp_singleA(hprime_xx,m1,dummyx_loc,dummyy_loc,dummyz_loc,tempx1,tempy1,tempz1,m2)
+    ! computes 2. matrix multiplication for tempx2,..
+    call mxm5_3comp_3dmat_singleB(dummyx_loc,dummyy_loc,dummyz_loc,m1,hprime_xxT,m1,tempx2,tempy2,tempz2,NGLLX)
+    ! computes 3. matrix multiplication for tempx3,..
+    call mxm5_3comp_singleB(dummyx_loc,dummyy_loc,dummyz_loc,m2,hprime_xxT,tempx3,tempy3,tempz3,m1)
+
+    call compute_element_dummy(ispec,ibool,tempx1,tempx2,tempx3,tempy1,tempy2,tempy3,tempz1,tempz2,tempz3, &
+                               dummyx_loc,dummyy_loc,dummyz_loc,rho_s_H)
+
+    ! subroutines adapted from Deville, Fischer and Mund, High-order methods
+    ! for incompressible fluid flow, Cambridge University Press (2002),
+    ! pages 386 and 389 and Figure 8.3.1
+
+    ! computes 1. matrix multiplication for newtempx1,..
+    call mxm5_3comp_singleA(hprimewgll_xxT,m1,tempx1,tempy1,tempz1,newtempx1,newtempy1,newtempz1,m2)
+    ! computes 2. matrix multiplication for tempx2,..
+    call mxm5_3comp_3dmat_singleB(tempx2,tempy2,tempz2,m1,hprimewgll_xx,m1,newtempx2,newtempy2,newtempz2,NGLLX)
+    ! computes 3. matrix multiplication for newtempx3,..
+    call mxm5_3comp_singleB(tempx3,tempy3,tempz3,m2,hprimewgll_xx,newtempx3,newtempy3,newtempz3,m1)
+
+    ! sums contributions
+    DO_LOOP_IJK
+      fac1 = wgllwgll_yz_3D(INDEX_IJK)
+      fac2 = wgllwgll_xz_3D(INDEX_IJK)
+      fac3 = wgllwgll_xy_3D(INDEX_IJK)
+      sum_terms(1,INDEX_IJK,ispec) = - (fac1*newtempx1(INDEX_IJK) + fac2*newtempx2(INDEX_IJK) + fac3*newtempx3(INDEX_IJK))
+      sum_terms(2,INDEX_IJK,ispec) = - (fac1*newtempy1(INDEX_IJK) + fac2*newtempy2(INDEX_IJK) + fac3*newtempy3(INDEX_IJK))
+      sum_terms(3,INDEX_IJK,ispec) = - (fac1*newtempz1(INDEX_IJK) + fac2*newtempz2(INDEX_IJK) + fac3*newtempz3(INDEX_IJK))
+    ENDDO_LOOP_IJK
+
+    ! adds gravity terms
+    if (GRAVITY_VAL) then
+#ifdef FORCE_VECTORIZATION
+      do ijk = 1,NDIM*NGLLCUBE
+        sum_terms(ijk,1,1,1,ispec) = sum_terms(ijk,1,1,1,ispec) + rho_s_H(ijk,1,1,1)
+      enddo
+#else
+      do k = 1,NGLLZ
+        do j = 1,NGLLY
+          do i = 1,NGLLX
+            sum_terms(1,i,j,k,ispec) = sum_terms(1,i,j,k,ispec) + rho_s_H(i,j,k,1)
+            sum_terms(2,i,j,k,ispec) = sum_terms(2,i,j,k,ispec) + rho_s_H(i,j,k,2)
+            sum_terms(3,i,j,k,ispec) = sum_terms(3,i,j,k,ispec) + rho_s_H(i,j,k,3)
+          enddo
+        enddo
+      enddo
+#endif
+    endif
+
+    ! updates acceleration
+#ifdef FORCE_VECTORIZATION
+    ! update will be done later at the very end..
+#else
+    ! updates for non-vectorization case
+
+! note: Critical OpenMP here might degrade performance,
+!       especially for a larger number of threads (>8).
+!       Using atomic operations can partially help.
+#ifndef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+#ifdef USE_OPENMP
+!$OMP CRITICAL
+#endif
+#endif
+! we can force vectorization using a compiler directive here because we know that there is no dependency
+! inside a given spectral element, since all the global points of a local elements are different by definition
+! (only common points between different elements can be the same)
+! IBM, Portland PGI, and Intel and Cray syntax (Intel and Cray are the same)
+!IBM* ASSERT (NODEPS)
+!pgi$ ivdep
+!DIR$ IVDEP
+    DO_LOOP_IJK
+      iglob = ibool(INDEX_IJK,ispec)
+#ifdef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+#ifdef USE_OPENMP
+!$OMP ATOMIC
+#endif
+#endif
+      accel(1,iglob) = accel(1,iglob) + sum_terms(1,INDEX_IJK,ispec)
+#ifdef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+#ifdef USE_OPENMP
+!$OMP ATOMIC
+#endif
+#endif
+      accel(2,iglob) = accel(2,iglob) + sum_terms(2,INDEX_IJK,ispec)
+#ifdef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+#ifdef USE_OPENMP
+!$OMP ATOMIC
+#endif
+#endif
+      accel(3,iglob) = accel(3,iglob) + sum_terms(3,INDEX_IJK,ispec)
+    ENDDO_LOOP_IJK
+#ifndef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+#ifdef USE_OPENMP
+!$OMP END CRITICAL
+#endif
+#endif
+#endif
+
+  enddo ! ispec
+#ifdef USE_OPENMP
+!$OMP enddo
+#endif
+
+  ! updates acceleration
+#ifdef FORCE_VECTORIZATION
+  ! updates for vectorized case
+  ! loops over all global nodes in this phase (inner/outer)
+#ifdef USE_OPENMP
+!$OMP DO
+#endif
+  do iglob_p = 1,num_globs(iphase)
+    ! global node index
+    iglob = phase_iglob(iglob_p,iphase)
+    ! loops over valence points
+    do ip = ibool_inv_st(iglob_p,iphase),ibool_inv_st(iglob_p+1,iphase)-1
+      ! local 1D index from array ibool
+      ijk_spec = ibool_inv_tbl(ip,iphase)
+
+      ! do NOT use array syntax ":" for the three statements below otherwise most compilers
+      ! will not be able to vectorize the outer loop
+      accel(1,iglob) = accel(1,iglob) + sum_terms(1,ijk_spec,1,1,1)
+      accel(2,iglob) = accel(2,iglob) + sum_terms(2,ijk_spec,1,1,1)
+      accel(3,iglob) = accel(3,iglob) + sum_terms(3,ijk_spec,1,1,1)
+    enddo
+  enddo
+#ifdef USE_OPENMP
+!$OMP enddo
+#endif
+#endif
+
+#ifdef USE_OPENMP
+!$OMP END PARALLEL
+#endif
+
+  contains
+
+!--------------------------------------------------------------------------------------------
+!
+! matrix-matrix multiplications
+!
+! subroutines adapted from Deville, Fischer and Mund, High-order methods
+! for incompressible fluid flow, Cambridge University Press (2002),
+! pages 386 and 389 and Figure 8.3.1
+!
+!--------------------------------------------------------------------------------------------
+!
+! note: the matrix-matrix multiplications are used for very small matrices ( 5 x 5 x 5 elements);
+!       thus, calling external optimized libraries for these multiplications are in general slower
+!
+! please leave the routines here to help compilers inlining the code
+
+  subroutine mxm5_3comp_singleA(A,n1,B1,B2,B3,C1,C2,C3,n3)
+
+! 3 different arrays for x/y/z-components, 2-dimensional arrays (25,5)/(5,25), same B matrix for all 3 component arrays
+
+#ifdef XSMM
+  use my_libxsmm,only: libxsmm_smm_5_25_5
+#endif
+
+  implicit none
+
+  integer,intent(in) :: n1,n3
+  real(kind=CUSTOM_REAL),dimension(n1,5),intent(in) :: A
+  real(kind=CUSTOM_REAL),dimension(5,n3),intent(in) :: B1,B2,B3
+  real(kind=CUSTOM_REAL),dimension(n1,n3),intent(out) :: C1,C2,C3
+
+  ! local parameters
+  integer :: i,j
+
+#ifdef XSMM
+  ! matrix-matrix multiplication C = alpha A * B + beta C
+  ! with A(n1,n2) 5x5-matrix, B(n2,n3) 5x25-matrix and C(n1,n3) 5x25-matrix
+  ! static version using MNK="5 25, 5" ALPHA=1 BETA=0
+  call libxsmm_smm_5_25_5(a=A, b=B1, c=C1, pa=A, pb=B2, pc=C2)
+  call libxsmm_smm_5_25_5(a=A, b=B2, c=C2, pa=A, pb=B3, pc=C3)
+  call libxsmm_smm_5_25_5(a=A, b=B3, c=C3, pa=A, pb=B1, pc=C1) ! with dummy prefetch
+  return
+#endif
+
+  ! matrix-matrix multiplication
+  do j = 1,n3
+!dir$ ivdep
+    do i = 1,n1
+      C1(i,j) =  A(i,1) * B1(1,j) &
+               + A(i,2) * B1(2,j) &
+               + A(i,3) * B1(3,j) &
+               + A(i,4) * B1(4,j) &
+               + A(i,5) * B1(5,j)
+
+      C2(i,j) =  A(i,1) * B2(1,j) &
+               + A(i,2) * B2(2,j) &
+               + A(i,3) * B2(3,j) &
+               + A(i,4) * B2(4,j) &
+               + A(i,5) * B2(5,j)
+
+      C3(i,j) =  A(i,1) * B3(1,j) &
+               + A(i,2) * B3(2,j) &
+               + A(i,3) * B3(3,j) &
+               + A(i,4) * B3(4,j) &
+               + A(i,5) * B3(5,j)
+    enddo
+  enddo
+
+  end subroutine mxm5_3comp_singleA
+
+
+!--------------------------------------------------------------------------------------------
+
+  subroutine mxm5_3comp_singleB(A1,A2,A3,n1,B,C1,C2,C3,n3)
+
+! 3 different arrays for x/y/z-components, 2-dimensional arrays (25,5)/(5,25), same B matrix for all 3 component arrays
+
+#ifdef XSMM
+  use my_libxsmm,only: libxsmm_smm_25_5_5
+#endif
+
+  implicit none
+
+  integer,intent(in) :: n1,n3
+  real(kind=CUSTOM_REAL),dimension(n1,5),intent(in) :: A1,A2,A3
+  real(kind=CUSTOM_REAL),dimension(5,n3),intent(in) :: B
+  real(kind=CUSTOM_REAL),dimension(n1,n3),intent(out) :: C1,C2,C3
+
+  ! local parameters
+  integer :: i,j
+
+#ifdef XSMM
+  ! matrix-matrix multiplication C = alpha A * B + beta C
+  ! with A(n1,n2) 25x5-matrix, B(n2,n3) 5x5-matrix and C(n1,n3) 25x5-matrix
+  ! static version
+  call libxsmm_smm_25_5_5(a=A1, b=B, c=C1, pa=A2, pb=B, pc=C2)
+  call libxsmm_smm_25_5_5(a=A2, b=B, c=C2, pa=A3, pb=B, pc=C3)
+  call libxsmm_smm_25_5_5(a=A3, b=B, c=C3, pa=A1, pb=B, pc=C1)
+  return
+#endif
+
+  ! matrix-matrix multiplication
+  do j = 1,n3
+!dir$ ivdep
+    do i = 1,n1
+      C1(i,j) =  A1(i,1) * B(1,j) &
+               + A1(i,2) * B(2,j) &
+               + A1(i,3) * B(3,j) &
+               + A1(i,4) * B(4,j) &
+               + A1(i,5) * B(5,j)
+
+      C2(i,j) =  A2(i,1) * B(1,j) &
+               + A2(i,2) * B(2,j) &
+               + A2(i,3) * B(3,j) &
+               + A2(i,4) * B(4,j) &
+               + A2(i,5) * B(5,j)
+
+      C3(i,j) =  A3(i,1) * B(1,j) &
+               + A3(i,2) * B(2,j) &
+               + A3(i,3) * B(3,j) &
+               + A3(i,4) * B(4,j) &
+               + A3(i,5) * B(5,j)
+    enddo
+  enddo
+
+  end subroutine mxm5_3comp_singleB
+
+
+!--------------------------------------------------------------------------------------------
+
+  subroutine mxm5_3comp_3dmat_singleB(A1,A2,A3,n1,B,n2,C1,C2,C3,n3)
+
+! 3 different arrays for x/y/z-components, 3-dimensional arrays (5,5,5), same B matrix for all 3 component arrays
+
+! note: on CPUs like Haswell or Sandy Bridge, the following will slow down computations
+!       however, on Intel Phi (KNC) it is still helpful (speedup +3%)
+#if defined(XSMM_FORCE_EVEN_IF_SLOWER) || ( defined(XSMM) && defined(__MIC__) )
+  use my_libxsmm,only: libxsmm_smm_5_5_5
+#endif
+
+  implicit none
+
+  integer,intent(in) :: n1,n2,n3
+  real(kind=CUSTOM_REAL),dimension(n1,5,n3),intent(in) :: A1,A2,A3
+  real(kind=CUSTOM_REAL),dimension(5,n2),intent(in) :: B
+  real(kind=CUSTOM_REAL),dimension(n1,n2,n3),intent(out) :: C1,C2,C3
+
+  ! local parameters
+  integer :: i,j,k
+
+#if defined(XSMM_FORCE_EVEN_IF_SLOWER) || ( defined(XSMM) && defined(__MIC__) )
+  ! matrix-matrix multiplication C = alpha A * B + beta C
+  ! with A(n1,n2,n4) 5x5x5-matrix, B(n2,n3) 5x5-matrix and C(n1,n3,n4) 5x5x5-matrix
+  ! static version
+  !do k = 1,5
+  !  call libxsmm_call(xmm3, A1(:,:,k), B, C1(:,:,k))
+  !  call libxsmm_call(xmm3, A2(:,:,k), B, C2(:,:,k))
+  !  call libxsmm_call(xmm3, A3(:,:,k), B, C3(:,:,k))
+  !enddo
+
+  ! unrolled
+  call libxsmm_smm_5_5_5(a=A1(1,1,1), b=B, c=C1(1,1,1),pa=A1(1,1,1+1), pb=B, pc=C1(1,1,1+1))
+  call libxsmm_smm_5_5_5(a=A1(1,1,2), b=B, c=C1(1,1,2),pa=A1(1,1,2+1), pb=B, pc=C1(1,1,2+1))
+  call libxsmm_smm_5_5_5(a=A1(1,1,3), b=B, c=C1(1,1,3),pa=A1(1,1,3+1), pb=B, pc=C1(1,1,3+1))
+  call libxsmm_smm_5_5_5(a=A1(1,1,4), b=B, c=C1(1,1,4),pa=A1(1,1,4+1), pb=B, pc=C1(1,1,4+1))
+  call libxsmm_smm_5_5_5(a=A1(1,1,5), b=B, c=C1(1,1,5),pa=A2(1,1,1), pb=B, pc=C2(1,1,1))
+
+  call libxsmm_smm_5_5_5(a=A2(1,1,1), b=B, c=C2(1,1,1),pa=A2(1,1,1+1), pb=B, pc=C2(1,1,1+1))
+  call libxsmm_smm_5_5_5(a=A2(1,1,2), b=B, c=C2(1,1,2),pa=A2(1,1,2+1), pb=B, pc=C2(1,1,2+1))
+  call libxsmm_smm_5_5_5(a=A2(1,1,3), b=B, c=C2(1,1,3),pa=A2(1,1,3+1), pb=B, pc=C2(1,1,3+1))
+  call libxsmm_smm_5_5_5(a=A2(1,1,4), b=B, c=C2(1,1,4),pa=A2(1,1,4+1), pb=B, pc=C2(1,1,4+1))
+  call libxsmm_smm_5_5_5(a=A2(1,1,5), b=B, c=C2(1,1,5),pa=A3(1,1,1), pb=B, pc=C3(1,1,1))
+
+  call libxsmm_smm_5_5_5(a=A3(1,1,1), b=B, c=C3(1,1,1),pa=A3(1,1,1+1), pb=B, pc=C3(1,1,1+1))
+  call libxsmm_smm_5_5_5(a=A3(1,1,2), b=B, c=C3(1,1,2),pa=A3(1,1,2+1), pb=B, pc=C3(1,1,2+1))
+  call libxsmm_smm_5_5_5(a=A3(1,1,3), b=B, c=C3(1,1,3),pa=A3(1,1,3+1), pb=B, pc=C3(1,1,3+1))
+  call libxsmm_smm_5_5_5(a=A3(1,1,4), b=B, c=C3(1,1,4),pa=A3(1,1,4+1), pb=B, pc=C3(1,1,4+1))
+  call libxsmm_smm_5_5_5(a=A3(1,1,5), b=B, c=C3(1,1,5),pa=A3(1,1,5), pb=B, pc=C3(1,1,5))
+  return
+#endif
+
+  ! matrix-matrix multiplication
+  do k = 1,n3
+    do j = 1,n2
+!dir$ ivdep
+      do i = 1,n1
+        C1(i,j,k) =  A1(i,1,k) * B(1,j) &
+                   + A1(i,2,k) * B(2,j) &
+                   + A1(i,3,k) * B(3,j) &
+                   + A1(i,4,k) * B(4,j) &
+                   + A1(i,5,k) * B(5,j)
+
+        C2(i,j,k) =  A2(i,1,k) * B(1,j) &
+                   + A2(i,2,k) * B(2,j) &
+                   + A2(i,3,k) * B(3,j) &
+                   + A2(i,4,k) * B(4,j) &
+                   + A2(i,5,k) * B(5,j)
+
+        C3(i,j,k) =  A3(i,1,k) * B(1,j) &
+                   + A3(i,2,k) * B(2,j) &
+                   + A3(i,3,k) * B(3,j) &
+                   + A3(i,4,k) * B(4,j) &
+                   + A3(i,5,k) * B(5,j)
+      enddo
+    enddo
+  enddo
+
+  end subroutine mxm5_3comp_3dmat_singleB
+
+  end subroutine compute_forces_with_xsmm_static
+

--- a/samples/specfem/config.fh
+++ b/samples/specfem/config.fh
@@ -1,0 +1,31 @@
+!-------------------------------------------------------------------
+!
+! macros
+!
+!-------------------------------------------------------------------
+
+! LIBXSMM for this test
+#define XSMM
+
+! macros for vectorization
+
+! switches indexing between: array( i,j,k .. ) <-> array( ijk,1,1 .. )
+#ifdef FORCE_VECTORIZATION
+#  define INDEX_IJK  ijk,1,1
+#else
+#  define INDEX_IJK  i,j,k
+#endif
+
+! switches do-loops between: do k=1,NGLLZ; do j=1,NGLLY; do i=1,NGLLX  <-> do ijk=1,NGLLCUBE
+#ifdef FORCE_VECTORIZATION
+#  define DO_LOOP_IJK  do ijk=1,NGLLCUBE
+#else
+#  define DO_LOOP_IJK  do k=1,NGLLZ; do j=1,NGLLY; do i=1,NGLLX
+#endif
+
+! switches enddo-loops between: enddo; enddo; enddo ! NGLLZ,NGLLY,NGLLX <-> enddo ! NGLLCUBE
+#ifdef FORCE_VECTORIZATION
+#  define ENDDO_LOOP_IJK  enddo ! NGLLCUBE
+#else
+#  define ENDDO_LOOP_IJK  enddo; enddo; enddo ! NGLLZ,NGLLY,NGLLX
+#endif

--- a/samples/specfem/specfem.F90
+++ b/samples/specfem/specfem.F90
@@ -1,0 +1,1131 @@
+!
+! test program for LIBXSMM function calls
+!
+! uses SPECFEM3D_GLOBE routine compute_forces_crust_mantle_Dev() with dummy example
+!
+
+! we switch between vectorized and non-vectorized version by using pre-processor flag FORCE_VECTORIZATION
+! and macros INDEX_IJK, DO_LOOP_IJK, ENDDO_LOOP_IJK defined in config.fh
+#include "config.fh"
+
+!-------------------------------------------------------------------
+!
+! modules
+!
+!-------------------------------------------------------------------
+
+module my_libxsmm
+
+  ! for C_LOC(A)
+  ! note: using C_LOC(A) however needs array A to be defined with "..,target :: A" attribute to become an interoperable pointer.
+  !       we haven't had issues yet though with array pointers when passing to C-functions, thus we omit it for now.
+  !use,intrinsic :: ISO_C_BINDING
+
+  use libxsmm !,only: C_LOC,LIBXSMM_SMMFUNCTION,libxsmm_dispatch,libxsmm_call,libxsmm_init,libxsmm_finalize
+
+  implicit none
+
+  ! function pointers
+  ! (note: defined for single precision, thus needs CUSTOM_REAL to be SIZE_REAL)
+  type(LIBXSMM_SMMFUNCTION) :: xmm1, xmm2, xmm3
+
+  ! prefetch versions
+  type(LIBXSMM_SMMFUNCTION) :: xmm1p, xmm2p, xmm3p
+
+  logical :: USE_XSMM_FUNCTION,USE_XSMM_FUNCTION_PREFETCH
+
+end module my_libxsmm
+
+!
+!-------------------------------------------------------------------
+!
+
+module constants
+
+  implicit none
+
+  integer, parameter :: SIZE_REAL = 4, SIZE_DOUBLE = 8
+  integer, parameter :: CUSTOM_REAL = SIZE_REAL
+
+  integer, parameter :: ISTANDARD_OUTPUT = 6
+  integer, parameter :: IMAIN = ISTANDARD_OUTPUT
+
+  ! number of GLL points in each direction of an element (degree plus one)
+  integer, parameter :: NGLLX = 5
+  integer, parameter :: NGLLY = NGLLX
+  integer, parameter :: NGLLZ = NGLLX
+  integer, parameter :: NGLLCUBE = NGLLX * NGLLY * NGLLZ
+
+  ! Deville routines optimized for NGLLX = NGLLY = NGLLZ = 5
+  integer, parameter :: m1 = NGLLX, m2 = NGLLX * NGLLY
+
+  ! 3-D simulation
+  integer, parameter :: NDIM = 3
+
+  ! some useful constants
+  double precision, parameter :: PI = 3.141592653589793d0
+
+  integer, parameter :: IFLAG_IN_FICTITIOUS_CUBE = 11
+
+end module constants
+
+!
+!-------------------------------------------------------------------
+!
+
+module specfem_par
+
+! main parameter module for specfem simulations
+
+  use constants
+  use libxsmm,only: LIBXSMM_ALIGNMENT
+
+  implicit none
+
+  !------------------------------------------------
+
+  ! number of spectral elements in x/y/z-directions
+  integer,parameter :: NEX = 40
+  integer,parameter :: NEY = 40
+  integer,parameter :: NEZ = 25
+
+  !------------------------------------------------
+
+  ! MPI rank (dummy, no MPI for this test needed)
+  integer :: myrank
+
+  ! array with derivatives of Lagrange polynomials and precalculated products
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLX) :: hprime_xx,hprimewgll_xx
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLX) :: hprime_xxT,hprimewgll_xxT
+
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY) :: wgllwgll_xy
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLZ) :: wgllwgll_xz
+  real(kind=CUSTOM_REAL), dimension(NGLLY,NGLLZ) :: wgllwgll_yz
+
+  ! arrays for Deville and force_vectorization
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ) :: wgllwgll_xy_3D,wgllwgll_xz_3D,wgllwgll_yz_3D
+
+  ! mesh parameters
+  ! number of spectral elements
+  integer :: NSPEC
+
+  ! number of global nodes
+  integer :: NGLOB
+
+  ! local to global indexing
+  integer, dimension(:,:,:,:),allocatable :: ibool
+
+  ! displacement, velocity, acceleration
+  real(kind=CUSTOM_REAL), dimension(:,:),allocatable :: displ,accel
+
+  ! for verification
+  real(kind=CUSTOM_REAL), dimension(:,:),allocatable :: accel_default
+
+  !slow-down: please don't use unless you're sure... !dir$ ATTRIBUTES align:LIBXSMM_ALIGNMENT :: displ,accel,ibool,accel_default
+
+  ! gravity
+  logical,parameter :: GRAVITY_VAL = .true.
+
+  ! optimized arrays
+  integer, dimension(:,:),allocatable :: ibool_inv_tbl
+  integer, dimension(:,:),allocatable :: ibool_inv_st
+  integer, dimension(:,:),allocatable :: phase_iglob
+  integer, dimension(2) :: num_globs
+
+  ! work array with contributions
+  real(kind=CUSTOM_REAL), dimension(:,:,:,:,:),allocatable :: sum_terms
+
+  ! inner / outer elements crust/mantle region
+  integer :: num_phase_ispec
+  integer :: nspec_inner,nspec_outer
+  integer, dimension(:,:), allocatable :: phase_ispec_inner
+  integer :: iphase
+
+end module specfem_par
+
+
+
+!-------------------------------------------------------------------
+!
+! main program
+!
+!-------------------------------------------------------------------
+
+program test
+
+  use specfem_par
+  use my_libxsmm
+
+  implicit none
+
+  ! timing
+  double precision :: duration,duration_default
+  integer(kind=8) :: start
+
+  ! verification
+  real :: diff
+  integer, dimension(2) :: iloc_max
+  logical, parameter :: DEBUG_VERIFICATION = .false.
+
+  ! repetitions (time steps)
+  integer :: it
+  integer,parameter :: NSTEP = 20 ! should be > NSTEP_JITTER because of average timing
+  integer,parameter :: NSTEP_JITTER = 5 ! skip first few steps when timing the kernels (the first steps exhibit runtime jitter)
+
+  ! different versions
+  integer,parameter :: num_versions = 5
+  character(len=20) :: str_version(num_versions) = (/character(len=20) :: &
+                                                     "Deville loops", &
+                                                     "unrolled loops", &
+                                                     "LIBXSMM dispatch" , &
+                                                     "LIBXSMM prefetch", &
+                                                     "LIBXSMM static" &
+                                                    /)
+  double precision :: avg_time(num_versions)
+  integer :: iversion
+
+  print *,'--------------------------------------'
+  print *,'specfem example'
+  print *,'--------------------------------------'
+  print *
+
+  ! creates test mesh
+  call setup_mesh()
+
+  ! prepares arrays for time iteration loop
+  call prepare_timerun()
+
+  ! OpenMP output info
+  call prepare_openmp()
+
+  ! prepares libxsmm functions
+  call prepare_xsmm()
+
+  ! timing averages
+  avg_time(:) = 0.d0
+  iphase = 2
+
+  do it = 1,NSTEP
+
+    print *
+    print *,'step ',it
+
+    do iversion = 1,num_versions
+      ! initializes
+      accel(:,:) = 0._CUSTOM_REAL
+
+      ! timing
+      start = libxsmm_timer_tick()
+
+      ! computes forces
+      select case (iversion)
+      case (1)
+        ! Deville loops
+        call compute_forces_Dev()
+
+      case (2)
+        ! unrolled loops
+        call compute_forces_noDev()
+
+      case (3)
+        ! LIBXSMM with dispatch functions
+        if (USE_XSMM_FUNCTION) then
+          call compute_forces_with_xsmm()
+        else
+          cycle
+        endif
+
+      case (4)
+        ! LIBXSMM with prefetch function calls
+        if (USE_XSMM_FUNCTION_PREFETCH) then
+          call compute_forces_with_xsmm_prefetch()
+        else
+          cycle
+        endif
+
+      case (5)
+        ! LIBXSMM with static function calls
+        call compute_forces_with_xsmm_static()
+
+      end select
+
+      ! timing
+      duration = libxsmm_timer_duration(start, libxsmm_timer_tick())
+      if (iversion == 1) duration_default = duration
+
+      ! average time
+      if (it > NSTEP_JITTER) avg_time(iversion) = avg_time(iversion) + duration
+
+      ! for verification
+      if (iversion == 1) then
+        accel_default(:,:) = accel(:,:)
+      endif
+      diff = maxval(abs(accel(:,:) - accel_default(:,:)))
+
+      ! user output
+      if (iversion == 1) then
+        write(*,'(a30,a,f8.4,a)') 'duration with '//str_version(iversion),' = ',sngl(duration),' (s)'
+      else
+        write(*,'(a30,a,f8.4,a,f8.2,a,e12.4)') 'duration with '//str_version(iversion),' = ', &
+                                    sngl(duration),' (s) / speedup = ', &
+                                    sngl(100.0 * (duration_default-duration)/duration_default),' %  / maximum diff = ',diff
+      endif
+
+      ! check
+      if (DEBUG_VERIFICATION) then
+        iloc_max = maxloc(abs(accel(:,:) - accel_default(:,:)))
+        print *,'verification: max diff  = ',diff
+        print *,'              iglob loc = ',iloc_max(1),iloc_max(2)
+        print *,'maximum difference: #current vs. #default value'
+        print *,'  ',accel(1,iloc_max(2)),accel_default(1,iloc_max(2))
+        print *,'  ',accel(2,iloc_max(2)),accel_default(2,iloc_max(2))
+        print *,'  ',accel(3,iloc_max(2)),accel_default(3,iloc_max(2))
+        print *,'min/max accel values = ',minval(accel(:,:)),maxval(accel(:,:))
+        print *
+      endif
+
+    enddo ! iversion
+  enddo ! it
+
+  ! average timing (avoiding the first 5 steps which fluctuate quite a bit...)
+  avg_time(:) = avg_time(:) / dble(NSTEP - NSTEP_JITTER)
+
+  print *
+  print *,'=============================================='
+  print *,'average over ',NSTEP - NSTEP_JITTER,'repetitions'
+  write(*,'(a30,a,f8.4)') '  timing with '//str_version(1),' = ',avg_time(1)
+  do iversion = 2,num_versions
+    ! skip unused tests
+    if (iversion == 3 .and. .not. USE_XSMM_FUNCTION) cycle
+    if (iversion == 4 .and. .not. USE_XSMM_FUNCTION_PREFETCH) cycle
+
+    write(*,'(a30,a,f8.4,a,f8.2,a)') '  timing with '//str_version(iversion),' = ', &
+                                     avg_time(iversion),' / speedup = ', &
+                                     sngl(100.0 * (avg_time(1)-avg_time(iversion))/avg_time(1)),' %'
+  enddo
+  print *,'=============================================='
+  print *
+
+  ! frees memory
+  deallocate(displ,accel)
+  deallocate(accel_default,ibool)
+  deallocate(sum_terms)
+  deallocate(ibool_inv_st,ibool_inv_tbl,phase_iglob)
+  deallocate(phase_ispec_inner)
+
+  ! finalizes LIBXSMM
+  call libxsmm_finalize()
+
+end program test
+
+!
+!-------------------------------------------------------------------
+!
+
+  subroutine setup_mesh()
+
+  use constants
+  use specfem_par
+
+  implicit none
+
+  integer :: i1,i2
+  integer :: ix,iy,iz
+  integer :: i,j,k
+  integer :: iglob,ispec,inumber
+
+  integer, dimension(:), allocatable :: mask_ibool
+  integer, dimension(:,:,:,:), allocatable :: copy_ibool_ori
+
+  logical, dimension(:), allocatable :: mask_ibool_flag
+
+  ! total number of elements
+  NSPEC = NEX * NEY * NEZ
+
+  ! set up local to global numbering
+  allocate(ibool(NGLLX,NGLLY,NGLLZ,NSPEC))
+  ibool(:,:,:,:) = 0
+  ispec = 0
+  iglob = 0
+
+  ! arranges a three-dimensional block, elements are collated side-by-side. mimicks a very simple unstructured grid.
+  do iz = 1,NEZ
+    do iy = 1,NEY
+      do ix = 1,NEX
+        ispec = ispec + 1
+        ! GLL point indexing
+        do k = 1,NGLLZ
+          do j = 1,NGLLY
+            do i = 1,NGLLX
+              ! set up local to global numbering
+              if ((i == 1) .and. (ix > 1)) then
+                ! previous element along x-direction
+                ibool(i,j,k,ispec) = ibool(NGLLX,j,k,ispec - 1)
+              else if ((j == 1) .and. (iy > 1)) then
+                ! previous element along y-direction
+                ibool(i,j,k,ispec) = ibool(i,NGLLY,k,ispec - NEX)
+              else if ((k == 1) .and. (iz > 1)) then
+                ! previous element along z-direction
+                ibool(i,j,k,ispec) = ibool(i,j,NGLLZ,ispec - NEX * NEY)
+              else
+                ! new point
+                iglob = iglob + 1
+                ibool(i,j,k,ispec) = iglob
+              endif
+            enddo
+          enddo
+        enddo
+
+      enddo ! NEX
+    enddo ! NEY
+  enddo ! NEZ
+
+  ! sets total numbers of nodes
+  NGLOB = iglob
+
+  print *,'mesh:'
+  print *,' total number of elements      = ',NSPEC
+  print *,' total number of global nodes  = ',NGLOB
+  !print *,' ibool min/max = ',minval(ibool),maxval(ibool)
+
+  ! checks
+  if (ispec /= NSPEC) stop 'Invalid ispec count'
+  if (minval(ibool(:,:,:,:)) < 1) stop 'Invalid ibool minimum value'
+  if (maxval(ibool(:,:,:,:)) > NSPEC * NGLLX * NGLLY * NGLLZ) stop 'Invalid ibool maximum value'
+
+  ! we can create a new indirect addressing to reduce cache misses
+  allocate(copy_ibool_ori(NGLLX,NGLLY,NGLLZ,NSPEC),mask_ibool(nglob))
+  mask_ibool(:) = -1
+  copy_ibool_ori(:,:,:,:) = ibool(:,:,:,:)
+  inumber = 0
+  do ispec = 1,NSPEC
+    do k = 1,NGLLZ
+      do j = 1,NGLLY
+        do i = 1,NGLLX
+          if (mask_ibool(copy_ibool_ori(i,j,k,ispec)) == -1) then
+            ! creates a new point
+            inumber = inumber + 1
+            ibool(i,j,k,ispec) = inumber
+            mask_ibool(copy_ibool_ori(i,j,k,ispec)) = inumber
+          else
+            ! uses an existing point created previously
+            ibool(i,j,k,ispec) = mask_ibool(copy_ibool_ori(i,j,k,ispec))
+          endif
+        enddo
+      enddo
+    enddo
+  enddo
+  if (inumber /= NGLOB) stop 'Invalid inumber count'
+  deallocate(copy_ibool_ori,mask_ibool)
+
+  ! define polynomial derivatives & weights
+  ! (dummy values)
+  do i1 = 1,NGLLX
+    do i2 = 1,NGLLX
+      hprime_xx(i2,i1) = i1 * 0.1 + i2 * 0.2  ! original: real(lagrange_deriv_GLL(i1-1,i2-1,xigll,NGLLX), kind=CUSTOM_REAL)
+      hprimewgll_xx(i2,i1) = hprime_xx(i2,i1) * (i2 * 1.0/NGLLX) ! real(lagrange_deriv_GLL(i1-1,i2-1,xigll,NGLLX)*wxgll(i2), kind=CUSTOM_REAL)
+    enddo
+  enddo
+  do i = 1,NGLLX
+    do j = 1,NGLLY
+      wgllwgll_xy(i,j) = (i * 1.0/NGLLX) * (j * 1.0/NGLLY) ! original: real(wxgll(i)*wygll(j), kind=CUSTOM_REAL)
+    enddo
+  enddo
+  do i = 1,NGLLX
+    do k = 1,NGLLZ
+      wgllwgll_xz(i,k) = (i * 1.0/NGLLX) * (k * 1.0/NGLLZ) ! original: real(wxgll(i)*wzgll(k), kind=CUSTOM_REAL)
+    enddo
+  enddo
+  do j = 1,NGLLY
+    do k = 1,NGLLZ
+      wgllwgll_yz(j,k) = (j * 1.0/NGLLY) * (k * 1.0/NGLLZ) ! original: real(wygll(j)*wzgll(k), kind=CUSTOM_REAL)
+    enddo
+  enddo
+
+  ! define a 3D extension in order to be able to force vectorization in the compute_forces_**_Dev routines
+  do k = 1,NGLLZ
+    do j = 1,NGLLY
+      do i = 1,NGLLX
+        wgllwgll_yz_3D(i,j,k) = wgllwgll_yz(j,k)
+        wgllwgll_xz_3D(i,j,k) = wgllwgll_xz(i,k)
+        wgllwgll_xy_3D(i,j,k) = wgllwgll_xy(i,j)
+      enddo
+    enddo
+  enddo
+
+  ! check that optimized routines from Deville et al. (2002) can be used
+  if (NGLLX /= 5 .or. NGLLY /= 5 .or. NGLLZ /= 5) &
+    stop 'Deville et al. (2002) routines can only be used if NGLLX = NGLLY = NGLLZ = 5'
+
+  ! define transpose of derivation matrix
+  do j = 1,NGLLX
+    do i = 1,NGLLX
+      hprime_xxT(j,i) = hprime_xx(i,j)
+      hprimewgll_xxT(j,i) = hprimewgll_xx(i,j)
+    enddo
+  enddo
+
+  ! displacement and acceleration (dummy fields)
+  allocate(displ(NDIM,NGLOB),accel(NDIM,NGLOB))
+  accel(:,:) = 0._CUSTOM_REAL
+
+  ! sets initial dummy values (to avoid getting only zero multiplications later on)
+  if (.true.) then
+    ! arbitrary linear function
+    do iglob = 1,NGLOB
+      displ(:,iglob) = dble(iglob - 1) / dble(NGLOB - 1)
+    enddo
+  else
+    ! arbitrary sine function
+    allocate(mask_ibool_flag(NGLOB))
+    mask_ibool_flag(:) = .false.
+    ispec = 0
+    do iz = 1,NEZ
+      do iy = 1,NEY
+        do ix = 1,NEX
+          ispec = ispec + 1
+          ! GLL point indexing
+          do k = 1,NGLLZ
+            do j = 1,NGLLY
+              do i = 1,NGLLX
+                iglob = ibool(i,j,k,ispec)
+                if (.not. mask_ibool_flag(iglob)) then
+                  ! only assigns global value once
+                  mask_ibool_flag(iglob) = .true.
+                  displ(:,iglob) = sin(PI * dble(ix - 1) / dble(NEX - 1)) &
+                                 * sin(PI * dble(iy - 1) / dble(NEY - 1)) &
+                                 * sin(PI * dble(iz - 1) / dble(NEZ - 1))
+                endif
+              enddo
+            enddo
+          enddo
+        enddo
+      enddo
+    enddo
+    deallocate(mask_ibool_flag)
+  endif
+
+  ! for verification
+  allocate(accel_default(NDIM,NGLOB))
+  accel_default(:,:) = 0._CUSTOM_REAL
+
+  end subroutine setup_mesh
+
+!
+!-------------------------------------------------------------------
+!
+
+  subroutine prepare_timerun()
+
+  use specfem_par
+
+  implicit none
+
+  ! local parameters
+  integer :: num_elements,ispec,ier
+
+  ! setup inner/outer elements (single slice only, no outer elements for halo)
+  myrank = 0
+  ! no MPI over-lapping communication in this example
+  nspec_inner = NSPEC
+  nspec_outer = 0
+  num_phase_ispec = NSPEC
+  allocate(phase_ispec_inner(num_phase_ispec,2),stat=ier)
+  if (ier /= 0 ) call exit_mpi(myrank,'Error allocating array phase_ispec_inner_crust_mantle')
+  phase_ispec_inner(:,:) = 0
+  do ispec = 1,NSPEC
+    phase_ispec_inner(ispec,2) = ispec
+  enddo
+
+  ! from original routine prepare_timerun_ibool_inv_tbl()
+
+  ! note: we use allocate for sum_terms arrays rather than defining within subroutine compute_forces_**_Dev() itself
+  !       as it will crash when using OpenMP and operating systems with small stack sizes
+  !       e.g. see http://stackoverflow.com/questions/22649827/illegal-instruction-error-when-running-openmp-in-gfortran-mac
+  allocate(sum_terms(NDIM,NGLLX,NGLLY,NGLLZ,NSPEC),stat=ier)
+  if (ier /= 0) stop 'Error allocating sum_terms arrays'
+  sum_terms(:,:,:,:,:) = 0._CUSTOM_REAL
+
+  ! inverse table
+  ! this helps to speedup the assembly, especially with OpenMP (or on MIC) threading
+  ! allocating arrays
+  allocate(ibool_inv_tbl(NGLLX*NGLLY*NGLLZ*NSPEC,2),stat=ier)
+  if (ier /= 0) stop 'Error allocating ibool_inv_tbl arrays'
+
+  allocate(ibool_inv_st(NGLOB+1,2),stat=ier)
+  if (ier /= 0) stop 'Error allocating ibool_inv_st arrays'
+
+  allocate(phase_iglob(NGLOB,2),stat=ier)
+  if (ier /= 0) stop 'Error allocating phase_iglob arrays'
+
+  ! initializing
+  num_globs(:) = 0
+  ibool_inv_tbl(:,:) = 0
+  ibool_inv_st(:,:) = 0
+  phase_iglob(:,:) = 0
+
+  !---- make inv. table ----------------------
+  ! loops over phases
+  ! (1 == outer elements / 2 == inner elements)
+  do iphase = 1,2
+    ! crust mantle
+    if (iphase == 1) then
+      ! outer elements (iphase=1)
+      num_elements = nspec_outer
+    else
+      ! inner elements (iphase=2)
+      num_elements = nspec_inner
+    endif
+    call make_inv_table(iphase,NGLOB,NSPEC, &
+                        num_elements,phase_ispec_inner, &
+                        ibool,phase_iglob, &
+                        ibool_inv_tbl, ibool_inv_st, &
+                        num_globs)
+  enddo
+
+  ! user output
+  if (myrank == 0) then
+    write(IMAIN,*) " inverse table of ibool done"
+    call flush_IMAIN()
+  endif
+
+  ! synchronizes processes
+  call synchronize_all()
+
+  contains
+
+    subroutine make_inv_table(iphase,nglob,nspec, &
+                              phase_nspec,phase_ispec,ibool,phase_iglob, &
+                              ibool_inv_tbl,ibool_inv_st,num_globs,idoubling)
+
+    implicit none
+
+    ! arguments
+    integer,intent(in) :: iphase
+    integer,intent(in) :: nglob
+    integer,intent(in) :: nspec
+    integer,intent(in) :: phase_nspec
+    integer, dimension(:,:),intent(in) :: phase_ispec
+    integer, dimension(:,:,:,:),intent(in) :: ibool
+
+    integer, dimension(:,:),intent(inout) :: phase_iglob
+    integer, dimension(:,:),intent(inout) :: ibool_inv_tbl
+    integer, dimension(:,:),intent(inout) :: ibool_inv_st
+    integer, dimension(:),intent(inout) :: num_globs
+
+    integer,dimension(:),optional :: idoubling
+
+    ! local parameters
+    integer, dimension(:),   allocatable :: ibool_inv_num
+    integer, dimension(:,:), allocatable :: ibool_inv_tbl_tmp
+    integer :: num_alloc_ibool_inv_tbl,num_alloc_ibool_inv_tbl_theor
+    integer :: num_used_ibool_inv_tbl
+    integer :: ip, iglob, ispec_p, ispec, iglob_p, ier
+    integer :: inum
+#ifdef FORCE_VECTORIZATION
+    integer :: ijk
+#else
+    integer :: i,j,k
+#endif
+    logical :: is_inner_core
+
+    ! tolerance number of shared degrees per node
+    integer, parameter :: N_TOL = 20
+
+    ! checks if anything to do (e.g., no outer elements for single process simulations)
+    if (phase_nspec == 0) return
+
+    ! checks if inner core region
+    if (present(idoubling)) then
+      is_inner_core = .true.
+    else
+      is_inner_core = .false.
+    endif
+
+    ! allocates temporary arrays
+    allocate(ibool_inv_num(nglob),stat=ier)
+    if (ier /= 0) stop 'Error allocating ibool_inv_num array'
+
+    ! gets valence of global degrees of freedom for current phase (inner/outer) elements
+    ibool_inv_num(:) = 0
+    do ispec_p = 1,phase_nspec
+      ispec = phase_ispec(ispec_p,iphase)
+
+      ! exclude fictitious elements in central cube
+      if (is_inner_core) then
+        if (idoubling(ispec) == IFLAG_IN_FICTITIOUS_CUBE) cycle
+      endif
+
+      DO_LOOP_IJK
+        iglob = ibool(INDEX_IJK,ispec)
+        ! increases valence counter
+        ibool_inv_num(iglob) = ibool_inv_num(iglob) + 1
+      ENDDO_LOOP_IJK
+    enddo
+
+    ! gets maximum valence value
+    num_alloc_ibool_inv_tbl = maxval(ibool_inv_num(:))
+
+    ! theoretical number of maximum shared degrees per node
+    num_alloc_ibool_inv_tbl_theor = N_TOL*(NGLLX*NGLLY*NGLLZ*nspec/nglob+1)
+
+    ! checks valence
+    if (num_alloc_ibool_inv_tbl < 1 .or. num_alloc_ibool_inv_tbl > num_alloc_ibool_inv_tbl_theor) then
+      print *,'Error invalid maximum valence:'
+      print *,'valence value = ',num_alloc_ibool_inv_tbl,' - theoretical maximum = ',num_alloc_ibool_inv_tbl_theor
+      stop 'Error invalid maximum valence value'
+    endif
+    ! debug
+    !print *,myrank,'maximum shared degrees theoretical = ',num_alloc_ibool_inv_tbl_theor ! regional_Greece_small example: 40
+    !print *,myrank,'maximum shared degrees from array  = ',maxval(ibool_inv_num(:))      ! regional_Greece_small example: 8 and 16
+
+    allocate(ibool_inv_tbl_tmp(num_alloc_ibool_inv_tbl,nglob),stat=ier)
+    if (ier /= 0) stop 'Error allocating ibool_inv_tbl_tmp array'
+
+    !---- make temporary array of inv. table : ibool_inv_tbl_tmp
+    ibool_inv_tbl_tmp(:,:) = 0
+    ibool_inv_num(:) = 0
+    do ispec_p = 1,phase_nspec
+      ispec = phase_ispec(ispec_p,iphase)
+
+      ! exclude fictitious elements in central cube
+      if (is_inner_core) then
+        if (idoubling(ispec) == IFLAG_IN_FICTITIOUS_CUBE) cycle
+      endif
+
+      DO_LOOP_IJK
+
+        iglob = ibool(INDEX_IJK,ispec)
+
+        ! increases counter
+        ibool_inv_num(iglob) = ibool_inv_num(iglob) + 1
+
+        ! inverse table
+        ! sets 1D index of local GLL point (between 1 and NGLLCUBE)
+#ifdef FORCE_VECTORIZATION
+        inum = ijk
+#else
+        inum = i + (j-1)*NGLLY + (k-1)*NGLLY*NGLLZ
+#endif
+        ! sets 1D index in local ibool array
+        ibool_inv_tbl_tmp(ibool_inv_num(iglob),iglob) = inum + NGLLX*NGLLY*NGLLZ*(ispec-1)
+
+      ENDDO_LOOP_IJK
+
+    enddo
+
+    !---- packing : ibool_inv_tbl_tmp -> ibool_inv_tbl
+    ip = 0
+    iglob_p = 0
+    num_used_ibool_inv_tbl = 0
+    do iglob = 1, nglob
+      if (ibool_inv_num(iglob) /= 0) then
+        iglob_p = iglob_p + 1
+
+        phase_iglob(iglob_p,iphase) = iglob
+
+        ! sets start index of table entry for this global node
+        ibool_inv_st(iglob_p,iphase) = ip + 1
+
+        ! sets maximum of used valence
+        if( ibool_inv_num(iglob) > num_used_ibool_inv_tbl ) num_used_ibool_inv_tbl = ibool_inv_num(iglob)
+
+        ! loops over valence
+        do inum = 1, ibool_inv_num(iglob)
+          ! increases total counter
+          ip = ip + 1
+          ! maps local 1D index in ibool array
+          ibool_inv_tbl(ip,iphase) = ibool_inv_tbl_tmp(inum,iglob)
+        enddo
+      endif
+    enddo
+    ! sets last entry in start index table
+    ibool_inv_st(iglob_p+1,iphase) = ip + 1
+
+    ! total number global nodes in this phase (inner/outer)
+    num_globs(iphase) = iglob_p
+
+    ! checks
+    if( num_used_ibool_inv_tbl > num_alloc_ibool_inv_tbl )  then
+      print *,"Error invalid inverse table setting:"
+      print *,"  num_alloc_ibool_inv_tbl = ",num_alloc_ibool_inv_tbl
+      print *,"  num_used_ibool_inv_tbl  = ",num_used_ibool_inv_tbl
+      print *,"invalid value encountered: num_used_ibool_inv_tbl > num_alloc_ibool_inv_tbl"
+      print *,"#### Program exits... ##########"
+      call exit_MPI(myrank,'Error making inverse table for optimized arrays')
+    endif
+
+    ! debug
+    !if (myrank == 0) then
+    !  print *,'ibool_inv_tbl: '
+    !  do iglob_p = 1,200
+    !    print *,'  ',iglob_p,'table = ',(ibool_inv_tbl(ip,iphase), &
+    !                                     ip = ibool_inv_st(iglob_p,iphase),ibool_inv_st(iglob_p+1,iphase)-1)
+    !  enddo
+    !endif
+
+    ! frees memory
+    deallocate(ibool_inv_num)
+    deallocate(ibool_inv_tbl_tmp)
+
+    end subroutine make_inv_table
+
+  end subroutine prepare_timerun
+
+!
+!-------------------------------------------------------------------
+!
+
+  subroutine prepare_openmp()
+
+! outputs OpenMP support info
+
+#ifdef USE_OPENMP
+  use specfem_par,only: myrank,IMAIN
+#endif
+
+  implicit none
+
+#ifdef USE_OPENMP
+  ! local parameters
+  integer :: thread_id,num_threads
+  integer :: num_procs,max_threads
+  logical :: is_dynamic,is_nested
+  ! OpenMP functions
+  integer,external :: OMP_GET_NUM_THREADS,OMP_GET_THREAD_NUM
+  integer,external :: OMP_GET_NUM_PROCS,OMP_GET_MAX_THREADS
+  logical,external :: OMP_GET_DYNAMIC,OMP_GET_NESTED
+
+  ! OpenMP only supported for Deville routine
+
+!$OMP PARALLEL DEFAULT(NONE) &
+!$OMP SHARED(myrank) &
+!$OMP PRIVATE(thread_id,num_threads,num_procs,max_threads,is_dynamic,is_nested)
+  ! gets thread number
+  thread_id = OMP_GET_THREAD_NUM()
+
+  ! gets total number of threads for this MPI process
+  num_threads = OMP_GET_NUM_THREADS()
+
+  ! OpenMP master thread only
+  if (thread_id == 0) then
+    ! gets additional environment info
+    num_procs = OMP_GET_NUM_PROCS()
+    max_threads = OMP_GET_MAX_THREADS()
+    is_dynamic = OMP_GET_DYNAMIC()
+    is_nested = OMP_GET_NESTED()
+
+    ! user output
+    if (myrank == 0) then
+      write(IMAIN,*) ''
+      write(IMAIN,*) 'OpenMP information:'
+      write(IMAIN,*) '  number of threads = ', num_threads
+      write(IMAIN,*) ''
+      write(IMAIN,*) '  number of processors available      = ', num_procs
+      write(IMAIN,*) '  maximum number of threads available = ', num_procs
+      write(IMAIN,*) '  dynamic thread adjustement          = ', is_dynamic
+      write(IMAIN,*) '  nested parallelism                  = ', is_nested
+      write(IMAIN,*) ''
+      call flush_IMAIN()
+    endif
+  endif
+!$OMP END PARALLEL
+#else
+  ! nothing to do..
+  return
+#endif
+
+  end subroutine prepare_openmp
+
+!
+!-------------------------------------------------------------------
+!
+
+  subroutine prepare_xsmm()
+
+  use constants,only: CUSTOM_REAL,SIZE_DOUBLE,m1,m2,IMAIN
+
+  use specfem_par,only: myrank
+
+  use my_libxsmm,only: libxsmm_init,libxsmm_dispatch,libxsmm_available,xmm1,xmm2,xmm3,USE_XSMM_FUNCTION
+  ! prefetch versions
+  use my_libxsmm,only: xmm1p,xmm2p,xmm3p,LIBXSMM_PREFETCH,USE_XSMM_FUNCTION_PREFETCH
+
+  implicit none
+
+  ! quick check
+  if (m1 /= 5) stop 'LibXSMM with invalid m1 constant (must have m1 == 5)'
+  if (m2 /= 5*5) stop 'LibXSMM with invalid m2 constant (must have m2 == 5*5)'
+  if (CUSTOM_REAL == SIZE_DOUBLE) stop 'LibXSMM optimization only for single precision functions'
+
+  ! initializes LIBXSMM
+  call libxsmm_init()
+
+  ! dispatch functions for matrix multiplications
+  ! (see in compute_forces_**Dev.F90 routines for actual function call)
+  ! example: a(n1,n2),b(n2,n3),c(n1,n3) -> c = a * b then libxsmm_dispatch(xmm,m=n1,n=n3,k=n2,alpha=1,beta=0)
+
+  ! with A(n1,n2) 5x5-matrix, B(n2,n3) 5x25-matrix and C(n1,n3) 5x25-matrix
+  call libxsmm_dispatch(xmm1, m=5, n=25, k=5, alpha=1.0_CUSTOM_REAL, beta=0.0_CUSTOM_REAL)
+
+  ! with A(n1,n2) 25x5-matrix, B(n2,n3) 5x5-matrix and C(n1,n3) 25x5-matrix
+  call libxsmm_dispatch(xmm2, m=25, n=5, k=5, alpha=1.0_CUSTOM_REAL, beta=0.0_CUSTOM_REAL)
+
+  ! with A(n1,n2,n4) 5x5x5-matrix, B(n2,n3) 5x5-matrix and C(n1,n3,n4) 5x5x5-matrix
+  call libxsmm_dispatch(xmm3, m=5, n=5, k=5, alpha=1.0_CUSTOM_REAL, beta=0.0_CUSTOM_REAL)
+
+  !directly: call libxsmm_smm_5_5_5(A,B,C)
+  if (libxsmm_available(xmm1) .and. libxsmm_available(xmm2) .and. libxsmm_available(xmm3)) then
+    USE_XSMM_FUNCTION = .true.
+    ! user output
+    if (myrank == 0) then
+      write(IMAIN,*)
+      write(IMAIN,*) "LIBXSMM dispatch functions ready for small matrix-matrix multiplications"
+      call flush_IMAIN()
+    endif
+  else
+    USE_XSMM_FUNCTION = .false.
+    print *,'LIBXSMM invalid dispatch function pointers:', &
+            libxsmm_available(xmm1),libxsmm_available(xmm2),libxsmm_available(xmm3)
+    ! hard stop
+    !call exit_MPI(myrank,'LIBXSMM functions not ready, please check configuration & compilation')
+  endif
+
+  ! synchronizes processes
+  call synchronize_all()
+
+  ! prefetch versions
+  call libxsmm_dispatch(xmm1p, m=5, n=25, k=5, alpha=1.0_CUSTOM_REAL, beta=0.0_CUSTOM_REAL,prefetch=LIBXSMM_PREFETCH)
+  call libxsmm_dispatch(xmm2p, m=25, n=5, k=5, alpha=1.0_CUSTOM_REAL, beta=0.0_CUSTOM_REAL,prefetch=LIBXSMM_PREFETCH)
+  call libxsmm_dispatch(xmm3p, m=5, n=5, k=5, alpha=1.0_CUSTOM_REAL, beta=0.0_CUSTOM_REAL,prefetch=LIBXSMM_PREFETCH)
+
+  if (libxsmm_available(xmm1p) .and. libxsmm_available(xmm2p) .and. libxsmm_available(xmm3p)) then
+    USE_XSMM_FUNCTION_PREFETCH = .true.
+    ! user output
+    if (myrank == 0) then
+      write(IMAIN,*) "LIBXSMM prefetch functions ready for small matrix-matrix multiplications"
+      write(IMAIN,*)
+      call flush_IMAIN()
+    endif
+  else
+    USE_XSMM_FUNCTION_PREFETCH = .false.
+    print *,'LIBXSMM invalid prefetch function pointers:', &
+            libxsmm_available(xmm1p),libxsmm_available(xmm2p),libxsmm_available(xmm3p)
+    ! hard stop
+    !call exit_MPI(myrank,'LIBXSMM prefetch functions not ready, please check configuration & compilation')
+  endif
+
+  ! force no dispatch
+  !USE_XSMM_FUNCTION = .false.
+  !USE_XSMM_FUNCTION_PREFETCH = .false.
+
+  end subroutine prepare_xsmm
+
+
+
+!-------------------------------------------------------------------
+!
+! dummy routines
+!
+!-------------------------------------------------------------------
+
+
+
+  subroutine compute_element_dummy(ispec,ibool,tempx1,tempx2,tempx3,tempy1,tempy2,tempy3,tempz1,tempz2,tempz3, &
+                                   dummyx_loc,dummyy_loc,dummyz_loc,rho_s_H)
+
+! dummy example (original: isotropic element in crust/mantle region)
+!
+! it is mostly used to avoid over-simplification of the compute_forces routine: if we omit it, then compilers can do
+! much more aggressive optimizations and the timing results would be misleading. the original routines for computing
+! stresses on elements are more expensive and complicated. the dummy here will be much faster to compute, but should
+! give similar relative performance results
+
+  use constants,only: CUSTOM_REAL,NGLLX,NGLLY,NGLLZ,NDIM
+#ifdef FORCE_VECTORIZATION
+  use constants,only: NGLLCUBE
+#endif
+  use specfem_par,only: NSPEC,GRAVITY_VAL
+  implicit none
+
+  ! element id
+  integer,intent(in) :: ispec
+
+  ! arrays with mesh parameters per slice
+  integer, dimension(NGLLX,NGLLY,NGLLZ,NSPEC),intent(in) :: ibool
+
+  ! element info
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ),intent(inout) :: &
+    tempx1,tempx2,tempx3,tempy1,tempy2,tempy3,tempz1,tempz2,tempz3
+
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ),intent(in) :: dummyx_loc,dummyy_loc,dummyz_loc
+
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ,NDIM),intent(out) :: rho_s_H
+
+  ! local parameters
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ) :: sigma_xx,sigma_yy,sigma_zz
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ) :: sigma_xy,sigma_xz,sigma_yz,sigma_yx,sigma_zx,sigma_zy
+  real(kind=CUSTOM_REAL) :: xixl,xiyl,xizl,etaxl,etayl,etazl,gammaxl,gammayl,gammazl
+  real(kind=CUSTOM_REAL) :: fac,factor
+  integer :: idummy
+
+#ifdef FORCE_VECTORIZATION
+! in this vectorized version we have to assume that N_SLS == 3 in order to be able to unroll and thus suppress
+! an inner loop that would otherwise prevent vectorization; this is safe in practice in all cases because N_SLS == 3
+! in all known applications, and in the main program we check that N_SLS == 3 if FORCE_VECTORIZATION is used and we stop
+  integer :: ijk
+#else
+  integer :: i,j,k
+#endif
+! note: profiling shows that this routine takes about 60% of the total time, another 30% is spend in the tiso routine below..
+
+  DO_LOOP_IJK
+    ! compute stress sigma
+    ! (dummy values)
+    sigma_xx(INDEX_IJK) = 0.1 * dummyx_loc(INDEX_IJK)
+    sigma_yy(INDEX_IJK) = 0.1 * dummyy_loc(INDEX_IJK)
+    sigma_zz(INDEX_IJK) = 0.1 * dummyz_loc(INDEX_IJK)
+
+    sigma_xy(INDEX_IJK) = 0.3 * sigma_xx(INDEX_IJK)
+    sigma_xz(INDEX_IJK) = 0.3 * sigma_yy(INDEX_IJK)
+    sigma_yz(INDEX_IJK) = 0.3 * sigma_zz(INDEX_IJK)
+  ENDDO_LOOP_IJK
+
+  ! define symmetric components of sigma (to be general in case of gravity)
+  DO_LOOP_IJK
+    sigma_yx(INDEX_IJK) = sigma_xy(INDEX_IJK)
+    sigma_zx(INDEX_IJK) = sigma_xz(INDEX_IJK)
+    sigma_zy(INDEX_IJK) = sigma_yz(INDEX_IJK)
+  ENDDO_LOOP_IJK
+
+  ! compute non-symmetric terms for gravity
+  if (GRAVITY_VAL) then
+    ! dummy example, originally calls more complicated subroutine compute_element_gravity(..)
+    DO_LOOP_IJK
+      ! compute G tensor from s . g and add to sigma (not symmetric)
+      ! (dummy values)
+      sigma_xx(INDEX_IJK) = sigma_xx(INDEX_IJK) + 1.1 ! real(sy_l*gyl + sz_l*gzl, kind=CUSTOM_REAL)
+      sigma_yy(INDEX_IJK) = sigma_yy(INDEX_IJK) + 1.1 ! real(sx_l*gxl + sz_l*gzl, kind=CUSTOM_REAL)
+      sigma_zz(INDEX_IJK) = sigma_zz(INDEX_IJK) + 1.1 ! real(sx_l*gxl + sy_l*gyl, kind=CUSTOM_REAL)
+
+      sigma_xy(INDEX_IJK) = sigma_xy(INDEX_IJK) - 0.3 ! real(sx_l * gyl, kind=CUSTOM_REAL)
+      sigma_yx(INDEX_IJK) = sigma_yx(INDEX_IJK) - 0.3 ! real(sy_l * gxl, kind=CUSTOM_REAL)
+
+      sigma_xz(INDEX_IJK) = sigma_xz(INDEX_IJK) - 0.5 ! real(sx_l * gzl, kind=CUSTOM_REAL)
+      sigma_zx(INDEX_IJK) = sigma_zx(INDEX_IJK) - 0.5 ! real(sz_l * gxl, kind=CUSTOM_REAL)
+
+      sigma_yz(INDEX_IJK) = sigma_yz(INDEX_IJK) - 0.7 ! real(sy_l * gzl, kind=CUSTOM_REAL)
+      sigma_zy(INDEX_IJK) = sigma_zy(INDEX_IJK) - 0.7 ! real(sz_l * gyl, kind=CUSTOM_REAL)
+
+      ! precompute vector
+      factor = 0.5 ! 0.5 * dummyz_loc(INDEX_IJK) ! dble(jacobianl(INDEX_IJK)) * wgll_cube(INDEX_IJK)
+
+      rho_s_H(INDEX_IJK,1) = factor * 1.5 ! real(factor * (sx_l * Hxxl + sy_l * Hxyl + sz_l * Hxzl), kind=CUSTOM_REAL)
+      rho_s_H(INDEX_IJK,2) = factor * 1.5 ! real(factor * (sx_l * Hxyl + sy_l * Hyyl + sz_l * Hyzl), kind=CUSTOM_REAL)
+      rho_s_H(INDEX_IJK,3) = factor * 1.5 ! real(factor * (sx_l * Hxzl + sy_l * Hyzl + sz_l * Hzzl), kind=CUSTOM_REAL)
+    ENDDO_LOOP_IJK
+  endif
+
+  ! dot product of stress tensor with test vector, non-symmetric form
+  DO_LOOP_IJK
+    ! reloads derivatives of ux, uy and uz with respect to x, y and z
+    ! (dummy)
+    xixl = 1.1
+    xiyl = 1.2
+    xizl = 1.3
+    etaxl = 1.4
+    etayl = 1.5
+    etazl = 1.6
+    gammaxl = 1.7
+    gammayl = 1.8
+    gammazl = 1.9
+
+    ! common factor (dummy)
+    fac = 0.5
+
+    ! form dot product with test vector, non-symmetric form
+    ! this goes to accel_x
+    tempx1(INDEX_IJK) = fac * (sigma_xx(INDEX_IJK)*xixl + sigma_yx(INDEX_IJK)*xiyl + sigma_zx(INDEX_IJK)*xizl)
+    ! this goes to accel_y
+    tempy1(INDEX_IJK) = fac * (sigma_xy(INDEX_IJK)*xixl + sigma_yy(INDEX_IJK)*xiyl + sigma_zy(INDEX_IJK)*xizl)
+    ! this goes to accel_z
+    tempz1(INDEX_IJK) = fac * (sigma_xz(INDEX_IJK)*xixl + sigma_yz(INDEX_IJK)*xiyl + sigma_zz(INDEX_IJK)*xizl)
+
+    ! this goes to accel_x
+    tempx2(INDEX_IJK) = fac * (sigma_xx(INDEX_IJK)*etaxl + sigma_yx(INDEX_IJK)*etayl + sigma_zx(INDEX_IJK)*etazl)
+    ! this goes to accel_y
+    tempy2(INDEX_IJK) = fac * (sigma_xy(INDEX_IJK)*etaxl + sigma_yy(INDEX_IJK)*etayl + sigma_zy(INDEX_IJK)*etazl)
+    ! this goes to accel_z
+    tempz2(INDEX_IJK) = fac * (sigma_xz(INDEX_IJK)*etaxl + sigma_yz(INDEX_IJK)*etayl + sigma_zz(INDEX_IJK)*etazl)
+
+    ! this goes to accel_x
+    tempx3(INDEX_IJK) = fac * (sigma_xx(INDEX_IJK)*gammaxl + sigma_yx(INDEX_IJK)*gammayl + sigma_zx(INDEX_IJK)*gammazl)
+    ! this goes to accel_y
+    tempy3(INDEX_IJK) = fac * (sigma_xy(INDEX_IJK)*gammaxl + sigma_yy(INDEX_IJK)*gammayl + sigma_zy(INDEX_IJK)*gammazl)
+    ! this goes to accel_z
+    tempz3(INDEX_IJK) = fac * (sigma_xz(INDEX_IJK)*gammaxl + sigma_yz(INDEX_IJK)*gammayl + sigma_zz(INDEX_IJK)*gammazl)
+
+  ENDDO_LOOP_IJK
+
+  ! avoid compiler warning
+  idummy = ispec
+  idummy = ibool(1,1,1,1)
+
+  end subroutine compute_element_dummy
+
+!
+!-------------------------------------------------------------------
+!
+
+  subroutine synchronize_all()
+
+! dummy routine to make it easier for copy-paste from the original code
+
+  implicit none
+
+  continue
+
+  end subroutine synchronize_all
+
+!
+!-------------------------------------------------------------------
+!
+
+
+  subroutine exit_MPI(myrank,error_msg)
+
+! dummy routine to make it easier for copy-paste from the original code
+
+  use constants
+
+  implicit none
+
+  ! identifier for error message file
+  integer, parameter :: IERROR = 30
+
+  integer :: myrank
+  character(len=*) :: error_msg
+
+  ! write error message to screen
+  write(*,*) error_msg(1:len(error_msg))
+  write(*,*) 'Error detected, aborting MPI... proc ',myrank
+
+  ! or just exit with message:
+  stop 'Error, program ended in exit_MPI'
+
+  end subroutine exit_MPI
+
+!
+!-------------------------------------------------------------------
+!
+
+  subroutine flush_IMAIN()
+
+! dummy routine to make it easier for copy-paste from the original code
+
+  implicit none
+
+  continue
+
+  end subroutine flush_IMAIN
+

--- a/samples/specfem/specfem.sh
+++ b/samples/specfem/specfem.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+HERE=$(cd $(dirname $0); pwd -P)
+NAME=$(basename $0 .sh)
+GREP=$(which grep)
+ENV=$(which env)
+
+if [ "Windows_NT" = "${OS}" ]; then
+  # Cygwin's ldd hangs with dyn. linked executables or certain shared libraries
+  LDD=$(which cygcheck)
+  # Cygwin's "env" does not set PATH ("Files/Black: No such file or directory")
+  export PATH=${PATH}:${HERE}/../../lib
+else
+  if [ "" != "$(which ldd)" ]; then
+    LDD=ldd
+  else
+    LDD=echo
+  fi
+fi
+
+MICINFO=$(which micinfo 2> /dev/null)
+if [ "" != "${MICINFO}" ]; then
+  MICCORES=$("${MICINFO}" | sed -n "0,/\s\+Total No of Active Cores :\s\+\([0-9]\+\)/s//\1/p")
+fi
+if [ "" = "${MICCORES}" ]; then
+  MICCORES=61
+fi
+MICTPERC=3
+
+if [ "-mic" != "$1" ]; then
+  if [ "" != "$(${LDD} ${HERE}/${NAME} 2> /dev/null | ${GREP} libiomp5\.so)" ]; then
+    ${ENV} LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${HERE}/../../lib \
+      DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}:${HERE}/../../lib \
+      KMP_AFFINITY=scatter,granularity=fine,1 \
+      MIC_KMP_AFFINITY=scatter,granularity=fine \
+      MIC_KMP_PLACE_THREADS=$((MICCORES-1))c${MICTPERC}t \
+      MIC_ENV_PREFIX=MIC \
+      OFFLOAD_INIT=on_start \
+    ${HERE}/${NAME} $*
+  else
+    ${ENV} LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${HERE}/../../lib \
+      DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}:${HERE}/../../lib \
+      OMP_PROC_BIND=TRUE \
+    ${HERE}/${NAME} $*
+  fi
+else
+  shift
+  ${ENV} \
+    SINK_LD_LIBRARY_PATH=${SINK_LD_LIBRARY_PATH}:${MIC_LD_LIBRARY_PATH}:${HERE}/../../lib \
+  micnativeloadex \
+    ${HERE}/${NAME} -a "$*" \
+    -e "KMP_AFFINITY=scatter,granularity=fine" \
+    -e "MIC_KMP_PLACE_THREADS=$((MICCORES-1))${MICTPERC}t"
+fi
+


### PR DESCRIPTION
this PR adds a new sample example "samples/specfem". it mimicks the SPECFEM3D_GLOBE stiffness computation for elastic domains (most heavy routine in the code). 

the example implements 4th-order spectral-element computations (used by default). the various flavors (Deville, unrolled, dispatched, prefetch, static) are timed and speedup compared to the Deville routine (compute_forces_Dev.F90).

a step-by-step explanation is given in the README.md.

best wishes,
daniel