### PR TITLE
Switch to using Eigen::bfloat16 instead of tensorflow::bfloat16.

### DIFF
--- a/include/libxsmm_typedefs.h
+++ b/include/libxsmm_typedefs.h
@@ -104,7 +104,7 @@ LIBXSMM_EXTERN_C typedef union LIBXSMM_RETARGETABLE libxsmm_bfloat16_hp {
 } libxsmm_bfloat16_hp;
 
 #if defined(__cplusplus)
-namespace tensorflow { struct bfloat16; }
+namespace Eigen { struct bfloat16; }
 #endif /*__cplusplus*/
 
 /** Integer type for LAPACK/BLAS (LP64: 32-bit, and ILP64: 64-bit). */

--- a/src/template/libxsmm.h
+++ b/src/template/libxsmm.h
@@ -650,7 +650,7 @@ template<> struct LIBXSMM_RETARGETABLE libxsmm_gemm_precision_enum<float>       
 template<> struct LIBXSMM_RETARGETABLE libxsmm_gemm_precision_enum<int>                  { static const libxsmm_gemm_precision value = LIBXSMM_GEMM_PRECISION_I32; };
 template<> struct LIBXSMM_RETARGETABLE libxsmm_gemm_precision_enum</*signed*/short>      { static const libxsmm_gemm_precision value = LIBXSMM_GEMM_PRECISION_I16; };
 template<> struct LIBXSMM_RETARGETABLE libxsmm_gemm_precision_enum<libxsmm_bfloat16>     { static const libxsmm_gemm_precision value = LIBXSMM_GEMM_PRECISION_BF16; };
-template<> struct LIBXSMM_RETARGETABLE libxsmm_gemm_precision_enum<tensorflow::bfloat16> { static const libxsmm_gemm_precision value = LIBXSMM_GEMM_PRECISION_BF16; };
+template<> struct LIBXSMM_RETARGETABLE libxsmm_gemm_precision_enum<Eigen::bfloat16>      { static const libxsmm_gemm_precision value = LIBXSMM_GEMM_PRECISION_BF16; };
 template<> struct LIBXSMM_RETARGETABLE libxsmm_gemm_precision_enum<signed char>          { static const libxsmm_gemm_precision value = LIBXSMM_GEMM_PRECISION_I8; };
 template<> struct LIBXSMM_RETARGETABLE libxsmm_gemm_precision_enum<unsigned char>        { static const libxsmm_gemm_precision value = LIBXSMM_GEMM_PRECISION_I8; };
 template<> struct LIBXSMM_RETARGETABLE libxsmm_gemm_precision_enum<char>                 { static const libxsmm_gemm_precision value = LIBXSMM_GEMM_PRECISION_I8; };


### PR DESCRIPTION
This is to address issue #393 since tensorflow will move to using Eigen::bfloat16 directly instead of defining its own struct, which will break xsmm when building together with tensorflow code without this change.