### PR TITLE
Enabling transpose of A in GEMM via an intermediate transpose on the stack

### DIFF
--- a/include/libxsmm_generator.h
+++ b/include/libxsmm_generator.h
@@ -14,10 +14,8 @@
 #include "libxsmm_typedefs.h"
 
 #define LIBXSMM_GEMM_NO_BYPASS(FLAGS, ALPHA, BETA) ( \
-  0 == ((FLAGS) & (LIBXSMM_GEMM_FLAG_TRANS_A)) && \
-        (LIBXSMM_FEQ(1, ALPHA) /*|| LIBXSMM_FEQ(-1, ALPHA)*/) && \
-        (LIBXSMM_FEQ(1, BETA) || LIBXSMM_FEQ(0, BETA)))
-
+  0 ==  (LIBXSMM_NEQ(1, ALPHA) /*&& LIBXSMM_NEQ(-1, ALPHA)*/) || \
+        (LIBXSMM_NEQ(1, BETA) && LIBXSMM_NEQ(0, BETA)))
 
 /** Initialize GEMM descriptor as used by low-level routines (type-specific). */
 LIBXSMM_API libxsmm_gemm_descriptor* libxsmm_dgemm_descriptor_init(libxsmm_descriptor_blob* blob,

--- a/samples/xgemm/kernel.c
+++ b/samples/xgemm/kernel.c
@@ -1011,7 +1011,11 @@ int main(int argc, char* argv []) {
     l_gemm_def.ldb = l_ldb;
     l_gemm_def.ldc = l_ldc;
 
-    l_a      = (char*)libxsmm_aligned_malloc((size_t)l_lda * (size_t)l_k * (size_t)l_br * LIBXSMM_TYPESIZE(l_gemm_def.in_type), 64);
+    if (l_gemm_def.trans_a == 0) {
+      l_a      = (char*)libxsmm_aligned_malloc((size_t)l_lda * (size_t)l_k * (size_t)l_br * LIBXSMM_TYPESIZE(l_gemm_def.in_type), 64);
+    } else {
+      l_a      = (char*)libxsmm_aligned_malloc((size_t)l_lda * (size_t)l_m * (size_t)l_br * LIBXSMM_TYPESIZE(l_gemm_def.in_type), 64);
+    }
     if (l_gemm_def.trans_b == 0) {
       l_b      = (char*)libxsmm_aligned_malloc((size_t)l_ldb * (size_t)l_n * (size_t)l_br * LIBXSMM_TYPESIZE(l_gemm_def.in_type), 64);
     } else {

--- a/samples/xgemm/kernel_test/sgemm_tn_eqld.slurm
+++ b/samples/xgemm/kernel_test/sgemm_tn_eqld.slurm
@@ -31,21 +31,21 @@ f1.close()
 f2.close()
 END
 
-./kernel ${TESTFILE1} 1 1 0 0 1 0 SP nobr 1 0 1 1
+./kernel ${TESTFILE1} 1 1 0 0 1 0 SP nobr 1 0 1 0
 
-./kernel ${TESTFILE2} 1 1 0 0 1 0 SP nobr 1 0 1 1
+./kernel ${TESTFILE2} 1 1 0 0 1 0 SP nobr 1 0 1 0
 
-./kernel ${TESTFILE1} 1 1 0 0 1 0 SP addrbr 5 0 1 1
+./kernel ${TESTFILE1} 1 1 0 0 1 0 SP addrbr 5 0 1 0
 
-./kernel ${TESTFILE1} 1 1 0 0 1 0 SP offsbr 5 0 1 1
+./kernel ${TESTFILE1} 1 1 0 0 1 0 SP offsbr 5 0 1 0
 
-./kernel ${TESTFILE1} 1 1 0 0 1 0 SP strdbr 5 0 1 1
+./kernel ${TESTFILE1} 1 1 0 0 1 0 SP strdbr 5 0 1 0
 
-./kernel ${TESTFILE2} 1 1 0 0 1 0 SP addrbr 5 1 1 1
+./kernel ${TESTFILE2} 1 1 0 0 1 0 SP addrbr 5 1 1 0
 
-./kernel ${TESTFILE2} 1 1 0 0 1 0 SP offsbr 5 1 1 1
+./kernel ${TESTFILE2} 1 1 0 0 1 0 SP offsbr 5 1 1 0
 
-./kernel ${TESTFILE2} 1 1 0 0 1 0 SP strdbr 5 1 1 1
+./kernel ${TESTFILE2} 1 1 0 0 1 0 SP strdbr 5 1 1 0
 
 rm ${TESTFILE1}
 rm ${TESTFILE2}

--- a/samples/xgemm/kernel_test/sgemm_tn_eqld.slurm
+++ b/samples/xgemm/kernel_test/sgemm_tn_eqld.slurm
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+./kernel 32 32 32 32 32 32 1 1 0 0 1 0 nopf SP nobr 1 0 1 1
+

--- a/samples/xgemm/kernel_test/sgemm_tn_fused_eqld.slurm
+++ b/samples/xgemm/kernel_test/sgemm_tn_fused_eqld.slurm
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+TESTFILE1=$(mktemp -p .)
+TESTFILE2=$(mktemp -p .)
+
+if [ -x "$(command -v python3)" ]; then
+  PYTHON=$(command -v python3)
+else
+  PYTHON=$(command -v python)
+fi
+
+${PYTHON} << END
+import random as rnd
+import time as time
+rnd.seed(time.time())
+randnum = rnd.sample(range(1,101), 18)
+f1 = open("${TESTFILE1}", "w+")
+f2 = open("${TESTFILE2}", "w+")
+i = 0
+for m in randnum:
+    for n in randnum:
+        for k in randnum:
+            line = str(m) + ' ' + str(n) + ' ' + str(k) + ' ' \
+                 + str(k) + ' ' + str(k) + ' ' + str(m) + '\n'
+            if 0 == (i % 2):
+                f1.write(line)
+            else:
+                f2.write(line)
+            i = i + 1
+f1.close()
+f2.close()
+END
+
+./kernel_fused_ops ${TESTFILE1} 1 1 0 0 1 0 SP nobr 1 0 1 1 0 0 0
+
+./kernel_fused_ops ${TESTFILE2} 1 1 0 0 1 0 SP nobr 1 0 1 1 0 0 0
+
+./kernel_fused_ops ${TESTFILE1} 1 1 0 0 1 0 SP addrbr 5 0 1 1 0 0 0
+
+./kernel_fused_ops ${TESTFILE1} 1 1 0 0 1 0 SP offsbr 5 0 1 1 0 0 0
+
+./kernel_fused_ops ${TESTFILE1} 1 1 0 0 1 0 SP strdbr 5 0 1 1 0 0 0
+
+./kernel_fused_ops ${TESTFILE2} 1 1 0 0 1 0 SP addrbr 5 1 1 1 0 0 0
+
+./kernel_fused_ops ${TESTFILE2} 1 1 0 0 1 0 SP offsbr 5 1 1 1 0 0 0
+
+./kernel_fused_ops ${TESTFILE2} 1 1 0 0 1 0 SP strdbr 5 1 1 1 0 0 0
+
+rm ${TESTFILE1}
+rm ${TESTFILE2}

--- a/samples/xgemm/kernel_test/sgemm_tn_gtld.slurm
+++ b/samples/xgemm/kernel_test/sgemm_tn_gtld.slurm
@@ -20,8 +20,7 @@ i = 0
 for m in randnum:
     for n in randnum:
         for k in randnum:
-            line = str(m) + ' ' + str(n) + ' ' + str(k) + ' ' \
-                 + str(k) + ' ' + str(k) + ' ' + str(m) + '\n'
+            line = str(m) + ' ' + str(n) + ' ' + str(k) + ' 100 100 100\n'
             if 0 == (i % 2):
                 f1.write(line)
             else:

--- a/samples/xgemm/kernel_test/sgemm_tn_gtld.slurm
+++ b/samples/xgemm/kernel_test/sgemm_tn_gtld.slurm
@@ -30,21 +30,21 @@ f1.close()
 f2.close()
 END
 
-./kernel ${TESTFILE1} 1 1 0 0 1 0 SP nobr 1 0 1 1
+./kernel ${TESTFILE1} 1 1 0 0 1 0 SP nobr 1 0 1 0
 
-./kernel ${TESTFILE2} 1 1 0 0 1 0 SP nobr 1 0 1 1
+./kernel ${TESTFILE2} 1 1 0 0 1 0 SP nobr 1 0 1 0
 
-./kernel ${TESTFILE1} 1 1 0 0 1 0 SP addrbr 5 0 1 1
+./kernel ${TESTFILE1} 1 1 0 0 1 0 SP addrbr 5 0 1 0
 
-./kernel ${TESTFILE1} 1 1 0 0 1 0 SP offsbr 5 0 1 1
+./kernel ${TESTFILE1} 1 1 0 0 1 0 SP offsbr 5 0 1 0
 
-./kernel ${TESTFILE1} 1 1 0 0 1 0 SP strdbr 5 0 1 1
+./kernel ${TESTFILE1} 1 1 0 0 1 0 SP strdbr 5 0 1 0
 
-./kernel ${TESTFILE2} 1 1 0 0 1 0 SP addrbr 5 1 1 1
+./kernel ${TESTFILE2} 1 1 0 0 1 0 SP addrbr 5 1 1 0
 
-./kernel ${TESTFILE2} 1 1 0 0 1 0 SP offsbr 5 1 1 1
+./kernel ${TESTFILE2} 1 1 0 0 1 0 SP offsbr 5 1 1 0
 
-./kernel ${TESTFILE2} 1 1 0 0 1 0 SP strdbr 5 1 1 1
+./kernel ${TESTFILE2} 1 1 0 0 1 0 SP strdbr 5 1 1 0
 
 rm ${TESTFILE1}
 rm ${TESTFILE2}

--- a/src/generator_common.c
+++ b/src/generator_common.c
@@ -1147,6 +1147,14 @@ const char* libxsmm_strerror(unsigned int i_error_code) {
       LIBXSMM_SNPRINTF( error_message, GENERATOR_COMMON_MAX_ERROR_LENGTH,
         "eltwise kernels with bitmasks are require for the chosen eltwise op (error #%u)!", i_error_code );
       break;
+    case LIBXSMM_ERR_TRANS_A:
+      LIBXSMM_SNPRINTF( error_message, GENERATOR_COMMON_MAX_ERROR_LENGTH,
+        "GEMM kernel with trans A requested, but target/datatype not supported (error #%u)!", i_error_code );
+      break;
+    case LIBXSMM_ERR_LDA_TRANS:
+      LIBXSMM_SNPRINTF( error_message, GENERATOR_COMMON_MAX_ERROR_LENGTH,
+        "lda needs to be greater than or equal to k (error #%u)!", i_error_code );
+      break;
     default: /* we do not know what happened */
       LIBXSMM_SNPRINTF( error_message, GENERATOR_COMMON_MAX_ERROR_LENGTH,
         "an unknown error occurred (error #%u)!", i_error_code );

--- a/src/generator_common.c
+++ b/src/generator_common.c
@@ -1155,6 +1155,10 @@ const char* libxsmm_strerror(unsigned int i_error_code) {
       LIBXSMM_SNPRINTF( error_message, GENERATOR_COMMON_MAX_ERROR_LENGTH,
         "lda needs to be greater than or equal to k (error #%u)!", i_error_code );
       break;
+    case LIBXSMM_ERR_BRGEMM_TRANS:
+      LIBXSMM_SNPRINTF( error_message, GENERATOR_COMMON_MAX_ERROR_LENGTH,
+        "BRGEMM is not supported for the specified configuration with A transpose (error #%u)!", i_error_code );
+      break;
     default: /* we do not know what happened */
       LIBXSMM_SNPRINTF( error_message, GENERATOR_COMMON_MAX_ERROR_LENGTH,
         "an unknown error occurred (error #%u)!", i_error_code );

--- a/src/generator_common.h
+++ b/src/generator_common.h
@@ -1180,6 +1180,7 @@
 #define LIBXSMM_ERR_BITMASK_REQUIRED      90045
 #define LIBXSMM_ERR_TRANS_A               90046
 #define LIBXSMM_ERR_LDA_TRANS             90047
+#define LIBXSMM_ERR_BRGEMM_TRANS          90048
 
 #define LIBXSMM_HANDLE_ERROR(GENERATED_CODE, ERROR_CODE) libxsmm_handle_error( \
   GENERATED_CODE, ERROR_CODE, LIBXSMM_FUNCNAME, 1 < libxsmm_ninit ? libxsmm_verbosity : 1)

--- a/src/generator_common.h
+++ b/src/generator_common.h
@@ -1178,6 +1178,8 @@
 #define LIBXSMM_ERR_NO_AVX512VL           90043
 #define LIBXSMM_ERR_GP_TEMP_MAPPING       90044
 #define LIBXSMM_ERR_BITMASK_REQUIRED      90045
+#define LIBXSMM_ERR_TRANS_A               90046
+#define LIBXSMM_ERR_LDA_TRANS             90047
 
 #define LIBXSMM_HANDLE_ERROR(GENERATED_CODE, ERROR_CODE) libxsmm_handle_error( \
   GENERATED_CODE, ERROR_CODE, LIBXSMM_FUNCNAME, 1 < libxsmm_ninit ? libxsmm_verbosity : 1)

--- a/src/generator_common.h
+++ b/src/generator_common.h
@@ -1787,7 +1787,8 @@ typedef enum libxsmm_gemm_stack_var {
   LIBXSMM_GEMM_STACK_VAR_TRANS_EXT_BUF_B    = 17,
   LIBXSMM_GEMM_STACK_VAR_TRANS_EXT_BUF_C    = 18,
   LIBXSMM_GEMM_STACK_VAR_ELT_RELU_BITMASK_PTR    = 19,
-  LIBXSMM_GEMM_STACK_VAR_BRCOUNT                 = 20
+  LIBXSMM_GEMM_STACK_VAR_BRCOUNT                 = 20,
+  LIBXSMM_GEMM_STACK_VAR_TRANSPOSE_PTR           = 21
 } libxsmm_gemm_stack_var;
 
 #if 0

--- a/src/generator_gemm.c
+++ b/src/generator_gemm.c
@@ -173,7 +173,10 @@ void libxsmm_generator_gemm_kernel( libxsmm_generated_code*        io_generated_
   if ( (l_xgemm_desc_mod.flags & LIBXSMM_GEMM_FLAG_TRANS_A) == LIBXSMM_GEMM_FLAG_TRANS_A ) {
     // Non FP32 and BRGEMM are not supported for the trans_a = 1 case
     if ((LIBXSMM_GEMM_PRECISION_F32 != LIBXSMM_GETENUM_INP( l_xgemm_desc_mod.datatype )) ||
-        (l_xgemm_desc_mod.flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS              )) {
+        (l_xgemm_desc_mod.flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS               ) ||
+        (l_xgemm_desc_mod.flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET                ) ||
+        (l_xgemm_desc_mod.flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE                )
+       ) {
       LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_INVALID_GEMM_CONFIG );
       return;
     }

--- a/src/generator_gemm.c
+++ b/src/generator_gemm.c
@@ -170,7 +170,13 @@ void libxsmm_generator_gemm_kernel( libxsmm_generated_code*        io_generated_
   }
 
   /* check LDA */
-  if ( (l_xgemm_desc_mod.flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0 ) {
+  if ( (l_xgemm_desc_mod.flags & LIBXSMM_GEMM_FLAG_TRANS_A) == LIBXSMM_GEMM_FLAG_TRANS_A ) {
+    // Non FP32 and BRGEMM are not supported for the trans_a = 1 case
+    if ((LIBXSMM_GEMM_PRECISION_F32 != LIBXSMM_GETENUM_INP( l_xgemm_desc_mod.datatype )) ||
+        (l_xgemm_desc_mod.flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS              )) {
+      LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_INVALID_GEMM_CONFIG );
+      return;
+    }
     if ( l_xgemm_desc_mod.lda < l_xgemm_desc_mod.k ) {
       LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_LDA_TRANS );
       return;

--- a/src/generator_gemm.c
+++ b/src/generator_gemm.c
@@ -171,7 +171,7 @@ void libxsmm_generator_gemm_kernel( libxsmm_generated_code*        io_generated_
 
   /* check LDA */
   if ( (l_xgemm_desc_mod.flags & LIBXSMM_GEMM_FLAG_TRANS_A) == LIBXSMM_GEMM_FLAG_TRANS_A ) {
-    // Neither non-FP32 nor BRGEMM are supported for the trans_a = 1 case
+    /* Neither non-FP32 nor BRGEMM are supported for the trans_a = 1 case */
     if ((l_xgemm_desc_mod.flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS               ) ||
         (l_xgemm_desc_mod.flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET                ) ||
         (l_xgemm_desc_mod.flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE                )

--- a/src/generator_gemm.c
+++ b/src/generator_gemm.c
@@ -170,9 +170,16 @@ void libxsmm_generator_gemm_kernel( libxsmm_generated_code*        io_generated_
   }
 
   /* check LDA */
-  if ( l_xgemm_desc_mod.lda < l_xgemm_desc_mod.m ) {
-    LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_LDA );
-    return;
+  if ( (l_xgemm_desc_mod.flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0 ) {
+    if ( l_xgemm_desc_mod.lda < l_xgemm_desc_mod.k ) {
+      LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_LDA_TRANS );
+      return;
+    }
+  } else {
+    if ( l_xgemm_desc_mod.lda < l_xgemm_desc_mod.m ) {
+      LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_LDA );
+      return;
+    }
   }
 
   /* check LDB */
@@ -192,6 +199,16 @@ void libxsmm_generator_gemm_kernel( libxsmm_generated_code*        io_generated_
   if ( l_xgemm_desc_mod.ldc < l_xgemm_desc_mod.m ) {
     LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_LDC );
     return;
+  }
+
+  /* check for trans A cases which are not supported in the generator */
+  if ( (l_xgemm_desc_mod.flags & LIBXSMM_GEMM_FLAG_TRANS_A) > 0 ) {
+    if ( (LIBXSMM_DATATYPE_F32 != LIBXSMM_GETENUM_INP( l_xgemm_desc_mod.datatype )) ) {
+      LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_TRANS_A );
+      return;
+    } else {
+      /* we are fine, we have transpose support */
+    }
   }
 
   /* check for trans B cases which are not supported in the generator */

--- a/src/generator_gemm.c
+++ b/src/generator_gemm.c
@@ -171,17 +171,20 @@ void libxsmm_generator_gemm_kernel( libxsmm_generated_code*        io_generated_
 
   /* check LDA */
   if ( (l_xgemm_desc_mod.flags & LIBXSMM_GEMM_FLAG_TRANS_A) == LIBXSMM_GEMM_FLAG_TRANS_A ) {
-    // Non FP32 and BRGEMM are not supported for the trans_a = 1 case
-    if ((LIBXSMM_GEMM_PRECISION_F32 != LIBXSMM_GETENUM_INP( l_xgemm_desc_mod.datatype )) ||
-        (l_xgemm_desc_mod.flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS               ) ||
+    // Neither non-FP32 nor BRGEMM are supported for the trans_a = 1 case
+    if ((l_xgemm_desc_mod.flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS               ) ||
         (l_xgemm_desc_mod.flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET                ) ||
         (l_xgemm_desc_mod.flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE                )
        ) {
-      LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_INVALID_GEMM_CONFIG );
+      LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_BRGEMM_TRANS );
       return;
     }
     if ( l_xgemm_desc_mod.lda < l_xgemm_desc_mod.k ) {
       LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_LDA_TRANS );
+      return;
+    }
+    if (LIBXSMM_GEMM_PRECISION_F32 != LIBXSMM_GETENUM_INP( l_xgemm_desc_mod.datatype )) {
+      LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_UNSUP_DATATYPE );
       return;
     }
   } else {

--- a/src/generator_gemm.c
+++ b/src/generator_gemm.c
@@ -183,7 +183,7 @@ void libxsmm_generator_gemm_kernel( libxsmm_generated_code*        io_generated_
       LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_LDA_TRANS );
       return;
     }
-    if (LIBXSMM_GEMM_PRECISION_F32 != LIBXSMM_GETENUM_INP( l_xgemm_desc_mod.datatype )) {
+    if (LIBXSMM_DATATYPE_F32 != LIBXSMM_GETENUM_INP( l_xgemm_desc_mod.datatype )) {
       LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_UNSUP_DATATYPE );
       return;
     }

--- a/src/generator_gemm_common.c
+++ b/src/generator_gemm_common.c
@@ -769,6 +769,8 @@ void libxsmm_generator_gemm_setup_stack_frame_allocate_scratch( libxsmm_generate
     libxsmm_micro_kernel_config*        i_micro_kernel_config ) {
   unsigned int gemm_scratch_size      = 0;
   unsigned int scratch_pad_size       = 0;
+  unsigned int transpose_scratch_size = 0;
+  unsigned int transpose_pad_size     = 0;
   int l_emu_amx = 0;
   const char *const l_env_emu_amx = getenv("EMULATE_AMX");
   if ( 0 == l_env_emu_amx ) {
@@ -804,9 +806,23 @@ void libxsmm_generator_gemm_setup_stack_frame_allocate_scratch( libxsmm_generate
     }
   }
 
+  /* Allocate scratch for stashing 32 zmms  */
+  if ( ((LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI) &&
+       ((LIBXSMM_GEMM_FLAG_TRANS_A & i_xgemm_desc->flags) > 0)  ) {
+    transpose_scratch_size = i_xgemm_desc->m * i_xgemm_desc->k * LIBXSMM_TYPESIZE(LIBXSMM_GETENUM_OUT(i_xgemm_desc->datatype));
+    transpose_pad_size  = (transpose_scratch_size % 64 == 0) ? 0 : ((transpose_scratch_size + 63)/64) * 64 - transpose_scratch_size;
+    transpose_scratch_size += transpose_pad_size;
+  }
+
   if (gemm_scratch_size > 0) {
     libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_sub_instruction, LIBXSMM_X86_GP_REG_RSP, gemm_scratch_size );
     libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_GEMM_SCRATCH_PTR, LIBXSMM_X86_GP_REG_RSP );
+  }
+
+  /* Allocate scratch for the A transpose */
+  if (transpose_scratch_size > 0) {
+    libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_sub_instruction, LIBXSMM_X86_GP_REG_RSP, transpose_scratch_size );
+    libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_TRANSPOSE_PTR, LIBXSMM_X86_GP_REG_RSP );
   }
 }
 
@@ -819,7 +835,7 @@ void libxsmm_generator_gemm_setup_stack_frame( libxsmm_generated_code*          
 
   libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_RBP );
   libxsmm_x86_instruction_alu_reg( io_generated_code, i_micro_kernel_config->alu_mov_instruction, LIBXSMM_X86_GP_REG_RSP, LIBXSMM_X86_GP_REG_RBP);
-  libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_sub_instruction, LIBXSMM_X86_GP_REG_RSP, 88 );
+  libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_sub_instruction, LIBXSMM_X86_GP_REG_RSP, 96 );
 
   if ( ((LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI) ||
        ((LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI) ) {
@@ -846,7 +862,8 @@ void libxsmm_generator_gemm_setup_stack_frame( libxsmm_generated_code*          
    *      Eltwise output_ptr                        <-- RBP-64
    *      Eltwise buf1_ptr                          <-- RBP-72
    *      Eltwise buf2_ptr                          <-- RBP-80
-   *      Batch-reduce count                        <-- RBP-88, RSP
+   *      Batch-reduce count                        <-- RBP-88,
+   *      Transpose A ptr                           <-- RBP-96, RSP
    *
    */
 
@@ -876,7 +893,8 @@ void libxsmm_generator_gemm_setup_stack_frame( libxsmm_generated_code*          
    *      Eltwise output_ptr                    <-- RBP-64
    *      Eltwise buf1_ptr                      <-- RBP-72
    *      Eltwise buf2_ptr                      <-- RBP-80
-   *      Batch-reduce count                    <-- RBP-88, RSP
+   *      Batch-reduce count                    <-- RBP-88
+   *      Transpose A ptr                       <-- RBP-96, RSP
    *      [ Potentianl  pad for 64b align ]
    *      GEMM scratch, 64b aligned             <-- (RBP-48) contains this address
    *
@@ -1136,6 +1154,7 @@ int libxsmm_generator_gemm_get_rbp_relative_offset( libxsmm_gemm_stack_var stack
    *      Eltwise buf1_ptr                          <-- RBP-72
    *      Eltwise buf2_ptr                          <-- RBP-80
    *      Batch-reduce count                        <-- RBP-88
+   *      Transpose A ptr                           <-- RBP-96
    * */
 
   switch ( stack_var ) {
@@ -1181,6 +1200,8 @@ int libxsmm_generator_gemm_get_rbp_relative_offset( libxsmm_gemm_stack_var stack
       return 72;
     case LIBXSMM_GEMM_STACK_VAR_ARG_10:
       return 80;
+    case LIBXSMM_GEMM_STACK_VAR_TRANSPOSE_PTR:
+      return -96;
     default:
       return 0;
   }

--- a/src/generator_gemm_common.c
+++ b/src/generator_gemm_common.c
@@ -806,7 +806,6 @@ void libxsmm_generator_gemm_setup_stack_frame_allocate_scratch( libxsmm_generate
     }
   }
 
-  /* Allocate scratch for stashing 32 zmms  */
   if ( ((LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI) &&
        ((LIBXSMM_GEMM_FLAG_TRANS_A & i_xgemm_desc->flags) > 0)  ) {
     transpose_scratch_size = i_xgemm_desc->m * i_xgemm_desc->k * LIBXSMM_TYPESIZE(LIBXSMM_GETENUM_OUT(i_xgemm_desc->datatype));

--- a/src/generator_gemm_common.c
+++ b/src/generator_gemm_common.c
@@ -806,8 +806,7 @@ void libxsmm_generator_gemm_setup_stack_frame_allocate_scratch( libxsmm_generate
     }
   }
 
-  if ( ((LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI) &&
-       ((LIBXSMM_GEMM_FLAG_TRANS_A & i_xgemm_desc->flags) > 0)  ) {
+  if ( (LIBXSMM_GEMM_FLAG_TRANS_A & i_xgemm_desc->flags) > 0 ) {
     transpose_scratch_size = i_xgemm_desc->m * i_xgemm_desc->k * LIBXSMM_TYPESIZE(LIBXSMM_GETENUM_OUT(i_xgemm_desc->datatype));
     transpose_pad_size  = (transpose_scratch_size % 64 == 0) ? 0 : ((transpose_scratch_size + 63)/64) * 64 - transpose_scratch_size;
     transpose_scratch_size += transpose_pad_size;

--- a/src/generator_gemm_sse_avx_avx2_avx512.c
+++ b/src/generator_gemm_sse_avx_avx2_avx512.c
@@ -282,7 +282,6 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
         libxsmm_generator_transform_norm_to_normt_32bit_sse_microkernel( io_generated_code, io_loop_label_tracker,
                                                                          l_gp_reg_in, l_gp_reg_out, l_gp_reg_mloop, l_gp_reg_nloop,
                                                                         &l_mateltwise_kernel_config, l_mateltwise_desc );
-
     }
 
     /* stack management at the end (does nothing for my case?) for melt kernel */

--- a/src/generator_gemm_sse_avx_avx2_avx512.c
+++ b/src/generator_gemm_sse_avx_avx2_avx512.c
@@ -235,13 +235,13 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
     libxsmm_generator_gemm_setup_stack_frame( io_generated_code, i_xgemm_desc, i_gp_reg_mapping, &l_micro_kernel_config);
   }
 
-  // Local variables used only for older gemm setup (not LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI)
+  /* Local variables used only for older gemm setup (not LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI) */
   unsigned int l_trans_a_stack_size = 0;
-  unsigned int l_transpose_stack_register = LIBXSMM_X86_GP_REG_UNDEF; // for saving start of the A transpose allocated on the stack
+  unsigned int l_transpose_stack_register = LIBXSMM_X86_GP_REG_UNDEF; /* for saving start of the A transpose allocated on the stack */
 
   if (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_A) {
     if ( ((LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI & i_xgemm_desc->flags) != LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI) ) {
-      // Aligning the stack at 64-byte boundary
+      /* Aligning the stack at 64-byte boundary */
       unsigned int temp_reg = LIBXSMM_X86_GP_REG_R12;
       libxsmm_x86_instruction_alu_reg( io_generated_code, LIBXSMM_X86_INSTR_MOVQ, LIBXSMM_X86_GP_REG_RSP, temp_reg);
       libxsmm_x86_instruction_alu_imm( io_generated_code, LIBXSMM_X86_INSTR_ANDQ, temp_reg, 0x000000000000003F );
@@ -331,7 +331,7 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
     /* stack management at the end for meltw kernel */
     libxsmm_generator_meltw_destroy_stack_frame( io_generated_code, l_mateltwise_desc, &l_mateltwise_kernel_config );
 
-    // popping back R9, R8, RDI and RDX after transpose
+    /* popping back R9, R8, RDI and RDX after transpose */
     libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_R9 );
     libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_R8 );
     libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_RDI );
@@ -344,7 +344,7 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
     } else {
       libxsmm_generator_gemm_getval_stack_var( io_generated_code, &l_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_TRANSPOSE_PTR, LIBXSMM_X86_GP_REG_RDI );
     }
-  } // if A needs to be transposed
+  } /* if A needs to be transposed */
 
   /* calling gemm kernel with the modified pointer to the first matrix (now trans_a on the stack) should go here */
   /* at this point RDI must point to the first matrix (A or its transpose) in both trans_a = 0 and trans_a = 1 cases */
@@ -629,7 +629,7 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
       l_m_blocking = libxsmm_generator_gemm_sse_avx_avx2_avx512_update_m_blocking( &l_micro_kernel_config, l_xgemm_desc_opa, io_generated_code->arch, l_m_blocking );
     }
     libxsmm_generator_gemm_footer_nloop( io_generated_code, io_loop_label_tracker, i_gp_reg_mapping, &l_micro_kernel_config, l_xgemm_desc_opa, l_n_blocking, l_n_done );
-  } // while l_n_done
+  } /* while l_n_done */
 
   if ( ((LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI) ) {
     libxsmm_generator_gemm_destroy_stack_frame( io_generated_code, i_xgemm_desc, i_gp_reg_mapping, &l_micro_kernel_config );

--- a/src/generator_gemm_sse_avx_avx2_avx512.c
+++ b/src/generator_gemm_sse_avx_avx2_avx512.c
@@ -101,6 +101,7 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel_wrappe
   libxsmm_x86_instruction_close_stream_gemm( io_generated_code, &l_gp_reg_mapping, 0, i_xgemm_desc->prefetch );
 }
 
+#define ALIGN_STACK_64
 
 LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxsmm_generated_code*        io_generated_code,
                                                                            libxsmm_loop_label_tracker*    io_loop_label_tracker,
@@ -132,19 +133,31 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
     }
   }
 
