### PR TITLE
Dynamically decide between sparse and dense kernels in dfsspmdm.

### DIFF
--- a/src/libxsmm_fsspmdm.c
+++ b/src/libxsmm_fsspmdm.c
@@ -13,6 +13,38 @@
 #include "libxsmm_main.h"
 
 
+/* Double precision AVX-512 lane broadcasts */
+LIBXSMM_APIVAR_DEFINE(const unsigned int dperm[]) = {
+  0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1,
+  2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3,
+  4, 5, 4, 5, 4, 5, 4, 5, 4, 5, 4, 5, 4, 5, 4, 5,
+  6, 7, 6, 7, 6, 7, 6, 7, 6, 7, 6, 7, 6, 7, 6, 7,
+  8, 9, 8, 9, 8, 9, 8, 9, 8, 9, 8, 9, 8, 9, 8, 9,
+  10, 11, 10, 11, 10, 11, 10, 11, 10, 11, 10, 11, 10, 11, 10, 11,
+  12, 13, 12, 13, 12, 13, 12, 13, 12, 13, 12, 13, 12, 13, 12, 13,
+  14, 15, 14, 15, 14, 15, 14, 15, 14, 15, 14, 15, 14, 15, 14, 15
+};
+
+/* Single precision AVX-512 lane broadcasts */
+LIBXSMM_APIVAR_DEFINE(const unsigned int sperm[]) = {
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+  3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+  4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+  6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+  7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+  8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+  9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
+  10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
+  11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+  12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12,
+  13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
+  14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14,
+  15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15
+};
+
 LIBXSMM_API libxsmm_dfsspmdm* libxsmm_dfsspmdm_create(
   libxsmm_blasint M, libxsmm_blasint N, libxsmm_blasint K,
   libxsmm_blasint lda, libxsmm_blasint ldb, libxsmm_blasint ldc,
@@ -23,12 +55,15 @@ LIBXSMM_API libxsmm_dfsspmdm* libxsmm_dfsspmdm_create(
   double* a_csr_values = 0;
   unsigned int* a_csr_rowptr = 0;
   unsigned int* a_csr_colidx = 0;
+  double* aa_dense = 0;
   int flags = LIBXSMM_GEMM_FLAGS('N', 'N');
   const libxsmm_gemm_prefetch_type prefetch = LIBXSMM_GEMM_PREFETCH_NONE;
   const libxsmm_gemm_descriptor* xgemm_desc;
   libxsmm_descriptor_blob xgemm_blob;
   libxsmm_dfsspmdm* new_handle = 0;
-  int i, j, a_nnz;
+  libxsmm_dmmfunction k_sparse = 0;
+  libxsmm_dmmfunction k_dense = 0;
+  int i, j, n, a_nnz, N_sparse, N_dense;
 
   /* some checks... */
   assert(N % 8 == 0);
@@ -38,11 +73,24 @@ LIBXSMM_API libxsmm_dfsspmdm* libxsmm_dfsspmdm_create(
   assert(N <= ldc);
   assert(N <= ldb);
 
-  /* allocate handle */
-  new_handle = (libxsmm_dfsspmdm*)malloc(sizeof(libxsmm_dfsspmdm));
-  if (0 == new_handle) return 0;
+  /* Get the number of non-zeros */
+  a_nnz = 0;
+  for (i = 0; i < M; i++) {
+    for (j = 0; j < K; j++) {
+      if (LIBXSMM_NEQ(a_dense[(i*lda) + j], 0.0)) {
+        a_nnz++;
+      }
+    }
+  }
 
-  /* initialize the handle */
+  /* Null matrix */
+  if ( 0 == a_nnz ) return 0;
+
+  /* Allocate handle */
+  new_handle = (libxsmm_dfsspmdm*)malloc(sizeof(libxsmm_dfsspmdm));
+  if ( 0 == new_handle ) return 0;
+
+  /* Initialize the handle */
   LIBXSMM_MEMZERO127(new_handle);
   /* TODO: in case of ILP64, check value ranges */
   new_handle->N = (int)N;
@@ -51,86 +99,135 @@ LIBXSMM_API libxsmm_dfsspmdm* libxsmm_dfsspmdm_create(
   new_handle->ldb = (int)ldb;
   new_handle->ldc = (int)ldc;
 
-  /* get number of non-zeros */
-  a_nnz = 0;
-  for (i = 0; i < M; ++i) {
-    for (j = 0; j < K; j++) {
-      if (LIBXSMM_NEQ(a_dense[(i*lda) + j], 0.0)) {
-        a_nnz++;
-      }
-    }
-  }
-
-  if (0 < a_nnz) {
-    /* allocate CSR structure */
-    a_csr_values = (double*)malloc((size_t)a_nnz * sizeof(double));
-    a_csr_rowptr = (unsigned int*)malloc(((size_t)M + 1) * sizeof(unsigned int));
-    a_csr_colidx = (unsigned int*)malloc((size_t)a_nnz * sizeof(unsigned int));
-  }
-
   /* update flags */
-  if ( (beta == 0.0f) && (c_is_nt != 0) ) {
+  if ( beta == 0.0 && c_is_nt != 0 ) {
     flags |= LIBXSMM_GEMM_FLAG_ALIGN_C_NTS_HINT;
   }
 
-  if (0 != a_csr_values && 0 != a_csr_rowptr && 0 != a_csr_colidx) {
-    int n = 0;
-    /* populate CSR structure */
-    for (i = 0; i < M; i++) {
-      a_csr_rowptr[i] = n;
-      for (j = 0; j < K; j++) {
-        if (LIBXSMM_NEQ(a_dense[(i*lda) + j], 0.0)) {
-          a_csr_values[n] = alpha*a_dense[(i*lda) + j];
-          a_csr_colidx[n] = j;
-          n++;
-        }
-      }
-    }
-    a_csr_rowptr[M] = a_nnz;
+  /* Allocate CSR structure */
+  a_csr_values = (double*)malloc((size_t)a_nnz * sizeof(double));
+  a_csr_rowptr = (unsigned int*)malloc(((size_t)M + 1) * sizeof(unsigned int));
+  a_csr_colidx = (unsigned int*)malloc((size_t)a_nnz * sizeof(unsigned int));
 
-    /* attempt to JIT a sparse_reg */
-    new_handle->N_chunksize = libxsmm_cpuid_vlen32(libxsmm_cpuid()) / 2;
+  /* Allocate dense storage */
+  aa_dense = (double*)libxsmm_aligned_malloc((size_t)M * (size_t)K * sizeof(double), 64);
 
-    xgemm_desc = libxsmm_dgemm_descriptor_init(&xgemm_blob, M, new_handle->N_chunksize, K,
-      0, ldb, ldc, one, beta, flags, prefetch);
-
-    if (0 != xgemm_desc) {
-      new_handle->kernel = libxsmm_create_dcsr_reg(xgemm_desc, a_csr_rowptr, a_csr_colidx, a_csr_values);
-    }
+  if ( 0 == a_csr_values || 0 == a_csr_rowptr || 0 == a_csr_colidx || 0 == aa_dense ) {
+    free( a_csr_values ); free( a_csr_rowptr ); free( a_csr_colidx );
+    free( new_handle );
+    libxsmm_free( aa_dense );
+    return 0;
   }
 
-  /* continue with sparse A */
-  if (new_handle->kernel != 0) {
-    /* allocate 8 * 512-bit permute operands if not stored in registers */
-    new_handle->permute_operands = (unsigned int*)libxsmm_aligned_malloc(8*16*sizeof(unsigned int), 64);
-    /* store permute operands */
-    for (i = 0; i < 8; i++) {
-      j = 0;
-      /* repeat pattern to select 64-bits using vpermd */
-      while (j < 16) {
-        new_handle->permute_operands[i*16+(j)] = i*2;
-        j++;
-        new_handle->permute_operands[i*16+(j)] = i*2 + 1;
-        j++;
-      }
-    }
-  /* attempt to JIT dense kernel as sparse_reg failed */
-  } else {
-    new_handle->N_chunksize = 8;
-    new_handle->kernel = libxsmm_dmmdispatch(new_handle->N_chunksize, M, K, &ldb, &K, &ldc, &one, &beta, &flags, (const int*)LIBXSMM_GEMM_PREFETCH_NONE);
-    /* copy A over */
-    new_handle->a_dense = (double*)libxsmm_aligned_malloc((size_t)M * (size_t)K * sizeof(double), 64);
-    for ( i = 0; i < M; ++i ) {
-      for ( j = 0; j < K; ++j ) {
-        new_handle->a_dense[(i*K)+j] = alpha*a_dense[(i*lda)+j];
+  /* Populate CSR structure */
+  for (i = 0, n = 0; i < M; i++) {
+    a_csr_rowptr[i] = n;
+    for (j = 0; j < K; j++) {
+      if (LIBXSMM_NEQ(a_dense[(i*lda) + j], 0.0)) {
+        a_csr_values[n] = alpha*a_dense[(i*lda) + j];
+        a_csr_colidx[n] = j;
+        n++;
       }
     }
   }
+  a_csr_rowptr[M] = a_nnz;
 
-  /* free CSR */
+  /* Attempt to JIT a sparse kernel */
+  N_sparse = libxsmm_cpuid_vlen32(libxsmm_cpuid()) / 2;
+  xgemm_desc = libxsmm_dgemm_descriptor_init(&xgemm_blob, M, N_sparse, K,
+                                              0, ldb, ldc, one, beta, flags, prefetch);
+  if ( 0 != xgemm_desc ) {
+    k_sparse = libxsmm_create_dcsr_reg(xgemm_desc, a_csr_rowptr, a_csr_colidx, a_csr_values);
+  }
+
+  /* Free CSR */
   free( a_csr_values );
   free( a_csr_rowptr );
   free( a_csr_colidx );
+
+  /* Also generate a dense kernel */
+  N_dense = 8;
+  k_dense = libxsmm_dmmdispatch(N_dense, M, K, &ldb, &K, &ldc, &one, &beta, &flags, (const int*)LIBXSMM_GEMM_PREFETCH_NONE);
+
+  if ( 0 != k_dense ) {
+    /* copy A over */
+    for ( i = 0; i < M; ++i )
+      for ( j = 0; j < K; ++j )
+        aa_dense[i*K + j] = alpha*a_dense[i*lda + j];
+  }
+
+  /* Sparse only */
+  if ( 0 != k_sparse && 0 == k_dense ) {
+    new_handle->N_chunksize = N_sparse;
+    new_handle->kernel = k_sparse;
+    libxsmm_free( aa_dense );
+  }
+  /* Dense only */
+  else if ( 0 != k_dense && 0 == k_sparse ) {
+    new_handle->N_chunksize = N_dense;
+    new_handle->kernel = k_dense;
+    new_handle->a_dense = aa_dense;
+  }
+  /* Both; benchmark */
+  else if ( 0 != k_dense && 0 != k_sparse ) {
+    int use_sparse = 1;
+    libxsmm_timer_tickint t1, t2, t3;
+    double* B = (double*)libxsmm_aligned_malloc((size_t)K * (size_t)ldb * sizeof(double), 64);
+    double* C = (double*)libxsmm_aligned_malloc((size_t)M * (size_t)ldc * sizeof(double), 64);
+    void* fp;
+
+    if (0 != B && 0 != C ) {
+      for ( i = 0; i < K; i++ )
+        for ( j = 0; j < N; j++ )
+          B[i*ldb + j] = 1;
+
+      for ( i = 0; i < M; i++ )
+        for ( j = 0; j < N; j++ )
+          C[i*ldc + j] = 1;
+
+      /* Benchmark sparse */
+      t1 = libxsmm_timer_tick();
+      for ( i = 0; i < 25; i++ )
+        for ( j = 0; j < N; j += N_sparse )
+          k_sparse( (double*)dperm, B + j, C + j );
+      t2 = libxsmm_timer_tick();
+
+      /* Benchmark dense */
+      for ( i = 0; i < 25; i++ )
+        for ( j = 0; j < N; j += N_dense )
+          k_dense( B + j, aa_dense, C + j );
+      t3 = libxsmm_timer_tick();
+
+      /* Compare */
+      use_sparse = libxsmm_timer_duration( t1, t2 ) < libxsmm_timer_duration( t2, t3 );
+    }
+
+    /* Sparse faster */
+    if ( use_sparse ) {
+      new_handle->N_chunksize = N_sparse;
+      new_handle->kernel = k_sparse;
+
+      libxsmm_free( aa_dense );
+    }
+    /* Dense faster */
+    else {
+      new_handle->N_chunksize = N_dense;
+      new_handle->kernel = k_dense;
+      new_handle->a_dense = aa_dense;
+
+      LIBXSMM_ASSIGN127( &fp, &k_sparse );
+      libxsmm_free( fp );
+    }
+
+    libxsmm_free( B );
+    libxsmm_free( C );
+  }
+  /* Neither */
+  else {
+    libxsmm_free( aa_dense );
+    free( new_handle );
+    new_handle = 0;
+  }
 
   return new_handle;
 }
@@ -146,12 +243,15 @@ LIBXSMM_API libxsmm_sfsspmdm* libxsmm_sfsspmdm_create(
   float* a_csr_values = 0;
   unsigned int* a_csr_rowptr = 0;
   unsigned int* a_csr_colidx = 0;
+  float* aa_dense = 0;
   int flags = LIBXSMM_GEMM_FLAGS('N', 'N');
   const libxsmm_gemm_prefetch_type prefetch = LIBXSMM_GEMM_PREFETCH_NONE;
   const libxsmm_gemm_descriptor* xgemm_desc;
   libxsmm_descriptor_blob xgemm_blob;
   libxsmm_sfsspmdm* new_handle = 0;
-  int i, j, a_nnz;
+  libxsmm_smmfunction k_sparse = 0;
+  libxsmm_smmfunction k_dense = 0;
+  int i, j, n, a_nnz, N_sparse, N_dense;
 
   /* some checks... */
   assert(N % 16 == 0);
@@ -161,11 +261,24 @@ LIBXSMM_API libxsmm_sfsspmdm* libxsmm_sfsspmdm_create(
   assert(N <= ldc);
   assert(N <= ldb);
 
-  /* allocate handle */
-  new_handle = (libxsmm_sfsspmdm*)malloc(sizeof(libxsmm_sfsspmdm));
-  if (0 == new_handle) return 0;
+  /* Get the number of non-zeros */
+  a_nnz = 0;
+  for (i = 0; i < M; i++) {
+    for (j = 0; j < K; j++) {
+      if (LIBXSMM_NEQ(a_dense[(i*lda) + j], 0.0)) {
+        a_nnz++;
+      }
+    }
+  }
 
-  /* initialize the handle */
+  /* Null matrix */
+  if ( 0 == a_nnz ) return 0;
+
+  /* Allocate handle */
+  new_handle = (libxsmm_sfsspmdm*)malloc(sizeof(libxsmm_sfsspmdm));
+  if ( 0 == new_handle ) return 0;
+
+  /* Initialize the handle */
   LIBXSMM_MEMZERO127(new_handle);
   /* TODO: in case of ILP64, check value ranges */
   new_handle->N = (int)N;
@@ -174,84 +287,135 @@ LIBXSMM_API libxsmm_sfsspmdm* libxsmm_sfsspmdm_create(
   new_handle->ldb = (int)ldb;
   new_handle->ldc = (int)ldc;
 
-  /* get number of non-zeros */
-  a_nnz = 0;
-  for (i = 0; i < M; ++i) {
-    for (j = 0; j < K; j++) {
-      if (LIBXSMM_NEQ(a_dense[(i*lda) + j], 0.0f)) {
-        a_nnz++;
-      }
-    }
-  }
-
-  if (0 < a_nnz) {
-    /* allocate CSR structure */
-    a_csr_values = (float*)malloc((size_t)a_nnz * sizeof(float));
-    a_csr_rowptr = (unsigned int*)malloc(((size_t)M + 1) * sizeof(unsigned int));
-    a_csr_colidx = (unsigned int*)malloc((size_t)a_nnz * sizeof(unsigned int));
-  }
-
   /* update flags */
-  if ( (beta == 0.0f) && (c_is_nt != 0) ) {
+  if ( beta == 0.0 && c_is_nt != 0 ) {
     flags |= LIBXSMM_GEMM_FLAG_ALIGN_C_NTS_HINT;
   }
 
-  if (0 != a_csr_values && 0 != a_csr_rowptr && 0 != a_csr_colidx) {
-    int n = 0;
-    /* populate CSR structure */
-    for (i = 0; i < M; i++) {
-      a_csr_rowptr[i] = n;
-      for (j = 0; j < K; j++) {
-        if (LIBXSMM_NEQ(a_dense[(i*lda) + j], 0.0f)) {
-          a_csr_values[n] = alpha*a_dense[(i*lda) + j];
-          a_csr_colidx[n] = j;
-          n++;
-        }
-      }
-    }
-    a_csr_rowptr[M] = a_nnz;
+  /* Allocate CSR structure */
+  a_csr_values = (float*)malloc((size_t)a_nnz * sizeof(float));
+  a_csr_rowptr = (unsigned int*)malloc(((size_t)M + 1) * sizeof(unsigned int));
+  a_csr_colidx = (unsigned int*)malloc((size_t)a_nnz * sizeof(unsigned int));
 
-    /* attempt to JIT a sparse_reg */
-    new_handle->N_chunksize = libxsmm_cpuid_vlen32(libxsmm_cpuid());
+  /* Allocate dense storage */
+  aa_dense = (float*)libxsmm_aligned_malloc((size_t)M * (size_t)K * sizeof(float), 64);
 
-    xgemm_desc = libxsmm_sgemm_descriptor_init(&xgemm_blob, M, new_handle->N_chunksize, K,
-      0, ldb, ldc, one, beta, flags, prefetch);
-
-    if (0 != xgemm_desc) {
-      new_handle->kernel = libxsmm_create_scsr_reg(xgemm_desc, a_csr_rowptr, a_csr_colidx, a_csr_values);
-    }
+  if ( 0 == a_csr_values || 0 == a_csr_rowptr || 0 == a_csr_colidx || 0 == aa_dense ) {
+    free( a_csr_values ); free( a_csr_rowptr ); free( a_csr_colidx );
+    free( new_handle );
+    libxsmm_free( aa_dense );
+    return 0;
   }
 
-  /* continue with sparse A */
-  if (new_handle->kernel != 0) {
-    /* allocate 16 * 512-bit permute operands if not stored in registers */
-    new_handle->permute_operands = (unsigned int*)libxsmm_aligned_malloc(16*16*sizeof(unsigned int), 64);
-    /* store permute operands */
-    for (i = 0; i < 16; i++) {
-      j = 0;
-      /* repeat pattern to select 32-bits using vpermd */
-      while (j < 16) {
-        new_handle->permute_operands[i*16+j] = i;
-        j++;
-      }
-    }
-  /* attempt to JIT dense kernel as sparse_reg failed */
-  } else {
-    new_handle->N_chunksize = 16;
-    new_handle->kernel = libxsmm_smmdispatch(new_handle->N_chunksize, M, K, &ldb, &K, &ldc, &one, &beta, &flags, (const int*)LIBXSMM_GEMM_PREFETCH_NONE);
-    /* copy A over */
-    new_handle->a_dense = (float*)libxsmm_aligned_malloc((size_t)M * (size_t)K * sizeof(float), 64);
-    for ( i = 0; i < M; ++i ) {
-      for ( j = 0; j < K; ++j ) {
-        new_handle->a_dense[(i*K)+j] = alpha*a_dense[(i*lda)+j];
+  /* Populate CSR structure */
+  for (i = 0, n = 0; i < M; i++) {
+    a_csr_rowptr[i] = n;
+    for (j = 0; j < K; j++) {
+      if (LIBXSMM_NEQ(a_dense[(i*lda) + j], 0.0f)) {
+        a_csr_values[n] = alpha*a_dense[(i*lda) + j];
+        a_csr_colidx[n] = j;
+        n++;
       }
     }
   }
+  a_csr_rowptr[M] = a_nnz;
 
-  /* free CSR */
+  /* Attempt to JIT a sparse kernel */
+  N_sparse = libxsmm_cpuid_vlen32(libxsmm_cpuid());
+  xgemm_desc = libxsmm_sgemm_descriptor_init(&xgemm_blob, M, N_sparse, K,
+                                             0, ldb, ldc, one, beta, flags, prefetch);
+  if ( 0 != xgemm_desc ) {
+    k_sparse = libxsmm_create_scsr_reg(xgemm_desc, a_csr_rowptr, a_csr_colidx, a_csr_values);
+  }
+
+  /* Free CSR */
   free( a_csr_values );
   free( a_csr_rowptr );
   free( a_csr_colidx );
+
+  /* Also generate a dense kernel */
+  N_dense = 16;
+  k_dense = libxsmm_smmdispatch(N_dense, M, K, &ldb, &K, &ldc, &one, &beta, &flags, (const int*)LIBXSMM_GEMM_PREFETCH_NONE);
+
+  if ( 0 != k_dense ) {
+    /* copy A over */
+    for ( i = 0; i < M; ++i )
+      for ( j = 0; j < K; ++j )
+        aa_dense[i*K + j] = alpha*a_dense[i*lda + j];
+  }
+
+  /* Sparse only */
+  if ( 0 != k_sparse && 0 == k_dense ) {
+    new_handle->N_chunksize = N_sparse;
+    new_handle->kernel = k_sparse;
+    libxsmm_free( aa_dense );
+  }
+  /* Dense only */
+  else if ( 0 != k_dense && 0 == k_sparse ) {
+    new_handle->N_chunksize = N_dense;
+    new_handle->kernel = k_dense;
+    new_handle->a_dense = aa_dense;
+  }
+  /* Both; benchmark */
+  else if ( 0 != k_dense && 0 != k_sparse ) {
+    int use_sparse = 1;
+    libxsmm_timer_tickint t1, t2, t3;
+    float* B = (float*)libxsmm_aligned_malloc((size_t)K * (size_t)ldb * sizeof(float), 64);
+    float* C = (float*)libxsmm_aligned_malloc((size_t)M * (size_t)ldc * sizeof(float), 64);
+    void* fp;
+
+    if (0 != B && 0 != C ) {
+      for ( i = 0; i < K; i++ )
+        for ( j = 0; j < N; j++ )
+          B[i*ldb + j] = 1;
+
+      for ( i = 0; i < M; i++ )
+        for ( j = 0; j < N; j++ )
+          C[i*ldc + j] = 1;
+
+      /* Benchmark sparse */
+      t1 = libxsmm_timer_tick();
+      for ( i = 0; i < 25; i++ )
+        for ( j = 0; j < N; j += N_sparse )
+          k_sparse( (float*)sperm, B + j, C + j );
+      t2 = libxsmm_timer_tick();
+
+      /* Benchmark dense */
+      for ( i = 0; i < 25; i++ )
+        for ( j = 0; j < N; j += N_dense )
+          k_dense( B + j, aa_dense, C + j );
+      t3 = libxsmm_timer_tick();
+
+      /* Compare */
+      use_sparse = libxsmm_timer_duration( t1, t2 ) < libxsmm_timer_duration( t2, t3 );
+    }
+
+    /* Sparse faster */
+    if ( use_sparse ) {
+      new_handle->N_chunksize = N_sparse;
+      new_handle->kernel = k_sparse;
+
+      libxsmm_free( aa_dense );
+    }
+    /* Dense faster */
+    else {
+      new_handle->N_chunksize = N_dense;
+      new_handle->kernel = k_dense;
+      new_handle->a_dense = aa_dense;
+
+      LIBXSMM_ASSIGN127( &fp, &k_sparse );
+      libxsmm_free( fp );
+    }
+
+    libxsmm_free( B );
+    libxsmm_free( C );
+  }
+  /* Neither */
+  else {
+    libxsmm_free( aa_dense );
+    free( new_handle );
+    new_handle = 0;
+  }
 
   return new_handle;
 }
@@ -264,7 +428,7 @@ LIBXSMM_API void libxsmm_dfsspmdm_execute( const libxsmm_dfsspmdm* handle, const
 
   if ( handle->a_dense == 0 ) {
     for ( i = 0; i < handle->N; i+=handle->N_chunksize ) {
-      handle->kernel( (double*)handle->permute_operands, B+i, C+i );
+      handle->kernel( (double*)dperm, B+i, C+i );
     }
   } else {
     for ( i = 0; i < handle->N; i+=handle->N_chunksize ) {
@@ -281,7 +445,7 @@ LIBXSMM_API void libxsmm_sfsspmdm_execute( const libxsmm_sfsspmdm* handle, const
 
   if ( handle->a_dense == 0 ) {
     for ( i = 0; i < handle->N; i+=handle->N_chunksize ) {
-      handle->kernel( (float*)handle->permute_operands, B+i, C+i );
+      handle->kernel( (float*)sperm, B+i, C+i );
     }
   } else {
     for ( i = 0; i < handle->N; i+=handle->N_chunksize ) {
@@ -302,9 +466,6 @@ LIBXSMM_API void libxsmm_dfsspmdm_destroy( libxsmm_dfsspmdm* handle )
        do not use libxsmm_release_kernel here! We also need to work
        around pointer-to-function to pointer-to-object conversion */
     void* fp;
-    if (handle->permute_operands != 0) {
-      libxsmm_free(handle->permute_operands);
-    }
     LIBXSMM_ASSIGN127(&fp, &handle->kernel);
     libxsmm_free(fp);
   }
@@ -324,9 +485,6 @@ LIBXSMM_API void libxsmm_sfsspmdm_destroy( libxsmm_sfsspmdm* handle )
        do not use libxsmm_release_kernel here! We also need to work
        around pointer-to-function to pointer-to-object conversion */
     void* fp;
-    if (handle->permute_operands != 0) {
-      libxsmm_free(handle->permute_operands);
-    }
     LIBXSMM_ASSIGN127(&fp, &handle->kernel);
     libxsmm_free(fp);
   }

--- a/src/libxsmm_main.h
+++ b/src/libxsmm_main.h
@@ -831,7 +831,6 @@ struct LIBXSMM_RETARGETABLE libxsmm_dfsspmdm {
   int ldb;
   int ldc;
   int N_chunksize;
-  unsigned int* permute_operands;
   double* a_dense;
   libxsmm_dmmfunction kernel;
 };
@@ -843,7 +842,6 @@ struct LIBXSMM_RETARGETABLE libxsmm_sfsspmdm {
   int ldb;
   int ldc;
   int N_chunksize;
-  unsigned int* permute_operands;
   float* a_dense;
   libxsmm_smmfunction kernel;
 };


### PR DESCRIPTION
The dfsspmdm now attempts to JIT both sparse and dense kernels and, if both are available, it benchmarks them to decide which to proceed with.  The code is functional, although I would like to get feedback before writing the single precision variant.

One area that needs work is how we release/free the slower kernel which we do not need.  Specifically, how to be sure that we do not deallocate a kernel which someone else still has a reference to.  As such the deallocation code is currently commented.