+  /* in case when A needs to be transposed, we need to change temporarily the desciptor dimensions for gemm */
+  libxsmm_descriptor_blob l_blob_opa;
+  unsigned int lda_transpose = i_xgemm_desc->m;
+  const libxsmm_gemm_descriptor *const l_xgemm_desc_opa = (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_A ?
+      libxsmm_sgemm_descriptor_init(&l_blob_opa, i_xgemm_desc->m, i_xgemm_desc->n, i_xgemm_desc->k,
+        lda_transpose,
+        i_xgemm_desc->ldb,
+        i_xgemm_desc->ldc,
+        1. /*alpha* is unused but used in the BYPASS check? */, (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BETA_0 ? 0.0 : 1.0) /*beta is already in the flags?*/,
+        (unsigned int)((unsigned int)(i_xgemm_desc->flags) & (~LIBXSMM_GEMM_FLAG_TRANS_A)), i_xgemm_desc->prefetch)
+      : i_xgemm_desc);
+
   /* define the micro kernel code gen properties */
-  libxsmm_generator_gemm_init_micro_kernel_config_fullvector( &l_micro_kernel_config, io_generated_code->arch, i_xgemm_desc, 0 );
+  libxsmm_generator_gemm_init_micro_kernel_config_fullvector( &l_micro_kernel_config, io_generated_code->arch, l_xgemm_desc_opa, 0 );
 
   /* block according to the number of available registers or given limits */
-  if ( i_xgemm_desc->n == 7 && io_generated_code->arch >= LIBXSMM_X86_AVX512_CORE && io_generated_code->arch <= LIBXSMM_X86_ALLFEAT ) {
-    libxsmm_compute_equalized_blocking( i_xgemm_desc->n, 7, &(l_n_N[0]), &(l_n_n[0]), &(l_n_N[1]), &(l_n_n[1]) );
+  if ( l_xgemm_desc_opa->n == 7 && io_generated_code->arch >= LIBXSMM_X86_AVX512_CORE && io_generated_code->arch <= LIBXSMM_X86_ALLFEAT ) {
+    libxsmm_compute_equalized_blocking( l_xgemm_desc_opa->n, 7, &(l_n_N[0]), &(l_n_n[0]), &(l_n_N[1]), &(l_n_n[1]) );
   } else {
-    unsigned int max_n_blocking = libxsmm_generator_gemm_sse_avx_avx2_avx512_get_max_n_blocking( &l_micro_kernel_config, i_xgemm_desc, io_generated_code->arch );
+    unsigned int max_n_blocking = libxsmm_generator_gemm_sse_avx_avx2_avx512_get_max_n_blocking( &l_micro_kernel_config, l_xgemm_desc_opa, io_generated_code->arch );
 #if 1
     if (3 < max_n_blocking)
 #endif
     {
-      const unsigned int init_m_blocking = libxsmm_generator_gemm_sse_avx_avx2_avx512_get_initial_m_blocking( &l_micro_kernel_config, i_xgemm_desc, io_generated_code->arch );
+      const unsigned int init_m_blocking = libxsmm_generator_gemm_sse_avx_avx2_avx512_get_initial_m_blocking( &l_micro_kernel_config, l_xgemm_desc_opa, io_generated_code->arch );
       const unsigned int init_m_blocks = LIBXSMM_UPDIV(init_m_blocking, l_micro_kernel_config.vector_length);
 /* ************************ To DO refactor the if condition code ********************************/
       if(io_generated_code->arch == LIBXSMM_X86_AVX512_VL256 || io_generated_code->arch == LIBXSMM_X86_AVX512_VL256_CPX
@@ -162,7 +175,7 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
       LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_N_BLOCK );
       return;
     }
-    libxsmm_compute_equalized_blocking( i_xgemm_desc->n, max_n_blocking, &(l_n_N[0]), &(l_n_n[0]), &(l_n_N[1]), &(l_n_n[1]) );
+    libxsmm_compute_equalized_blocking( l_xgemm_desc_opa->n, max_n_blocking, &(l_n_N[0]), &(l_n_n[0]), &(l_n_N[1]), &(l_n_n[1]) );
   }
   /* check that l_n_N1 is non-zero */
   if ( l_n_N[0] == 0 ) {
@@ -170,9 +183,134 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
     return;
   }
 
+
+#ifndef NO_TRANSPOSE_PART
+  unsigned int l_trans_a_stack_size = 0;
+  unsigned int l_transpose_stack_register = LIBXSMM_X86_GP_REG_UNDEF; // for saving start of the A transpose allocated on the stack
+  if (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_TRANS_A) {
+    // QUESTION: Do we need to align rsp first to 16/32/64-byte boundary? By default it's 16-byte aligned, correct ? Yes, we need 64-byte for performance but
+    // default 16-byte alignment should be functionally correct
+    // Example for making it 64-byte aligned:
+    //unsigned int temp_reg                 = LIBXSMM_X86_GP_REG_R10;
+    //libxsmm_x86_instruction_alu_imm_i64( io_generated_code, i_micro_kernel_config->alu_mov_instruction, temp_reg, 0xFFFFFFFFFFFFFFC0 );
+    //libxsmm_x86_instruction_alu_reg( io_generated_code, LIBXSMM_X86_INSTR_ANDQ, temp_reg, LIBXSMM_X86_GP_REG_RSP);
+    // REMINDER:
+    // If RSP does not get aligned on 64-byte boundary, remember to override in the gemm descriptor aligned load with 0
+    // otherwise the GEMM might generate vmovaps
+    // If we do the 64-byte alignment, some extra step will be needed to avoid stack leakage?
+#ifdef ALIGN_STACK_64
+    unsigned int temp_reg = LIBXSMM_X86_GP_REG_R12;
+    libxsmm_x86_instruction_alu_reg( io_generated_code, LIBXSMM_X86_INSTR_MOVQ, LIBXSMM_X86_GP_REG_RSP, temp_reg);
+    libxsmm_x86_instruction_alu_imm( io_generated_code, LIBXSMM_X86_INSTR_ANDQ, temp_reg, 0x000000000000003F );
+    libxsmm_x86_instruction_alu_reg( io_generated_code, LIBXSMM_X86_INSTR_SUBQ, LIBXSMM_X86_GP_REG_RSP, temp_reg );
+    libxsmm_x86_instruction_push_reg( io_generated_code, temp_reg);
+#endif
+
+    /* allocate space on the stack */
+    l_trans_a_stack_size = i_xgemm_desc->m * i_xgemm_desc->k * LIBXSMM_TYPESIZE(LIBXSMM_GETENUM_OUT( i_xgemm_desc->datatype ));
+    libxsmm_x86_instruction_alu_imm( io_generated_code, LIBXSMM_X86_INSTR_SUBQ, LIBXSMM_X86_GP_REG_RSP, l_trans_a_stack_size );
+
+    /* saving start of the allocated stack space in a register which is not used in the transpose */
+    l_transpose_stack_register = LIBXSMM_X86_GP_REG_R11;
+    libxsmm_x86_instruction_alu_reg( io_generated_code, LIBXSMM_X86_INSTR_MOVQ, LIBXSMM_X86_GP_REG_RSP, l_transpose_stack_register);
+
+    /* pushing RDX, RCX, RDI, R8 and R9 to restore them later after transpose */
+    libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_RDX );
+    libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_RCX );
+    libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_RDI );
+    libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_R8 );
+    libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_R9 );
+
+    /* the libxsmm_generator_transform_norm_to_normt_64bit_avx512_microkernel() called below uses r8 for input and r9 for output */
+    /* so we set r8 and r9 accordingly */
+    libxsmm_x86_instruction_alu_reg( io_generated_code, LIBXSMM_X86_INSTR_MOVQ, LIBXSMM_X86_GP_REG_RDI, LIBXSMM_X86_GP_REG_R8);
+    libxsmm_x86_instruction_alu_reg( io_generated_code, LIBXSMM_X86_INSTR_MOVQ, l_transpose_stack_register, LIBXSMM_X86_GP_REG_R9);
+
+    /* creating a descriptor for the meltwise transform (transpose) */
+    // QUESTION: Are flags for meltwise same as for xgemm? Choice of init over init2 is good?
+    // QUESTION: Do we need to destroy any of the local two descriptors (for gemm or meltw)? Seems like no
+    libxsmm_descriptor_blob l_meltw_blob;
+    const libxsmm_meltw_descriptor *const l_mateltwise_desc = libxsmm_meltw_descriptor_init(&l_meltw_blob,
+      i_xgemm_desc->datatype/*in_type*/ /*, compute_type only for init2*/, i_xgemm_desc->datatype/*out_type*/,
+       /*LIBXSMM_DATATYPE_UNSUPPORTED, out2_type only for init2*/ i_xgemm_desc->k /*m*/, i_xgemm_desc->m /*n*/,
+      i_xgemm_desc->lda /*(ldi == NULL) ? m : *ldi*/, i_xgemm_desc->m/*(ldo == NULL) ? m : *ldo*/, /*0, 0, only for init2*/
+      i_xgemm_desc->flags /*(unsigned short)flags*/, LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_NORMT /*(unsigned short)type*/, LIBXSMM_MELTW_OPERATION_UNARY);
+
+    /* initializng required register variables for meltwise transform (transpose) */
+    unsigned int l_gp_reg_in  = LIBXSMM_X86_GP_REG_R8;
+    unsigned int l_gp_reg_out = LIBXSMM_X86_GP_REG_R9;
+    unsigned int l_gp_reg_mloop = LIBXSMM_X86_GP_REG_RAX;
+    unsigned int l_gp_reg_nloop = LIBXSMM_X86_GP_REG_RDX;
+    unsigned int l_gp_reg_mask = LIBXSMM_X86_GP_REG_R10;
+    unsigned int l_gp_reg_mask_2 = LIBXSMM_X86_GP_REG_R11;
+    unsigned int l_mask_reg_0 = 1;
+    unsigned int l_mask_reg_1 = 2;
+    unsigned int l_mask_reg_2 = 3;
+    unsigned int l_mask_reg_3 = 4;
+    unsigned int l_mask_reg_4 = 5;
+    unsigned int l_mask_reg_5 = 6;
+    unsigned int l_mask_reg_6 = 7;
+
+    /* define mateltwise kernel config */
+    libxsmm_mateltwise_kernel_config  l_mateltwise_kernel_config;
+    libxsmm_generator_mateltwise_init_micro_kernel_config_fullvector( io_generated_code, &l_mateltwise_kernel_config, l_mateltwise_desc);
+
+    /* define gp register mapping */
+    libxsmm_mateltwise_gp_reg_mapping l_mateltwise_gp_reg_mapping;
+    memset(&l_mateltwise_gp_reg_mapping, 0, sizeof(l_mateltwise_gp_reg_mapping));
+#if defined(_WIN32) || defined(__CYGWIN__)
+    l_mateltwise_gp_reg_mapping.gp_reg_param_struct = LIBXSMM_X86_GP_REG_RCX;
+#else /* match calling convention on Linux */
+    l_mateltwise_gp_reg_mapping.gp_reg_param_struct = LIBXSMM_X86_GP_REG_RDI;
+#endif
+
+    /* stack management at the start (does nothing for my case?) for meltw kernel */
+    libxsmm_generator_meltw_setup_stack_frame( io_generated_code, l_mateltwise_desc, &l_mateltwise_gp_reg_mapping, &l_mateltwise_kernel_config);
+
+    /* main transform (transpose) kernel generator call, dispatched over supported microkernel ISA */
+    if ( io_generated_code->arch >= LIBXSMM_X86_AVX512 ) {
+        libxsmm_generator_transform_norm_to_normt_32bit_avx512_microkernel( io_generated_code, io_loop_label_tracker,
+                                                                            l_gp_reg_in, l_gp_reg_out, l_gp_reg_mloop, l_gp_reg_nloop,
+                                                                            l_gp_reg_mask, l_gp_reg_mask_2, l_mask_reg_0, l_mask_reg_1, l_mask_reg_2, l_mask_reg_3,
+                                                                            l_mask_reg_4, l_mask_reg_5, l_mask_reg_6,
+                                                                            &l_mateltwise_kernel_config, l_mateltwise_desc );
+    } else if ( io_generated_code->arch >= LIBXSMM_X86_AVX ) {
+        libxsmm_generator_transform_norm_to_normt_32bit_avx_microkernel( io_generated_code, io_loop_label_tracker,
+                                                                         l_gp_reg_in, l_gp_reg_out, l_gp_reg_mloop, l_gp_reg_nloop,
+                                                                        &l_mateltwise_kernel_config, l_mateltwise_desc );
+    } else if ( (io_generated_code->arch >= LIBXSMM_X86_GENERIC) && (io_generated_code->arch < LIBXSMM_X86_AVX) ) {
+        libxsmm_generator_transform_norm_to_normt_32bit_sse_microkernel( io_generated_code, io_loop_label_tracker,
+                                                                         l_gp_reg_in, l_gp_reg_out, l_gp_reg_mloop, l_gp_reg_nloop,
+                                                                        &l_mateltwise_kernel_config, l_mateltwise_desc );
+
+    }
+
+    /* stack management at the end (does nothing for my case?) for melt kernel */
+    libxsmm_generator_meltw_destroy_stack_frame( io_generated_code, l_mateltwise_desc, &l_mateltwise_kernel_config );
+
+    // popping back R9, R8, RDI and RDX after transpose
+    libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_R9 );
+    libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_R8 );
+    libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_RDI );
+    libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_RCX );
+    libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_RDX );
+
+    /* setting RDI (pointer to A) for the gemm code to the transpose on the stack */
+#ifndef TRANSPOSE_BUT_NOT_USE
+    libxsmm_x86_instruction_alu_reg( io_generated_code, LIBXSMM_X86_INSTR_MOVQ, l_transpose_stack_register, LIBXSMM_X86_GP_REG_RDI);
+#endif
+  }
+#endif // for #ifndef NO_TRANSPOSE_PART
+
+  /* calling gemm kernel with the modified pointer to the first matrix (now trans_a on the stack) should go here */
+  /* at this point RDI must point to the first matrix (A or its transpose) in both trans_a = 0 and trans_a = 1 cases */
+#ifndef NO_GEMM_PART
+
+  libxsmm_reset_loop_label_tracker( io_loop_label_tracker );
+
   /* implementing load from struct */
-  if ( ((LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI) ||
-       ((LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI) ) {
+  if ( ((LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI & l_xgemm_desc_opa->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI) ||
+       ((LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI & l_xgemm_desc_opa->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI) ) {
     /* RDI holds the pointer to the strcut, so lets first move this one into R15 */
     libxsmm_x86_instruction_alu_reg( io_generated_code, LIBXSMM_X86_INSTR_MOVQ, i_gp_reg_mapping->gp_reg_param_struct, i_gp_reg_mapping->gp_reg_help_1 );
     /* A pointer */
@@ -184,7 +322,7 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
     /* C pointer */
     libxsmm_x86_instruction_alu_mem( io_generated_code, l_micro_kernel_config.alu_mov_instruction,
                                      i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 96, i_gp_reg_mapping->gp_reg_c, 0 );
-    if ( i_xgemm_desc->prefetch != LIBXSMM_GEMM_PREFETCH_NONE ) {
+    if ( l_xgemm_desc_opa->prefetch != LIBXSMM_GEMM_PREFETCH_NONE ) {
       /* A prefetch pointer */
       libxsmm_x86_instruction_alu_mem( io_generated_code, l_micro_kernel_config.alu_mov_instruction,
                                        i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 56, i_gp_reg_mapping->gp_reg_a_prefetch, 0 );
@@ -193,11 +331,11 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
                                        i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 88, i_gp_reg_mapping->gp_reg_b_prefetch, 0 );
     }
     /* batch reduce count & offsett arrays*/
-    if ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS) || (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE) || (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET)) {
+    if ((l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS) || (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE) || (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET)) {
       libxsmm_x86_instruction_alu_mem( io_generated_code, l_micro_kernel_config.alu_mov_instruction,
                                        i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 16, i_gp_reg_mapping->gp_reg_reduce_count, 0 );
 
-      if ( i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET ) {
+      if ( l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET ) {
         libxsmm_x86_instruction_alu_mem( io_generated_code, l_micro_kernel_config.alu_mov_instruction,
                                          i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 40, i_gp_reg_mapping->gp_reg_a_offset, 0 );
         libxsmm_x86_instruction_alu_mem( io_generated_code, l_micro_kernel_config.alu_mov_instruction,
@@ -205,7 +343,7 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
       }
     }
     /* loading scaling factor for tertenary C */
-    if ( (LIBXSMM_DATATYPE_I8 == LIBXSMM_GETENUM_INP( i_xgemm_desc->datatype )) && (LIBXSMM_DATATYPE_I8 == LIBXSMM_GETENUM_OUT( i_xgemm_desc->datatype )) ) {
+    if ( (LIBXSMM_DATATYPE_I8 == LIBXSMM_GETENUM_INP( l_xgemm_desc_opa->datatype )) && (LIBXSMM_DATATYPE_I8 == LIBXSMM_GETENUM_OUT( l_xgemm_desc_opa->datatype )) ) {
       libxsmm_x86_instruction_alu_mem( io_generated_code, l_micro_kernel_config.alu_mov_instruction,
                                        i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 112, i_gp_reg_mapping->gp_reg_scf, 0 );
     }
@@ -225,8 +363,8 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
   }
 
   /* generate hoisted BF16 emulation mask for AVX512 */
-  if ( (LIBXSMM_DATATYPE_BF16 == LIBXSMM_GETENUM_INP( i_xgemm_desc->datatype )) &&
-         ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_VNNI_A) > 0) &&
+  if ( (LIBXSMM_DATATYPE_BF16 == LIBXSMM_GETENUM_INP( l_xgemm_desc_opa->datatype )) &&
+         ((l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_VNNI_A) > 0) &&
          (io_generated_code->arch != LIBXSMM_X86_AVX512_CPX) &&
          (io_generated_code->arch >= LIBXSMM_X86_AVX512_VL256) &&
          (io_generated_code->arch <= LIBXSMM_X86_ALLFEAT) &&
@@ -239,7 +377,7 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
   }
 
   /* Load the actual batch-reduce trip count */
-  if ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS) || (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET) || (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE)) {
+  if ((l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS) || (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET) || (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE)) {
     libxsmm_x86_instruction_alu_mem( io_generated_code,
         l_micro_kernel_config.alu_mov_instruction,
         i_gp_reg_mapping->gp_reg_reduce_count,
@@ -250,7 +388,7 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
   }
 
   /* apply n_blocking */
-  while (l_n_done != (unsigned int)i_xgemm_desc->n) {
+  while (l_n_done != (unsigned int)l_xgemm_desc_opa->n) {
     unsigned int l_n_blocking = l_n_n[l_n_count];
     unsigned int l_m_done = 0;
     unsigned int l_m_done_old = 0;
@@ -264,10 +402,10 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
     l_n_count++;
 
     /* define the micro kernel code gen properties, especially m-blocking affects the vector instruction length */
-    l_m_blocking = libxsmm_generator_gemm_sse_avx_avx2_avx512_get_initial_m_blocking( &l_micro_kernel_config, i_xgemm_desc, io_generated_code->arch );
+    l_m_blocking = libxsmm_generator_gemm_sse_avx_avx2_avx512_get_initial_m_blocking( &l_micro_kernel_config, l_xgemm_desc_opa, io_generated_code->arch );
 
     /* apply m_blocking */
-    while (l_m_done != (unsigned int)i_xgemm_desc->m) {
+    while (l_m_done != (unsigned int)l_xgemm_desc_opa->m) {
       if ( l_m_blocking == 0 ) {
         LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_M_BLOCK );
         return;
@@ -275,26 +413,26 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
 
       if (l_m_done == 0) {
         /* This is a SeisSol Order 6, HSW, DP performance fix */
-        if ( ( io_generated_code->arch == LIBXSMM_X86_AVX2 ) && ( LIBXSMM_DATATYPE_F64 == LIBXSMM_GETENUM_INP( i_xgemm_desc->datatype ) ) ) {
+        if ( ( io_generated_code->arch == LIBXSMM_X86_AVX2 ) && ( LIBXSMM_DATATYPE_F64 == LIBXSMM_GETENUM_INP( l_xgemm_desc_opa->datatype ) ) ) {
           l_m_done_old = l_m_done;
-          if (i_xgemm_desc->m == 56) {
+          if (l_xgemm_desc_opa->m == 56) {
             l_m_done = 32;
           } else {
             LIBXSMM_ASSERT(0 != l_m_blocking);
             /* coverity[divide_by_zero] */
-            l_m_done = l_m_done + (((i_xgemm_desc->m - l_m_done_old) / l_m_blocking) * l_m_blocking);
+            l_m_done = l_m_done + (((l_xgemm_desc_opa->m - l_m_done_old) / l_m_blocking) * l_m_blocking);
           }
         } else {
           l_m_done_old = l_m_done;
           LIBXSMM_ASSERT(0 != l_m_blocking);
           /* coverity[divide_by_zero] */
-          l_m_done = l_m_done + (((i_xgemm_desc->m - l_m_done_old) / l_m_blocking) * l_m_blocking);
+          l_m_done = l_m_done + (((l_xgemm_desc_opa->m - l_m_done_old) / l_m_blocking) * l_m_blocking);
         }
       } else {
         l_m_done_old = l_m_done;
         LIBXSMM_ASSERT(0 != l_m_blocking);
         /* coverity[divide_by_zero] */
-        l_m_done = l_m_done + (((i_xgemm_desc->m - l_m_done_old) / l_m_blocking) * l_m_blocking);
+        l_m_done = l_m_done + (((l_xgemm_desc_opa->m - l_m_done_old) / l_m_blocking) * l_m_blocking);
       }
 
       if ( (l_m_done != l_m_done_old) && (l_m_done > 0) ) {
@@ -304,22 +442,23 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
           unsigned int l_corrected_vlen = l_micro_kernel_config.vector_length;
           unsigned int l_mask_count = l_corrected_vlen - ( l_m_blocking % l_corrected_vlen );
 
-          libxsmm_generator_gemm_initialize_avx512_mask( io_generated_code, i_gp_reg_mapping->gp_reg_help_1, i_xgemm_desc, l_mask_count );
+          libxsmm_generator_gemm_initialize_avx512_mask( io_generated_code, i_gp_reg_mapping->gp_reg_help_1, l_xgemm_desc_opa, l_mask_count );
         }
 
         libxsmm_generator_gemm_header_mloop( io_generated_code, io_loop_label_tracker, i_gp_reg_mapping, &l_micro_kernel_config, l_m_done_old, l_m_blocking );
-        libxsmm_generator_gemm_load_C( io_generated_code, i_gp_reg_mapping, &l_micro_kernel_config, i_xgemm_desc, l_m_blocking, l_n_blocking );
+        libxsmm_generator_gemm_load_C( io_generated_code, i_gp_reg_mapping, &l_micro_kernel_config, l_xgemm_desc_opa, l_m_blocking, l_n_blocking );
 
-        if ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS) || (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET) || (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE)) {
-          if ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET) || (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE)) {
+        if ((l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS) || (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET) || (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE)) {
+          if ((l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET) || (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE)) {
             libxsmm_x86_instruction_push_reg( io_generated_code, i_gp_reg_mapping->gp_reg_b);
             libxsmm_x86_instruction_push_reg( io_generated_code, i_gp_reg_mapping->gp_reg_a);
           }
           /* This is the reduce loop  */
           libxsmm_generator_gemm_header_reduceloop( io_generated_code, io_loop_label_tracker, i_gp_reg_mapping, &l_micro_kernel_config );
-          if (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS) {
+          if (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS) {
             libxsmm_x86_instruction_push_reg( io_generated_code, i_gp_reg_mapping->gp_reg_a);
             libxsmm_x86_instruction_push_reg( io_generated_code, i_gp_reg_mapping->gp_reg_b);
+
             if (adjust_A_pf_ptrs) {
               /* coverity[dead_error_line] */
               libxsmm_x86_instruction_push_reg( io_generated_code, i_gp_reg_mapping->gp_reg_a_prefetch );
@@ -362,7 +501,7 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
                   i_gp_reg_mapping->gp_reg_b_prefetch,
                   0 );
             }
-          } else if (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET) {
+          } else if (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET) {
             libxsmm_x86_instruction_pop_reg( io_generated_code, i_gp_reg_mapping->gp_reg_a);
             libxsmm_x86_instruction_pop_reg( io_generated_code, i_gp_reg_mapping->gp_reg_b);
             libxsmm_x86_instruction_push_reg( io_generated_code, i_gp_reg_mapping->gp_reg_b);
@@ -385,27 +524,27 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
                 i_gp_reg_mapping->gp_reg_help_0,
                 0 );
             libxsmm_x86_instruction_alu_reg( io_generated_code, l_micro_kernel_config.alu_add_instruction, i_gp_reg_mapping->gp_reg_help_0, i_gp_reg_mapping->gp_reg_b);
-          } else if (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE) {
+          } else if (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE) {
             libxsmm_x86_instruction_pop_reg( io_generated_code, i_gp_reg_mapping->gp_reg_a);
             libxsmm_x86_instruction_pop_reg( io_generated_code, i_gp_reg_mapping->gp_reg_b);
             libxsmm_x86_instruction_push_reg( io_generated_code, i_gp_reg_mapping->gp_reg_b);
             libxsmm_x86_instruction_push_reg( io_generated_code, i_gp_reg_mapping->gp_reg_a);
             /* Calculate to reg_a the proper address based on the reduce loop index  */
             libxsmm_x86_instruction_alu_reg( io_generated_code, l_micro_kernel_config.alu_mov_instruction, i_gp_reg_mapping->gp_reg_reduce_loop, i_gp_reg_mapping->gp_reg_help_0);
-            libxsmm_x86_instruction_alu_imm( io_generated_code, LIBXSMM_X86_INSTR_IMUL, i_gp_reg_mapping->gp_reg_help_0, i_xgemm_desc->c1);
+            libxsmm_x86_instruction_alu_imm( io_generated_code, LIBXSMM_X86_INSTR_IMUL, i_gp_reg_mapping->gp_reg_help_0, l_xgemm_desc_opa->c1);
             libxsmm_x86_instruction_alu_reg( io_generated_code, l_micro_kernel_config.alu_add_instruction, i_gp_reg_mapping->gp_reg_help_0, i_gp_reg_mapping->gp_reg_a);
             /* Calculate to reg_b the proper address based on the reduce loop index  */
             libxsmm_x86_instruction_alu_reg( io_generated_code, l_micro_kernel_config.alu_mov_instruction, i_gp_reg_mapping->gp_reg_reduce_loop, i_gp_reg_mapping->gp_reg_help_0);
-            libxsmm_x86_instruction_alu_imm( io_generated_code, LIBXSMM_X86_INSTR_IMUL, i_gp_reg_mapping->gp_reg_help_0, i_xgemm_desc->c2);
+            libxsmm_x86_instruction_alu_imm( io_generated_code, LIBXSMM_X86_INSTR_IMUL, i_gp_reg_mapping->gp_reg_help_0, l_xgemm_desc_opa->c2);
             libxsmm_x86_instruction_alu_reg( io_generated_code, l_micro_kernel_config.alu_add_instruction, i_gp_reg_mapping->gp_reg_help_0, i_gp_reg_mapping->gp_reg_b);
           }
         }
 
         libxsmm_generator_gemm_sse_avx_avx2_avx512_kloop( io_generated_code, io_loop_label_tracker, i_gp_reg_mapping, &l_micro_kernel_config,
-                                                           i_xgemm_desc, l_m_blocking, l_n_blocking );
+                                                           l_xgemm_desc_opa, l_m_blocking, l_n_blocking );
 
-        if ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS) || (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET) || (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE)) {
-          if (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS) {
+        if ((l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS) || (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET) || (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE)) {
+          if (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS) {
             if (adjust_B_pf_ptrs) {
               /* coverity[dead_error_begin] */
               libxsmm_x86_instruction_pop_reg( io_generated_code, i_gp_reg_mapping->gp_reg_help_0);
@@ -452,8 +591,8 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
             /* Move to reg_a the address of A_array  */
             libxsmm_x86_instruction_alu_reg( io_generated_code, l_micro_kernel_config.alu_mov_instruction, i_gp_reg_mapping->gp_reg_help_0, i_gp_reg_mapping->gp_reg_a);
           }
-          libxsmm_generator_gemm_footer_reduceloop( io_generated_code, io_loop_label_tracker, i_gp_reg_mapping, &l_micro_kernel_config, i_xgemm_desc);
-          if (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET) {
+          libxsmm_generator_gemm_footer_reduceloop( io_generated_code, io_loop_label_tracker, i_gp_reg_mapping, &l_micro_kernel_config, l_xgemm_desc_opa);
+          if (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET) {
             /* Calculate to reg_a the proper A advance form the microkernel */
             libxsmm_x86_instruction_alu_mem( io_generated_code,
                 l_micro_kernel_config.alu_mov_instruction,
@@ -476,16 +615,16 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
             libxsmm_x86_instruction_pop_reg( io_generated_code, i_gp_reg_mapping->gp_reg_help_0);
             libxsmm_x86_instruction_pop_reg( io_generated_code, i_gp_reg_mapping->gp_reg_help_0);
           }
-          if (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE) {
+          if (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE) {
             /* Calculate to reg_a the proper A advance form the microkernel */
             libxsmm_x86_instruction_alu_reg( io_generated_code, l_micro_kernel_config.alu_mov_instruction, i_gp_reg_mapping->gp_reg_reduce_count, i_gp_reg_mapping->gp_reg_help_0);
-            libxsmm_x86_instruction_alu_imm( io_generated_code, LIBXSMM_X86_INSTR_IMUL, i_gp_reg_mapping->gp_reg_help_0, i_xgemm_desc->c1);
-            libxsmm_x86_instruction_alu_imm( io_generated_code, l_micro_kernel_config.alu_sub_instruction, i_gp_reg_mapping->gp_reg_help_0, i_xgemm_desc->c1);
+            libxsmm_x86_instruction_alu_imm( io_generated_code, LIBXSMM_X86_INSTR_IMUL, i_gp_reg_mapping->gp_reg_help_0, l_xgemm_desc_opa->c1);
+            libxsmm_x86_instruction_alu_imm( io_generated_code, l_micro_kernel_config.alu_sub_instruction, i_gp_reg_mapping->gp_reg_help_0, l_xgemm_desc_opa->c1);
             libxsmm_x86_instruction_alu_reg( io_generated_code, l_micro_kernel_config.alu_sub_instruction, i_gp_reg_mapping->gp_reg_help_0, i_gp_reg_mapping->gp_reg_a);
             /* Calculate to reg_b the proper B advance form the microkernel */
             libxsmm_x86_instruction_alu_reg( io_generated_code, l_micro_kernel_config.alu_mov_instruction, i_gp_reg_mapping->gp_reg_reduce_count, i_gp_reg_mapping->gp_reg_help_0);
-            libxsmm_x86_instruction_alu_imm( io_generated_code, LIBXSMM_X86_INSTR_IMUL, i_gp_reg_mapping->gp_reg_help_0, i_xgemm_desc->c2);
-            libxsmm_x86_instruction_alu_imm( io_generated_code, l_micro_kernel_config.alu_sub_instruction, i_gp_reg_mapping->gp_reg_help_0, i_xgemm_desc->c2);
+            libxsmm_x86_instruction_alu_imm( io_generated_code, LIBXSMM_X86_INSTR_IMUL, i_gp_reg_mapping->gp_reg_help_0, l_xgemm_desc_opa->c2);
+            libxsmm_x86_instruction_alu_imm( io_generated_code, l_micro_kernel_config.alu_sub_instruction, i_gp_reg_mapping->gp_reg_help_0, l_xgemm_desc_opa->c2);
             libxsmm_x86_instruction_alu_reg( io_generated_code, l_micro_kernel_config.alu_sub_instruction, i_gp_reg_mapping->gp_reg_help_0, i_gp_reg_mapping->gp_reg_b);
             /* Consume the last two pushes form the stack */
             libxsmm_x86_instruction_pop_reg( io_generated_code, i_gp_reg_mapping->gp_reg_help_0);
@@ -493,21 +632,39 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
           }
         }
 
-        libxsmm_generator_gemm_store_C( io_generated_code, i_gp_reg_mapping, &l_micro_kernel_config, i_xgemm_desc, l_m_blocking, l_n_blocking );
-        libxsmm_generator_gemm_footer_mloop( io_generated_code, io_loop_label_tracker, i_gp_reg_mapping, &l_micro_kernel_config, i_xgemm_desc, l_m_blocking, l_m_done );
+        libxsmm_generator_gemm_store_C( io_generated_code, i_gp_reg_mapping, &l_micro_kernel_config, l_xgemm_desc_opa, l_m_blocking, l_n_blocking );
+        libxsmm_generator_gemm_footer_mloop( io_generated_code, io_loop_label_tracker, i_gp_reg_mapping, &l_micro_kernel_config, l_xgemm_desc_opa, l_m_blocking, l_m_done );
       }
 
       /* switch to next smaller m_blocking */
-      l_m_blocking = libxsmm_generator_gemm_sse_avx_avx2_avx512_update_m_blocking( &l_micro_kernel_config, i_xgemm_desc, io_generated_code->arch, l_m_blocking );
+      l_m_blocking = libxsmm_generator_gemm_sse_avx_avx2_avx512_update_m_blocking( &l_micro_kernel_config, l_xgemm_desc_opa, io_generated_code->arch, l_m_blocking );
     }
-    libxsmm_generator_gemm_footer_nloop( io_generated_code, io_loop_label_tracker, i_gp_reg_mapping, &l_micro_kernel_config, i_xgemm_desc, l_n_blocking, l_n_done );
+    libxsmm_generator_gemm_footer_nloop( io_generated_code, io_loop_label_tracker, i_gp_reg_mapping, &l_micro_kernel_config, l_xgemm_desc_opa, l_n_blocking, l_n_done );
+  } // while l_n_done
+
+#endif // #ifndef  NO_GEMM_PART
+  ////////////***************************************** End of gemm kernel copy ********************************
+
+#ifndef NO_TRANSPOSE_PART
+  if (l_xgemm_desc_opa->flags & LIBXSMM_GEMM_FLAG_TRANS_A) {
+      /* cleaning up the stack memory */
+
+      /* cleaning up the space for transpose */
+      libxsmm_x86_instruction_alu_imm( io_generated_code, LIBXSMM_X86_INSTR_ADDQ, LIBXSMM_X86_GP_REG_RSP, l_trans_a_stack_size );
+
+#ifdef ALIGN_STACK_64
+      /* removing the extra offset applied to RSP to 64-byte boundary */
+      unsigned int temp_reg = LIBXSMM_X86_GP_REG_R12;
+      libxsmm_x86_instruction_pop_reg( io_generated_code, temp_reg);
+      libxsmm_x86_instruction_alu_reg( io_generated_code, LIBXSMM_X86_INSTR_ADDQ, LIBXSMM_X86_GP_REG_RSP, temp_reg );
+#endif
   }
+#endif // for ifdef NO_TRANPOSE_PART
 
   if ( ((LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI) ) {
     libxsmm_generator_gemm_destroy_stack_frame( io_generated_code, i_xgemm_desc, i_gp_reg_mapping, &l_micro_kernel_config );
   }
 }
-
 
 LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kloop( libxsmm_generated_code*            io_generated_code,
                                                                            libxsmm_loop_label_tracker*        io_loop_label_tracker,

--- a/src/generator_gemm_sse_avx_avx2_avx512.c
+++ b/src/generator_gemm_sse_avx_avx2_avx512.c
@@ -148,6 +148,41 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
   /* define the micro kernel code gen properties */
   libxsmm_generator_gemm_init_micro_kernel_config_fullvector( &l_micro_kernel_config, io_generated_code->arch, l_xgemm_desc_opa, 0 );
 
+  /* block according to the number of available registers or given limits */
+  if ( l_xgemm_desc_opa->n == 7 && io_generated_code->arch >= LIBXSMM_X86_AVX512_CORE && io_generated_code->arch <= LIBXSMM_X86_ALLFEAT ) {
+    libxsmm_compute_equalized_blocking( l_xgemm_desc_opa->n, 7, &(l_n_N[0]), &(l_n_n[0]), &(l_n_N[1]), &(l_n_n[1]) );
+  } else {
+    unsigned int max_n_blocking = libxsmm_generator_gemm_sse_avx_avx2_avx512_get_max_n_blocking( &l_micro_kernel_config, l_xgemm_desc_opa, io_generated_code->arch );
+#if 1
+    if (3 < max_n_blocking)
+#endif
+    {
+      const unsigned int init_m_blocking = libxsmm_generator_gemm_sse_avx_avx2_avx512_get_initial_m_blocking( &l_micro_kernel_config, l_xgemm_desc_opa, io_generated_code->arch );
+      const unsigned int init_m_blocks = LIBXSMM_UPDIV(init_m_blocking, l_micro_kernel_config.vector_length);
+/* ************************ To DO refactor the if condition code ********************************/
+      if(io_generated_code->arch == LIBXSMM_X86_AVX512_VL256 || io_generated_code->arch == LIBXSMM_X86_AVX512_VL256_CPX
+          || io_generated_code->arch == LIBXSMM_X86_AVX512_VL256_CLX){
+        while ((init_m_blocks * max_n_blocking + max_n_blocking + 1) > l_micro_kernel_config.vector_reg_count) {
+          max_n_blocking--;
+        }
+      } else {
+        while ((init_m_blocks * max_n_blocking + init_m_blocks + 1) > l_micro_kernel_config.vector_reg_count) {
+          max_n_blocking--;
+        }
+      }
+    }
+    if ( max_n_blocking == 0 ) {
+      LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_N_BLOCK );
+      return;
+    }
+    libxsmm_compute_equalized_blocking( l_xgemm_desc_opa->n, max_n_blocking, &(l_n_N[0]), &(l_n_n[0]), &(l_n_N[1]), &(l_n_n[1]) );
+  }
+  /* check that l_n_N1 is non-zero */
+  if ( l_n_N[0] == 0 ) {
+    LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_N_BLOCK );
+    return;
+  }
+
   /* implementing load from struct */
   if ( ((LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI & l_xgemm_desc_opa->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI) ||
        ((LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI & l_xgemm_desc_opa->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI) ) {
@@ -195,41 +230,6 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
         return;
       }
     }
-  }
-
-  /* block according to the number of available registers or given limits */
-  if ( l_xgemm_desc_opa->n == 7 && io_generated_code->arch >= LIBXSMM_X86_AVX512_CORE && io_generated_code->arch <= LIBXSMM_X86_ALLFEAT ) {
-    libxsmm_compute_equalized_blocking( l_xgemm_desc_opa->n, 7, &(l_n_N[0]), &(l_n_n[0]), &(l_n_N[1]), &(l_n_n[1]) );
-  } else {
-    unsigned int max_n_blocking = libxsmm_generator_gemm_sse_avx_avx2_avx512_get_max_n_blocking( &l_micro_kernel_config, l_xgemm_desc_opa, io_generated_code->arch );
-#if 1
-    if (3 < max_n_blocking)
-#endif
-    {
-      const unsigned int init_m_blocking = libxsmm_generator_gemm_sse_avx_avx2_avx512_get_initial_m_blocking( &l_micro_kernel_config, l_xgemm_desc_opa, io_generated_code->arch );
-      const unsigned int init_m_blocks = LIBXSMM_UPDIV(init_m_blocking, l_micro_kernel_config.vector_length);
-/* ************************ To DO refactor the if condition code ********************************/
-      if(io_generated_code->arch == LIBXSMM_X86_AVX512_VL256 || io_generated_code->arch == LIBXSMM_X86_AVX512_VL256_CPX
-          || io_generated_code->arch == LIBXSMM_X86_AVX512_VL256_CLX){
-        while ((init_m_blocks * max_n_blocking + max_n_blocking + 1) > l_micro_kernel_config.vector_reg_count) {
-          max_n_blocking--;
-        }
-      } else {
-        while ((init_m_blocks * max_n_blocking + init_m_blocks + 1) > l_micro_kernel_config.vector_reg_count) {
-          max_n_blocking--;
-        }
-      }
-    }
-    if ( max_n_blocking == 0 ) {
-      LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_N_BLOCK );
-      return;
-    }
-    libxsmm_compute_equalized_blocking( l_xgemm_desc_opa->n, max_n_blocking, &(l_n_N[0]), &(l_n_n[0]), &(l_n_N[1]), &(l_n_n[1]) );
-  }
-  /* check that l_n_N1 is non-zero */
-  if ( l_n_N[0] == 0 ) {
-    LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_N_BLOCK );
-    return;
   }
 
 #ifndef NO_TRANSPOSE_PART

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-dev/kvoronin/stack_transpose_gemm-1.17-2166
+dev/kvoronin/stack_transpose_gemm-1.17-2168

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-dev/kvoronin/stack_transpose_gemm-1.17-2164
+dev/kvoronin/stack_transpose_gemm-1.17-2165

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-dev/kvoronin/stack_transpose_gemm-1.17-2165
+dev/kvoronin/stack_transpose_gemm-1.17-2166

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-enable_gemm_in_eqs-1.17-2153
+dev/kvoronin/stack_transpose_gemm-1.17-2164


### PR DESCRIPTION
Summary:
Adding a stack transpose as a means to enable GEMM with trans_a = 1. For transposing on the stack, meltwise transform generator is used. Currently only for SP, AVX512.

Note:
A not-really-clean version to initiate a code review and understand what should be the desired final state (hoisting the changes to libxsmm_generator_gemm_kernel if we want to enable trans_a for a wider configuration scope?).

Testing:
Code has been only tested for functional correctness on just a couple of problems with square and rectangular A. More will be needed before merging. 