### PR TITLE
GEMM Fusion / GEMMs in Equations / CNN TPPfy (#573)

### DIFF
--- a/include/libxsmm.h
+++ b/include/libxsmm.h
@@ -554,10 +554,12 @@ LIBXSMM_API int libxsmm_matrix_eqn_push_back_arg( const libxsmm_blasint idx, con
 LIBXSMM_API int libxsmm_matrix_eqn_push_back_unary_op( const libxsmm_blasint idx, const libxsmm_meltw_unary_type type, const libxsmm_meltw_unary_flags flags, const libxsmm_datatype dtype );
 LIBXSMM_API int libxsmm_matrix_eqn_push_back_binary_op( const libxsmm_blasint idx, const libxsmm_meltw_binary_type type, const libxsmm_meltw_binary_flags flags, const libxsmm_datatype dtype );
 LIBXSMM_API int libxsmm_matrix_eqn_push_back_ternary_op( const libxsmm_blasint idx, const libxsmm_meltw_ternary_type type, const libxsmm_meltw_ternary_flags flags, const libxsmm_datatype dtype );
-LIBXSMM_API int libxsmm_matrix_eqn_push_back_arg_v2( const libxsmm_blasint idx, const libxsmm_meqn_arg_shape arg_shape, const libxsmm_blasint in_pos, const libxsmm_blasint offs_in_pos );
-LIBXSMM_API int libxsmm_matrix_eqn_push_back_unary_op_v2( const libxsmm_blasint idx, const libxsmm_meltw_unary_type unary_type, const libxsmm_datatype dtype, const libxsmm_bitfield unary_flags );
-LIBXSMM_API int libxsmm_matrix_eqn_push_back_binary_op_v2( const libxsmm_blasint idx, const libxsmm_meltw_binary_type binary_type, const libxsmm_datatype dtype, const libxsmm_bitfield binary_flags );
-LIBXSMM_API int libxsmm_matrix_eqn_push_back_ternary_op_v2( const libxsmm_blasint idx, const libxsmm_meltw_ternary_type ternary_type, const libxsmm_datatype dtype, const libxsmm_bitfield ternary_flags );
+
+LIBXSMM_API int libxsmm_matrix_eqn_push_back_arg_v2( const libxsmm_matrix_eqn_arg_metadata arg_metadata, const libxsmm_meqn_arg_shape arg_shape, libxsmm_matrix_arg_attributes arg_attr);
+LIBXSMM_API int libxsmm_matrix_eqn_push_back_unary_op_v2( const libxsmm_matrix_eqn_op_metadata op_metadata, const libxsmm_meltw_unary_type type, const libxsmm_datatype dtype, const libxsmm_bitfield flags);
+LIBXSMM_API int libxsmm_matrix_eqn_push_back_binary_op_v2( const libxsmm_matrix_eqn_op_metadata op_metadata, const libxsmm_meltw_binary_type type, const libxsmm_datatype dtype, const libxsmm_bitfield flags);
+LIBXSMM_API int libxsmm_matrix_eqn_push_back_ternary_op_v2( const libxsmm_matrix_eqn_op_metadata op_metadata, const libxsmm_meltw_ternary_type type, const libxsmm_datatype dtype, const libxsmm_bitfield flags);
+
 LIBXSMM_API void libxsmm_matrix_eqn_tree_print( const libxsmm_blasint idx );
 LIBXSMM_API void libxsmm_matrix_eqn_rpn_print( const libxsmm_blasint idx );
 LIBXSMM_API libxsmm_matrix_eqn_function libxsmm_dispatch_matrix_eqn_desc( const libxsmm_meqn_descriptor* descriptor );

--- a/include/libxsmm_typedefs.h
+++ b/include/libxsmm_typedefs.h
@@ -309,7 +309,13 @@ typedef enum libxsmm_meltw_unary_type {
   LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_PADNM_MOD2         = 41,
   LIBXSMM_MELTW_TYPE_UNARY_QUANT                        = 42,
   LIBXSMM_MELTW_TYPE_UNARY_DEQUANT                      = 43,
-  LIBXSMM_MELTW_TYPE_UNARY_REDUCE_COLS_IDX              = 44
+  LIBXSMM_MELTW_TYPE_UNARY_REDUCE_COLS_IDX              = 44,
+  LIBXSMM_MELTW_TYPE_UNARY_DECOMPRESS_SPARSE_FACTOR_1   = 45,
+  LIBXSMM_MELTW_TYPE_UNARY_DECOMPRESS_SPARSE_FACTOR_2   = 46,
+  LIBXSMM_MELTW_TYPE_UNARY_DECOMPRESS_SPARSE_FACTOR_4   = 47,
+  LIBXSMM_MELTW_TYPE_UNARY_DECOMPRESS_SPARSE_FACTOR_8   = 48,
+  LIBXSMM_MELTW_TYPE_UNARY_DECOMPRESS_SPARSE_FACTOR_16  = 49,
+  LIBXSMM_MELTW_TYPE_UNARY_DECOMPRESS_SPARSE_FACTOR_32  = 50
 } libxsmm_meltw_unary_type;
 
 typedef enum libxsmm_meltw_binary_flags {
@@ -331,21 +337,36 @@ typedef enum libxsmm_meltw_binary_type {
   LIBXSMM_MELTW_TYPE_BINARY_MULADD      =  5,
   LIBXSMM_MELTW_TYPE_BINARY_MATMUL      =  6,
   LIBXSMM_MELTW_TYPE_BINARY_MUL_AND_REDUCE_TO_SCALAR_OP_ADD = 7,
-  LIBXSMM_MELTW_TYPE_BINARY_PACK        =  8
+  LIBXSMM_MELTW_TYPE_BINARY_PACK        =  8,
+  LIBXSMM_MELTW_TYPE_BINARY_BRGEMM                       =  9,
+  LIBXSMM_MELTW_TYPE_BINARY_BRGEMM_B_TRANS               =  10,
+  LIBXSMM_MELTW_TYPE_BINARY_BRGEMM_A_TRANS               =  11,
+  LIBXSMM_MELTW_TYPE_BINARY_BRGEMM_A_TRANS_B_TRANS       =  12,
+  LIBXSMM_MELTW_TYPE_BINARY_BRGEMM_A_VNNI                =  13,
+  LIBXSMM_MELTW_TYPE_BINARY_BRGEMM_A_VNNI_B_TRANS        =  14,
+  LIBXSMM_MELTW_TYPE_BINARY_BRGEMM_A_VNNI_TRANS          =  15,
+  LIBXSMM_MELTW_TYPE_BINARY_BRGEMM_A_VNNI_TRANS_B_TRANS  =  16,
+  LIBXSMM_MELTW_TYPE_BINARY_MATMUL_B_TRANS               =  17,
+  LIBXSMM_MELTW_TYPE_BINARY_MATMUL_A_TRANS               =  18,
+  LIBXSMM_MELTW_TYPE_BINARY_MATMUL_A_TRANS_B_TRANS       =  19,
+  LIBXSMM_MELTW_TYPE_BINARY_MATMUL_A_VNNI                =  20,
+  LIBXSMM_MELTW_TYPE_BINARY_MATMUL_A_VNNI_B_TRANS        =  21,
+  LIBXSMM_MELTW_TYPE_BINARY_MATMUL_A_VNNI_TRANS          =  22,
+  LIBXSMM_MELTW_TYPE_BINARY_MATMUL_A_VNNI_TRANS_B_TRANS  =  23
 } libxsmm_meltw_binary_type;
 
 typedef enum libxsmm_meltw_ternary_flags {
-  LIBXSMM_MELTW_FLAG_TERNARY_NONE              =   0,
-  LIBXSMM_MELTW_FLAG_TERNARY_BCAST_ROW_IN_0    =   1,
-  LIBXSMM_MELTW_FLAG_TERNARY_BCAST_ROW_IN_1    =   2,
-  LIBXSMM_MELTW_FLAG_TERNARY_BCAST_ROW_IN_2    =   4,
-  LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_0    =   8,
+  LIBXSMM_MELTW_FLAG_TERNARY_NONE              =  0,
+  LIBXSMM_MELTW_FLAG_TERNARY_BCAST_ROW_IN_0    =  1,
+  LIBXSMM_MELTW_FLAG_TERNARY_BCAST_ROW_IN_1    =  2,
+  LIBXSMM_MELTW_FLAG_TERNARY_BCAST_ROW_IN_2    =  4,
+  LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_0    =  8,
   LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_1    =  16,
   LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_2    =  32,
   LIBXSMM_MELTW_FLAG_TERNARY_BCAST_SCALAR_IN_0 =  64,
-  LIBXSMM_MELTW_FLAG_TERNARY_BCAST_SCALAR_IN_1 = 128,
-  LIBXSMM_MELTW_FLAG_TERNARY_BCAST_SCALAR_IN_2 = 256,
-  LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT = 512
+  LIBXSMM_MELTW_FLAG_TERNARY_BCAST_SCALAR_IN_1 =  128,
+  LIBXSMM_MELTW_FLAG_TERNARY_BCAST_SCALAR_IN_2 =  256,
+  LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT =  512
 } libxsmm_meltw_ternary_flags;
 
 typedef enum libxsmm_meltw_ternary_type {
@@ -353,7 +374,22 @@ typedef enum libxsmm_meltw_ternary_type {
   LIBXSMM_MELTW_TYPE_TERNARY_MULADD      =  1,
   LIBXSMM_MELTW_TYPE_TERNARY_MATMUL      =  2,
   LIBXSMM_MELTW_TYPE_TERNARY_BLEND       =  3,
-  LIBXSMM_MELTW_TYPE_TERNARY_NMULADD     =  4
+  LIBXSMM_MELTW_TYPE_TERNARY_NMULADD     =  4,
+  LIBXSMM_MELTW_TYPE_TERNARY_BRGEMM                       =  5,
+  LIBXSMM_MELTW_TYPE_TERNARY_BRGEMM_B_TRANS               =  6,
+  LIBXSMM_MELTW_TYPE_TERNARY_BRGEMM_A_TRANS               =  7,
+  LIBXSMM_MELTW_TYPE_TERNARY_BRGEMM_A_TRANS_B_TRANS       =  8,
+  LIBXSMM_MELTW_TYPE_TERNARY_BRGEMM_A_VNNI                =  9,
+  LIBXSMM_MELTW_TYPE_TERNARY_BRGEMM_A_VNNI_B_TRANS        =  10,
+  LIBXSMM_MELTW_TYPE_TERNARY_BRGEMM_A_VNNI_TRANS          =  11,
+  LIBXSMM_MELTW_TYPE_TERNARY_BRGEMM_A_VNNI_TRANS_B_TRANS  =  12,
+  LIBXSMM_MELTW_TYPE_TERNARY_MATMUL_B_TRANS               =  13,
+  LIBXSMM_MELTW_TYPE_TERNARY_MATMUL_A_TRANS               =  14,
+  LIBXSMM_MELTW_TYPE_TERNARY_MATMUL_A_TRANS_B_TRANS       =  15,
+  LIBXSMM_MELTW_TYPE_TERNARY_MATMUL_A_VNNI                =  16,
+  LIBXSMM_MELTW_TYPE_TERNARY_MATMUL_A_VNNI_B_TRANS        =  17,
+  LIBXSMM_MELTW_TYPE_TERNARY_MATMUL_A_VNNI_TRANS          =  18,
+  LIBXSMM_MELTW_TYPE_TERNARY_MATMUL_A_VNNI_TRANS_B_TRANS  =  19
 } libxsmm_meltw_ternary_type;
 
 LIBXSMM_EXTERN_C typedef union LIBXSMM_RETARGETABLE libxsmm_xmelt_flags {
@@ -746,6 +782,35 @@ LIBXSMM_EXTERN_C typedef struct LIBXSMM_RETARGETABLE libxsmm_meltw_opreduce_vecs
   void* argop_off_vec_0;
   void* argop_off_vec_1;
 } libxsmm_meltw_opreduce_vecs_idx_param;
+
+typedef enum libxsmm_matrix_arg_type {
+  LIBXSMM_MATRIX_ARG_TYPE_SINGULAR = 0,
+  LIBXSMM_MATRIX_ARG_TYPE_SET      = 1
+} libxsmm_matrix_arg_type;
+
+typedef enum libxsmm_matrix_arg_set_type {
+  LIBXSMM_MATRIX_ARG_SET_TYPE_NONE        = 0,
+  LIBXSMM_MATRIX_ARG_SET_TYPE_ABS_ADDRESS = 1,
+  LIBXSMM_MATRIX_ARG_SET_TYPE_OFFSET_BASE = 2,
+  LIBXSMM_MATRIX_ARG_SET_TYPE_STRIDE_BASE = 3
+} libxsmm_matrix_arg_set_type;
+
+LIBXSMM_EXTERN_C typedef struct LIBXSMM_RETARGETABLE libxsmm_matrix_arg_attributes {
+  libxsmm_matrix_arg_type     type;
+  libxsmm_matrix_arg_set_type set_type;
+  libxsmm_blasint             set_cardinality_hint;
+  libxsmm_blasint             set_stride_hint;
+} libxsmm_matrix_arg_attributes;
+
+LIBXSMM_EXTERN_C typedef struct LIBXSMM_RETARGETABLE libxsmm_matrix_eqn_op_metadata {
+  libxsmm_blasint eqn_idx;
+  libxsmm_blasint op_arg_pos;
+} libxsmm_matrix_eqn_op_metadata;
+
+LIBXSMM_EXTERN_C typedef struct LIBXSMM_RETARGETABLE libxsmm_matrix_eqn_arg_metadata {
+  libxsmm_blasint eqn_idx;
+  libxsmm_blasint in_arg_pos;
+} libxsmm_matrix_eqn_arg_metadata;
 
 /** argument struct for matrix-eltwise: unary */
 LIBXSMM_EXTERN_C typedef struct LIBXSMM_RETARGETABLE libxsmm_meltw_unary_param {

--- a/samples/deeplearning/common/dnn_common.h
+++ b/samples/deeplearning/common/dnn_common.h
@@ -1060,6 +1060,169 @@ LIBXSMM_INLINE void matrix_copy_KCCK_to_CKKC_bf16(libxsmm_bfloat16 *src, libxsmm
   }
 }
 
+LIBXSMM_INLINE void tensor_copy_NCHW_to_NCHWc(float *src, float *dst, int N, int C, int H, int W, int bc)
+{
+  int n, h, w, c1, c2;
+  int cBlocks = C/bc;
+  LIBXSMM_VLA_DECL(4, float, in, src, C, H, W);
+  LIBXSMM_VLA_DECL(5, float,out, dst, cBlocks, H, W, bc);
+
+#if defined(_OPENMP)
+  LIBXSMM_OMP_VAR(c2); LIBXSMM_OMP_VAR(h); LIBXSMM_OMP_VAR(w);
+# pragma omp parallel for private(c1,c2,h,w)
+#endif
+  for (n = 0; n < N; n++) {
+    for (c1 = 0; c1 < cBlocks; c1++) {
+      for (c2 = 0; c2 < bc; c2++) {
+        for (h = 0; h < H; h++) {
+          for (w = 0; w < W; w++) {
+            LIBXSMM_VLA_ACCESS(5, out, n, c1,       h, w, c2, cBlocks, H, W, bc) =
+            LIBXSMM_VLA_ACCESS(4, in,  n, c1*bc+c2, h, w, C, H, W);
+          }
+        }
+      }
+    }
+  }
+}
+
+LIBXSMM_INLINE void tensor_pollute_rim_NCHWc(float *dst, int N, int C, int H, int W, int bc, int pad_h, int pad_w, float polute_val)
+{
+  int n, h, w, c1, c2;
+  int cBlocks = C/bc;
+  LIBXSMM_VLA_DECL(5, float,out, dst, cBlocks, H, W, bc);
+
+#if defined(_OPENMP)
+  LIBXSMM_OMP_VAR(c2); LIBXSMM_OMP_VAR(h); LIBXSMM_OMP_VAR(w);
+# pragma omp parallel for private(c1,c2,h,w)
+#endif
+  for (n = 0; n < N; n++) {
+    for (c1 = 0; c1 < cBlocks; c1++) {
+      for (h = 0; h < H; h++) {
+        for (w = 0; w < W; w++) {
+          for (c2 = 0; c2 < bc; c2++) {
+            if ( (h < pad_h) || (h >= H-pad_h)) {
+              LIBXSMM_VLA_ACCESS(5, out, n, c1, h, w, c2, cBlocks, H, W, bc) = polute_val;
+            } else {
+              if ( (w < pad_w) || (w >= W-pad_w)) {
+                LIBXSMM_VLA_ACCESS(5, out, n, c1, h, w, c2, cBlocks, H, W, bc) = polute_val;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+LIBXSMM_INLINE void tensor_copy_NCHWc_to_NCHW(float *src, float *dst, int N, int C, int H, int W, int bc)
+{
+  int n, h, w, c1, c2;
+  int cBlocks = C/bc;
+  LIBXSMM_VLA_DECL(4, float,out, dst, C, H, W);
+  LIBXSMM_VLA_DECL(5, float, in, src, cBlocks, H, W, bc);
+
+#if defined(_OPENMP)
+  LIBXSMM_OMP_VAR(c1); LIBXSMM_OMP_VAR(c2); LIBXSMM_OMP_VAR(h); LIBXSMM_OMP_VAR(w);
+# pragma omp parallel for private(c1,c2,h,w)
+#endif
+  for (n = 0; n < N; n++) {
+    for (c1 = 0; c1 < cBlocks; c1++) {
+      for (c2 = 0; c2 < bc; c2++) {
+        for (h = 0; h < H; h++) {
+          for (w = 0; w < W; w++) {
+            LIBXSMM_VLA_ACCESS(4,out,  n, c1*bc+c2, h, w, C, H, W) =
+            LIBXSMM_VLA_ACCESS(5, in, n, c1,       h, w, c2, cBlocks, H, W, bc);
+          }
+        }
+      }
+    }
+  }
+}
+
+LIBXSMM_INLINE void tensor_copy_KCRS_to_KCRSck(float *src, float *dst, int K, int C, int R, int S, int bc, int bk)
+{
+  int k1, k2, c1, c2, r, s;
+  int cBlocks = C/bc;
+  int kBlocks = K/bk;
+  LIBXSMM_VLA_DECL(4, float, in, src, C, R, S);
+  LIBXSMM_VLA_DECL(6, float,out, dst, cBlocks, R, S, bc, bk);
+
+#if defined(_OPENMP)
+  LIBXSMM_OMP_VAR(c1); LIBXSMM_OMP_VAR(c2); LIBXSMM_OMP_VAR(r); LIBXSMM_OMP_VAR(s);
+# pragma omp parallel for private(k2,c1,c2,r,s)
+#endif
+  for (k1 = 0; k1 < kBlocks; k1++) {
+    for (k2 = 0; k2 < bk; k2++) {
+      for (c1 = 0; c1 < cBlocks; c1++) {
+        for (c2 = 0; c2 < bc; c2++) {
+          for (r = 0; r < R; r++) {
+            for (s = 0; s < S; s++) {
+              LIBXSMM_VLA_ACCESS(6, out, k1,     c1,         r, s, c2, k2, cBlocks, R, S, bc, bk) =
+              LIBXSMM_VLA_ACCESS(4, in,  k1*bk+k2, c1*bc+c2, r, s, C, R, S);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+LIBXSMM_INLINE void tensor_copy_KCRSck_to_KCRS(float *src, float *dst, int K, int C, int R, int S, int bc, int bk)
+{
+  int k1, k2, c1, c2, r, s;
+  int cBlocks = C/bc;
+  int kBlocks = K/bk;
+  LIBXSMM_VLA_DECL(4, float, out, dst, C, R, S);
+  LIBXSMM_VLA_DECL(6, float,  in, src, cBlocks, R, S, bc, bk);
+
+#if defined(_OPENMP)
+  LIBXSMM_OMP_VAR(c1); LIBXSMM_OMP_VAR(c2); LIBXSMM_OMP_VAR(r); LIBXSMM_OMP_VAR(s);
+# pragma omp parallel for private(k2,c1,c2,r,s)
+#endif
+  for (k1 = 0; k1 < kBlocks; k1++) {
+    for (k2 = 0; k2 < bk; k2++) {
+      for (c1 = 0; c1 < cBlocks; c1++) {
+        for (c2 = 0; c2 < bc; c2++) {
+          for (r = 0; r < R; r++) {
+            for (s = 0; s < S; s++) {
+              LIBXSMM_VLA_ACCESS(4, out,  k1*bk+k2, c1*bc+c2, r, s, C, R, S) =
+                LIBXSMM_VLA_ACCESS(6, in, k1,     c1,         r, s, c2, k2, cBlocks, R, S, bc, bk);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+LIBXSMM_INLINE void tensor_transpose_KCRCck_to_CKRSkc(float *src, float *dst, int K, int C, int R, int S, int bc, int bk)
+{
+  int k1, k2, c1, c2, r, s;
+  int cBlocks = C/bc;
+  int kBlocks = K/bk;
+  LIBXSMM_VLA_DECL(6, float, out, dst, kBlocks, R, S, bk, bc);
+  LIBXSMM_VLA_DECL(6, float, in , src, cBlocks, R, S, bc, bk);
+
+#if defined(_OPENMP)
+  LIBXSMM_OMP_VAR(c1); LIBXSMM_OMP_VAR(c2); LIBXSMM_OMP_VAR(r); LIBXSMM_OMP_VAR(s);
+# pragma omp parallel for private(k2,c1,c2,r,s)
+#endif
+  for (k1 = 0; k1 < kBlocks; k1++) {
+    for (k2 = 0; k2 < bk; k2++) {
+      for (c1 = 0; c1 < cBlocks; c1++) {
+        for (c2 = 0; c2 < bc; c2++) {
+          for (r = 0; r < R; r++) {
+            for (s = 0; s < S; s++) {
+              LIBXSMM_VLA_ACCESS(6, out, c1, k1, R-1-r, S-1-s, k2, c2, kBlocks, R, S, bk, bc) =
+              LIBXSMM_VLA_ACCESS(6,  in, k1, c1, r, s, c2, k2, cBlocks, R, S, bc, bk);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 LIBXSMM_INLINE void matrix_add(int size, float *a, float *b, float *c)
 {
   int i;
@@ -1524,6 +1687,89 @@ LIBXSMM_INLINE void naive_conv_fp(naive_conv_t* param, const float* input, float
         }
       }
 #endif
+    }
+  }
+}
+
+LIBXSMM_INLINE void naive_fused_conv_fp(naive_conv_t* param, const float* input, float* output, const float* filter, const float* bias, libxsmm_blasint fuse_type)
+{
+  int nImg      = param->nImg;
+  int nIfm      = param->nIfm;
+  int nOfm      = param->nOfm;
+  int ifhp      = param->ifhp;
+  int ifwp      = param->ifwp;
+  int ofhp      = param->ofhp;
+  int ofwp      = param->ofwp;
+  int ifh       = param->ifh;
+  int ifw       = param->ifw;
+  int ofh       = param->ofh;
+  int ofw       = param->ofw;
+  int pad_h     = param->pad_h;
+  int pad_w     = param->pad_w;
+  int pad_h_in  = param->pad_h_in;
+  int pad_w_in  = param->pad_w_in;
+  int pad_h_out = param->pad_h_out;
+  int pad_w_out = param->pad_w_out;
+  int kh        = param->kh;
+  int kw        = param->kw;
+  int stride_h  = param->stride_h;
+  int stride_w  = param->stride_w;
+  /* loop counters */
+  int img, ofm, ifm, oj, oi, ij, ii, kj, ki;
+
+  LIBXSMM_VLA_DECL(4,       float, output_t, output + (pad_h_out * ofwp + pad_w_out), nOfm, ofhp, ofwp);
+  LIBXSMM_VLA_DECL(4, const float,  input_t,  input + (pad_h_in * ifwp + pad_w_in), nIfm, ifhp, ifwp);
+  LIBXSMM_VLA_DECL(4, const float, filter_t, filter, nIfm, kh, kw);
+
+
+  if (fuse_type == 1 || fuse_type == 3) {
+#if defined(_OPENMP)
+# pragma omp parallel for LIBXSMM_OPENMP_COLLAPSE(2) private(img, ofm, ifm, oj, oi, ij, ii, kj, ki)
+#endif
+    for (img = 0; img < nImg; ++img) {
+      for (ofm = 0; ofm < nOfm; ++ofm) {
+        for (oj = 0; oj < ofh; ++oj) {
+          for (oi = 0; oi < ofw; ++oi) {
+            LIBXSMM_VLA_ACCESS(  4, output_t, img, ofm, oj, oi, nOfm, ofhp, ofwp) += bias[ofm];
+          }
+        }
+      }
+    }
+  }
+
+
+#if defined(_OPENMP)
+  LIBXSMM_OMP_VAR(img); LIBXSMM_OMP_VAR(ofm); LIBXSMM_OMP_VAR(oj);  LIBXSMM_OMP_VAR(oi);
+  LIBXSMM_OMP_VAR(ifm); LIBXSMM_OMP_VAR(ij);  LIBXSMM_OMP_VAR(ii);  LIBXSMM_OMP_VAR(kj);  LIBXSMM_OMP_VAR(ki);
+# pragma omp parallel for LIBXSMM_OPENMP_COLLAPSE(2) private(img, ofm, ifm, oj, oi, ij, ii, kj, ki)
+#endif
+  for (img = 0; img < nImg; ++img) {
+    for (ofm = 0; ofm < nOfm; ++ofm) {
+      for (ifm = 0; ifm < nIfm; ++ifm) {
+        for (oj = 0; oj < ofh; ++oj) {
+          ij = oj * stride_h - pad_h;
+          for (oi = 0; oi < ofw; ++oi) {
+            ii = oi * stride_w - pad_w;
+            for (kj = 0; kj < kh; ++kj) {
+              if (ij+kj < 0 || ij+kj >= ifh) continue;
+              for (ki = 0; ki < kw; ++ki) {
+                if (ii+ki < 0 || ii+ki >= ifw) continue;
+                LIBXSMM_VLA_ACCESS(  4, output_t, img, ofm, oj, oi, nOfm, ofhp, ofwp) +=
+                  LIBXSMM_VLA_ACCESS(4,  input_t, img, ifm, ij + kj, ii + ki, nIfm, ifhp, ifwp)
+                  * LIBXSMM_VLA_ACCESS(4, filter_t, ofm, ifm, kj, ki, nIfm, kh, kw);
+              }
+            }
+          }
+        }
+      }
+      if (fuse_type == 2 || fuse_type == 3) {
+        for (oj = 0; oj < ofh; ++oj) {
+          for (oi = 0; oi < ofw; ++oi) {
+            LIBXSMM_VLA_ACCESS(  4, output_t, img, ofm, oj, oi, nOfm, ofhp, ofwp) =
+              (LIBXSMM_VLA_ACCESS(  4, output_t, img, ofm, oj, oi, nOfm, ofhp, ofwp) < 0.0f) ? 0.0f : LIBXSMM_VLA_ACCESS(  4, output_t, img, ofm, oj, oi, nOfm, ofhp, ofwp);
+          }
+        }
+      }
     }
   }
 }

--- a/samples/equation/Makefile
+++ b/samples/equation/Makefile
@@ -37,7 +37,7 @@ COBJCTS := $(patsubst %,$(BLDDIR)/%,$(notdir $(CSOURCS:.c=-c.o)))
 SOURCES := $(CPPSRCS) $(CXXSRCS) $(CCXSRCS) $(CSOURCS)
 OBJECTS := $(CPPOBJS) $(CXXOBJS) $(CCXOBJS) $(COBJCTS)
 MODULES := $(addsuffix .mod,$(basename $(FTNSRCS))) $(addsuffix .modmic,$(basename $(FTNSRCS)))
-XFILES := $(OUTDIR)/equation_simple $(OUTDIR)/equation_softmax $(OUTDIR)/equation_layernorm $(OUTDIR)/equation_groupnorm $(OUTDIR)/equation_batchnorm $(OUTDIR)/equation_splitSGD
+XFILES := $(OUTDIR)/equation_simple $(OUTDIR)/equation_matmul $(OUTDIR)/equation_softmax $(OUTDIR)/equation_layernorm $(OUTDIR)/equation_groupnorm $(OUTDIR)/equation_batchnorm $(OUTDIR)/equation_splitSGD
 .PHONY: all
 all: $(XFILES)
 
@@ -46,6 +46,9 @@ compile: $(OBJECTS)
 
 $(OUTDIR)/equation_simple: $(OUTDIR)/.make $(BLDDIR)/equation_simple-c.o $(LIBDEP)
 	$(LD) -o $@ $(BLDDIR)/equation_simple-c.o $(MAINLIB) $(SLDFLAGS) $(LDFLAGS) $(CLDFLAGS)
+
+$(OUTDIR)/equation_matmul: $(OUTDIR)/.make $(BLDDIR)/equation_matmul-c.o $(LIBDEP)
+	$(LD) -o $@ $(BLDDIR)/equation_matmul-c.o $(MAINLIB) $(SLDFLAGS) $(LDFLAGS) $(CLDFLAGS)
 
 $(OUTDIR)/equation_softmax: $(OUTDIR)/.make $(BLDDIR)/equation_softmax-c.o $(LIBDEP)
 	$(LD) -o $@ $(BLDDIR)/equation_softmax-c.o $(MAINLIB) $(SLDFLAGS) $(LDFLAGS) $(CLDFLAGS)

--- a/samples/equation/equation_batchnorm.c
+++ b/samples/equation/equation_batchnorm.c
@@ -1098,8 +1098,8 @@ int main( int argc, char* argv[] ) {
   tmp_ld2 = 1;
 
   my_eqn10 = libxsmm_matrix_eqn_create();                                                        /* y = (s*x + b)*gamma + beta */
-  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn10, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_1 | LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_2 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32 );
-  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn10, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_1 | LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_2 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32 );
+  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn10, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_1 | LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_2 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32);
+  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn10, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_1 | LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_2 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32);
   libxsmm_matrix_eqn_push_back_arg( my_eqn10, CB, HW/num_HW_blocks, ld, 0, 0, in_dt );                         /* x = [HW, CB] */
   libxsmm_matrix_eqn_push_back_arg( my_eqn10, CB, 1, tmp_ld, 1, 0, LIBXSMM_DATATYPE_F32 );       /* s = [CB] */
   libxsmm_matrix_eqn_push_back_arg( my_eqn10, CB, 1, tmp_ld, 2, 0, LIBXSMM_DATATYPE_F32 );       /* b = [CB] */
@@ -1204,7 +1204,7 @@ int main( int argc, char* argv[] ) {
   libxsmm_matrix_eqn_push_back_binary_op(my_eqn11, LIBXSMM_MELTW_TYPE_BINARY_ADD, LIBXSMM_MELTW_FLAG_BINARY_NONE, LIBXSMM_DATATYPE_F32);                   /* dgamma = ((inp *a + b) * dout) + dgamma */
   libxsmm_matrix_eqn_push_back_unary_op(my_eqn11, LIBXSMM_MELTW_TYPE_UNARY_REDUCE_X_OP_ADD, LIBXSMM_MELTW_FLAG_UNARY_REDUCE_COLS, LIBXSMM_DATATYPE_F32);   /* [HW, CB] -> [CB] */
   libxsmm_matrix_eqn_push_back_binary_op(my_eqn11, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_NONE, LIBXSMM_DATATYPE_F32);                   /* ((inp *a + b) * dout) */
-  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn11, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_1 | LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_2 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32 );
+  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn11, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_1 | LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_2 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32);
   libxsmm_matrix_eqn_push_back_arg( my_eqn11, CB, HW/num_HW_blocks, ld, 0, 0, in_dt );          /* inp [HW, CB] */
   libxsmm_matrix_eqn_push_back_arg( my_eqn11, CB, 1, 1, 1, 0, LIBXSMM_DATATYPE_F32 );           /* a [CB] */
   libxsmm_matrix_eqn_push_back_arg( my_eqn11, CB, 1, 1, 2, 0, LIBXSMM_DATATYPE_F32 );           /* b [CB] */
@@ -1234,10 +1234,10 @@ int main( int argc, char* argv[] ) {
 
   /* din long equation */
   my_eqn16 = libxsmm_matrix_eqn_create();                                                       /* din = a * dout + (b * inp + c) */
-  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn16, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_0 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32 );
+  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn16, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_0 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32);
   libxsmm_matrix_eqn_push_back_arg( my_eqn16, CB, 1, 1, 1, 0, LIBXSMM_DATATYPE_F32 );           /* a [CB] */
   libxsmm_matrix_eqn_push_back_arg( my_eqn16, CB, HW/num_HW_blocks, ld, 3, 0, in_dt );          /* dout [HW, CB] */
-  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn16, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_1 | LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_2 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32 );
+  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn16, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_1 | LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_2 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32);
   libxsmm_matrix_eqn_push_back_arg( my_eqn16, CB, HW/num_HW_blocks, ld, 0, 0, in_dt );          /* inp [HW, CB] */
   libxsmm_matrix_eqn_push_back_arg( my_eqn16, CB, 1, 1, 2, 0, LIBXSMM_DATATYPE_F32 );           /* b [CB] */
   libxsmm_matrix_eqn_push_back_arg( my_eqn16, CB, 1, 1, 7, 0, LIBXSMM_DATATYPE_F32 );           /* c [CB] */

--- a/samples/equation/equation_groupnorm.c
+++ b/samples/equation/equation_groupnorm.c
@@ -1235,8 +1235,8 @@ int main( int argc, char* argv[] ) {
   tmp_ld = 1;
   tmp_ld2 = 1;
   my_eqn10 = libxsmm_matrix_eqn_create();                                                        /* y = (s*x + b)*gamma + beta */
-  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn10, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_1 | LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_2 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32 );
-  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn10, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_1 | LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_2 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32 );
+  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn10, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_1 | LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_2 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32);
+  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn10, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_1 | LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_2 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32);
   libxsmm_matrix_eqn_push_back_arg( my_eqn10, CB, HW/num_HW_blocks, ld, 0, 0, in_dt );                         /* x = [HW, CB] */
   libxsmm_matrix_eqn_push_back_arg( my_eqn10, CB, 1, tmp_ld, 1, 0, LIBXSMM_DATATYPE_F32 );       /* s = [CB] */
   libxsmm_matrix_eqn_push_back_arg( my_eqn10, CB, 1, tmp_ld, 2, 0, LIBXSMM_DATATYPE_F32 );       /* b = [CB] */
@@ -1332,7 +1332,7 @@ int main( int argc, char* argv[] ) {
   libxsmm_matrix_eqn_push_back_binary_op(my_eqn11, LIBXSMM_MELTW_TYPE_BINARY_ADD, LIBXSMM_MELTW_FLAG_BINARY_NONE, LIBXSMM_DATATYPE_F32);                   /* dgamma = ((inp *a + b) * dout) + dgamma */
   libxsmm_matrix_eqn_push_back_unary_op(my_eqn11, LIBXSMM_MELTW_TYPE_UNARY_REDUCE_X_OP_ADD, LIBXSMM_MELTW_FLAG_UNARY_REDUCE_COLS, LIBXSMM_DATATYPE_F32);   /* [HW, CB] -> [CB] */
   libxsmm_matrix_eqn_push_back_binary_op(my_eqn11, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_NONE, LIBXSMM_DATATYPE_F32);                   /* ((inp *a + b) * dout) */
-  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn11, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_1 | LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_2 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32 );
+  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn11, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_1 | LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_2 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32);
   libxsmm_matrix_eqn_push_back_arg( my_eqn11, CB, HW/num_HW_blocks, ld, 0, 0, in_dt );                        /* inp [HW, CB] */
   libxsmm_matrix_eqn_push_back_arg( my_eqn11, CB, 1, 1, 1, 0, LIBXSMM_DATATYPE_F32 );           /* a [CB] */
   libxsmm_matrix_eqn_push_back_arg( my_eqn11, CB, 1, 1, 2, 0, LIBXSMM_DATATYPE_F32 );           /* b [CB] */
@@ -1372,12 +1372,12 @@ int main( int argc, char* argv[] ) {
 
   /* din equation */
   my_eqn15 = libxsmm_matrix_eqn_create();                                                       /* din = ((gamma * a) * dout) + (inp * b + c) */
-  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn15, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_0 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32 );
+  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn15, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_0 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32);
   libxsmm_matrix_eqn_push_back_binary_op( my_eqn15, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_NONE, LIBXSMM_DATATYPE_F32 );
   libxsmm_matrix_eqn_push_back_arg( my_eqn15, CB, 1, 1, 6, 0, in_dt );                          /* gamma [CB] */
   libxsmm_matrix_eqn_push_back_arg( my_eqn15, CB, 1, 1, 1, 0, LIBXSMM_DATATYPE_F32 );           /* a [CB] */
   libxsmm_matrix_eqn_push_back_arg( my_eqn15, CB, HW/num_HW_blocks, ld, 3, 0, in_dt );                        /* dout [HW, CB] */
-  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn15, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_1 | LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_2 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32 );
+  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn15, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_1 | LIBXSMM_MELTW_FLAG_TERNARY_BCAST_COL_IN_2 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32);
   libxsmm_matrix_eqn_push_back_arg( my_eqn15, CB, HW/num_HW_blocks, ld, 0, 0, in_dt );                        /* inp [HW, CB] */
   libxsmm_matrix_eqn_push_back_arg( my_eqn15, CB, 1, 1, 2, 0, LIBXSMM_DATATYPE_F32 );           /* b [CB] */
   libxsmm_matrix_eqn_push_back_arg( my_eqn15, CB, 1, 1, 7, 0, LIBXSMM_DATATYPE_F32 );           /* c [CB] */

--- a/samples/equation/equation_layernorm.c
+++ b/samples/equation/equation_layernorm.c
@@ -836,12 +836,12 @@ int main( int argc, char* argv[] ) {
 
   /* din equation */
   my_eqn5 = libxsmm_matrix_eqn_create();
-  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn5, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32 );
+  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn5, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32);
   libxsmm_matrix_eqn_push_back_binary_op( my_eqn5, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_1, LIBXSMM_DATATYPE_F32 );
   libxsmm_matrix_eqn_push_back_arg( my_eqn5, S3, S1, tmp_ld, 6, 0, in_dt );
   libxsmm_matrix_eqn_push_back_arg( my_eqn5, 1, 1, 1, 1, 0, LIBXSMM_DATATYPE_F32 );
   libxsmm_matrix_eqn_push_back_arg( my_eqn5, S3, S1, ld, 3, 0, in_dt );
-  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn5, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_SCALAR_IN_1 | LIBXSMM_MELTW_FLAG_TERNARY_BCAST_SCALAR_IN_2 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32 );
+  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn5, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_SCALAR_IN_1 | LIBXSMM_MELTW_FLAG_TERNARY_BCAST_SCALAR_IN_2 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32);
   libxsmm_matrix_eqn_push_back_arg( my_eqn5, S3, S1, ld, 0, 0, in_dt );
   libxsmm_matrix_eqn_push_back_arg( my_eqn5, 1, 1, 1, 2, 0, LIBXSMM_DATATYPE_F32 );
   libxsmm_matrix_eqn_push_back_arg( my_eqn5, 1, 1, 1, 7, 0, LIBXSMM_DATATYPE_F32 );

--- a/samples/equation/equation_matmul.c
+++ b/samples/equation/equation_matmul.c
@@ -1,0 +1,994 @@
+/******************************************************************************
+* Copyright (c) Intel Corporation - All rights reserved.                      *
+* This file is part of the LIBXSMM library.                                   *
+*                                                                             *
+* For information on the license, see the LICENSE file.                       *
+* Further information: https://github.com/hfp/libxsmm/                        *
+* SPDX-License-Identifier: BSD-3-Clause                                       *
+******************************************************************************/
+/* Evangelos Georganas (Intel Corp.)
+******************************************************************************/
+#include <libxsmm.h>
+#include <libxsmm_sync.h>
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <math.h>
+#if defined(_OPENMP)
+# include <omp.h>
+#endif
+
+float fsigmoid(float x) {
+  return (LIBXSMM_TANHF(x/2.0f) + 1.0f)/2.0f;
+}
+
+float upconvert_bf16(libxsmm_bfloat16 x) {
+  union libxsmm_bfloat16_hp bf16_hp;
+  bf16_hp.i[1] = x;
+  bf16_hp.i[0] = 0;
+  return bf16_hp.f;
+}
+
+float gelu(float x) {
+  return (LIBXSMM_ERFF(x/LIBXSMM_SQRTF(2.0f)) + 1.0f)*0.5f*x;
+}
+
+void gemm_fp32(float *A, float *B, float *C, float beta,
+              libxsmm_blasint m, libxsmm_blasint n, libxsmm_blasint k,
+              libxsmm_blasint lda, libxsmm_blasint ldb, libxsmm_blasint ldc,
+              libxsmm_blasint brgemm_count, libxsmm_blasint str_a, libxsmm_blasint str_b) {
+
+  libxsmm_blasint i, j, l, br, br_count;
+
+  if (brgemm_count <= 0) {
+    br_count = 1;
+  } else {
+    br_count = brgemm_count;
+  }
+
+  for (j = 0; j < n; j++) {
+    for (i = 0; i < m; i++) {
+      if (beta == 0) {
+        C[i + j * ldc] = 0.0;
+      }
+      for (br = 0; br < br_count; br++) {
+        for (l = 0; l < k; l++) {
+          C[i + j * ldc] += A[i + l * lda + br * str_a] * B[l + j * ldb + br * str_b];
+        }
+      }
+    }
+  }
+}
+
+void gemm_bf16(libxsmm_bfloat16 *A, libxsmm_bfloat16 *B, libxsmm_bfloat16 *C, libxsmm_bfloat16 beta,
+              libxsmm_blasint m, libxsmm_blasint n, libxsmm_blasint k,
+              libxsmm_blasint lda, libxsmm_blasint ldb, libxsmm_blasint ldc,
+              libxsmm_blasint brgemm_count, libxsmm_blasint str_a, libxsmm_blasint str_b) {
+
+  libxsmm_blasint i, j, l, br, br_count;
+
+  if (brgemm_count <= 0) {
+    br_count = 1;
+  } else {
+    br_count = brgemm_count;
+  }
+
+  for (j = 0; j < n; j++) {
+    for (i = 0; i < m; i++) {
+      float acc = 0.0;
+      if (beta == 0) {
+        C[i + j * ldc] = 0;
+      }
+      acc = upconvert_bf16(C[i + j * ldc]);
+      for (br = 0; br < br_count; br++) {
+        for (l = 0; l < k; l++) {
+          acc +=  upconvert_bf16(A[i + l * lda + br * str_a]) * upconvert_bf16(B[l + j * ldb + br * str_b]);
+        }
+      }
+      libxsmm_rne_convert_fp32_bf16( &acc, &C[i + j * ldc], 1 );
+    }
+  }
+}
+
+void eqn0_f32(float *Out, libxsmm_blasint m, libxsmm_blasint n, libxsmm_blasint ld,
+              float *A, libxsmm_blasint m_A, libxsmm_blasint n_A, libxsmm_blasint lda,
+              float *B, libxsmm_blasint m_B, libxsmm_blasint n_B, libxsmm_blasint ldb,
+              float *C, libxsmm_blasint m_C, libxsmm_blasint n_C, libxsmm_blasint ldc,
+              float *D, libxsmm_blasint m_D, libxsmm_blasint n_D, libxsmm_blasint ldd ) {
+ /*
+  *
+  * Result = gelu(A+B) * tanh(C x D)
+  *
+  */
+
+  libxsmm_blasint i, j;
+  float tmp[m_C * n_D];
+
+  gemm_fp32(C, D, tmp, 0,
+            m_C, n_D, n_C,
+            ldc, ldd, m_C,
+            0, 0, 0);
+  for (j = 0; j < n; j++) {
+    for (i = 0; i < m; i++) {
+      Out[i + j * ld] = gelu(A[i + j * lda] + B[i + j *ldb]) * LIBXSMM_TANHF(tmp[i + j * m_C]);
+    }
+  }
+}
+
+void eqn1_f32(float *Out, libxsmm_blasint m, libxsmm_blasint n, libxsmm_blasint ld,
+              float *A, libxsmm_blasint m_A, libxsmm_blasint n_A, libxsmm_blasint lda,
+              float *B, libxsmm_blasint m_B, libxsmm_blasint n_B, libxsmm_blasint ldb, libxsmm_blasint brgemm_count,
+              float *C, libxsmm_blasint m_C, libxsmm_blasint n_C, libxsmm_blasint ldc, libxsmm_blasint stride_a,
+              float *D, libxsmm_blasint m_D, libxsmm_blasint n_D, libxsmm_blasint ldd, libxsmm_blasint stride_b ) {
+ /*
+  *
+  * Result = gelu(A) * tanh( B + Sum Ci x Di )
+  *
+  */
+
+  libxsmm_blasint i, j;
+  float tmp[m_C * n_D];
+
+  gemm_fp32(C, D, B, 1.0,
+            m_C, n_D, n_C,
+            ldc, ldd, ldb,
+            brgemm_count, stride_a, stride_b);
+
+  for (j = 0; j < n; j++) {
+    for (i = 0; i < m; i++) {
+      Out[i + j * ld] = gelu(A[i + j * lda]) * LIBXSMM_TANHF(B[i + j * ldb]);
+    }
+  }
+}
+
+void eqn2_f32(float *Out, libxsmm_blasint m, libxsmm_blasint n, libxsmm_blasint ld,
+              float *A, libxsmm_blasint m_A, libxsmm_blasint n_A, libxsmm_blasint lda,
+              float *B, libxsmm_blasint m_B, libxsmm_blasint n_B, libxsmm_blasint ldb, libxsmm_blasint brgemm_count,
+              float *C, libxsmm_blasint m_C, libxsmm_blasint n_C, libxsmm_blasint ldc, libxsmm_blasint stride_a,
+              float *D, libxsmm_blasint m_D, libxsmm_blasint n_D, libxsmm_blasint ldd, libxsmm_blasint stride_b ) {
+ /*
+  *
+  * Result = gelu(A) * tanh( Sum Ci x Di )
+  *
+  */
+
+  libxsmm_blasint i, j;
+  float tmp[m_C * n_D];
+
+  gemm_fp32(C, D, tmp, 0,
+            m_C, n_D, n_C,
+            ldc, ldd, m_C,
+            brgemm_count, stride_a, stride_b);
+
+  for (j = 0; j < n; j++) {
+    for (i = 0; i < m; i++) {
+      Out[i + j * ld] = gelu(A[i + j * lda]) + LIBXSMM_TANHF(tmp[i + j * m_C]);
+    }
+  }
+}
+
+void eqn3_f32(float *Out, libxsmm_blasint m, libxsmm_blasint n, libxsmm_blasint ld,
+              float *A, libxsmm_blasint m_A, libxsmm_blasint n_A, libxsmm_blasint lda,
+              float *B, libxsmm_blasint m_B, libxsmm_blasint n_B, libxsmm_blasint ldb, libxsmm_blasint brgemm_count,
+              float *C, libxsmm_blasint m_C, libxsmm_blasint n_C, libxsmm_blasint ldc, libxsmm_blasint stride_a,
+              float *D, libxsmm_blasint m_D, libxsmm_blasint n_D, libxsmm_blasint ldd, libxsmm_blasint stride_b ) {
+
+  /* Result = Sum(Ci x Di) + gelu(A) */
+
+  libxsmm_blasint i, j;
+  float tmp[m_C * n_D];
+
+  gemm_fp32(C, D, tmp, 0,
+            m_C, n_D, n_C,
+            ldc, ldd, m_C,
+            brgemm_count, stride_a, stride_b);
+
+  for (j = 0; j < n; j++) {
+    for (i = 0; i < m; i++) {
+      Out[i + j * ld] = gelu(A[i + j * lda]) + tmp[i + j * m_C];
+    }
+  }
+}
+
+void eqn4_f32(float *Out, libxsmm_blasint m, libxsmm_blasint n, libxsmm_blasint ld,
+              float *A, libxsmm_blasint m_A, libxsmm_blasint n_A, libxsmm_blasint lda,
+              float *B, libxsmm_blasint m_B, libxsmm_blasint n_B, libxsmm_blasint ldb, libxsmm_blasint brgemm_count,
+              float *C, libxsmm_blasint m_C, libxsmm_blasint n_C, libxsmm_blasint ldc, libxsmm_blasint stride_a,
+              float *D, libxsmm_blasint m_D, libxsmm_blasint n_D, libxsmm_blasint ldd, libxsmm_blasint stride_b,
+              float *colbias, int relu_sigmoid_fusion_mode ) {
+
+  /* Result =  sigmoid( Sum(Ci x Di) + colbias + 1.0) */
+
+  libxsmm_blasint i, j;
+  float tmp[m_C * n_D];
+
+  gemm_fp32(C, D, tmp, 0,
+            m_C, n_D, n_C,
+            ldc, ldd, m_C,
+            brgemm_count, stride_a, stride_b);
+
+  if (relu_sigmoid_fusion_mode == 0) {
+    for (j = 0; j < n; j++) {
+      for (i = 0; i < m; i++) {
+        Out[i + j * ld] = tmp[j *m_C + i] + colbias[i] + 1.0;
+      }
+    }
+  } else if (relu_sigmoid_fusion_mode == 1) {
+    for (j = 0; j < n; j++) {
+      for (i = 0; i < m; i++) {
+        Out[i + j * ld] = LIBXSMM_MAX(0.0, tmp[j *m_C + i] + colbias[i] + 1.0);
+      }
+    }
+  } else if (relu_sigmoid_fusion_mode == 2) {
+    for (j = 0; j < n; j++) {
+      for (i = 0; i < m; i++) {
+        Out[i + j * ld] = fsigmoid(tmp[j *m_C + i] + colbias[i] + 1.0);
+      }
+    }
+  }
+}
+
+int main( int argc, char* argv[] ) {
+  libxsmm_blasint my_eqn0, my_eqn1, my_eqn2, my_eqn3, my_eqn4, my_eqn5;
+  libxsmm_matrix_eqn_function func0, func1, func2, func3, func4, func5;
+  libxsmm_blasint i, j, k, l, it;
+  libxsmm_matrix_eqn_param eqn_param;
+  unsigned long long l_start, l_end;
+  double l_total = 0, l_total2 = 0;
+  libxsmm_matdiff_info norms_out;
+  int iters = 100;
+  int datatype_mode = 0;
+  libxsmm_datatype  in_dt = LIBXSMM_DATATYPE_F32;
+  libxsmm_datatype  out_dt = LIBXSMM_DATATYPE_F32;
+  libxsmm_blasint m_i[128], n_i[128], ld_i[128], blocks_i[128];
+  libxsmm_meqn_arg_shape  arg_shape[128];
+  libxsmm_matrix_arg_attributes arg_set_attr0, arg_set_attr1;
+  libxsmm_matrix_arg_attributes arg_singular_attr;
+  float *arg[128];
+  libxsmm_matrix_arg arg_array[128];
+  libxsmm_bfloat16 *bf16_arg[128];
+  libxsmm_matrix_arg bf16_arg_array[128];
+  libxsmm_matrix_eqn_arg_metadata arg_metadata[128];
+  libxsmm_matrix_eqn_op_metadata  op_metadata[128];
+  libxsmm_blasint n_tensors, ref_id;
+  libxsmm_matrix_op_arg op_arg_arr[9];
+  int relu_sigmoid_fusion_mode = 0;
+  unsigned long long  brcount;
+  i = 1;
+  n_tensors = atoi(argv[i++]);
+  ref_id = n_tensors;
+  for (j = 0; j < n_tensors; j++) {
+    m_i[j] = atoi(argv[i++]);
+    n_i[j] = atoi(argv[i++]);
+    ld_i[j] = atoi(argv[i++]);
+    blocks_i[j] = atoi(argv[i++]);
+  }
+  datatype_mode = atoi(argv[i++]);
+  relu_sigmoid_fusion_mode = atoi(argv[i++]);
+  iters = atoi(argv[i]);
+
+#if defined(__SSE3__)
+  _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
+  _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
+  _MM_SET_ROUNDING_MODE(_MM_ROUND_NEAREST);
+#endif
+
+  if (datatype_mode == 0) {
+    in_dt = LIBXSMM_DATATYPE_F32;
+    out_dt = LIBXSMM_DATATYPE_F32;
+  } else if (datatype_mode == 1) {
+    in_dt = LIBXSMM_DATATYPE_BF16;
+    out_dt = LIBXSMM_DATATYPE_BF16;
+  } else if (datatype_mode == 2) {
+    in_dt = LIBXSMM_DATATYPE_F32;
+    out_dt = LIBXSMM_DATATYPE_BF16;
+  } else if (datatype_mode == 3) {
+    in_dt = LIBXSMM_DATATYPE_BF16;
+    out_dt = LIBXSMM_DATATYPE_F32;
+  }
+
+  for (j = 0; j < n_tensors; j++) {
+    arg_shape[j].m = m_i[j];
+    arg_shape[j].n = n_i[j];
+    arg_shape[j].ld = &ld_i[j];
+    if (j == n_tensors-1) {
+      arg_shape[j].type = out_dt;
+    } else {
+      arg_shape[j].type = in_dt;
+    }
+  }
+
+  for (i = 0; i < n_tensors; i++) {
+    arg[i] = (float*) libxsmm_aligned_malloc( sizeof(float)*n_i[i]*ld_i[i]*blocks_i[i],   64);
+  }
+  arg[ref_id] = (float*) libxsmm_aligned_malloc( sizeof(float)*n_i[n_tensors-1]*ld_i[n_tensors-1]*blocks_i[n_tensors-1],   64);
+
+  for (i = 0; i < n_tensors; i++) {
+    bf16_arg[i] = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*n_i[i]*ld_i[i]*blocks_i[i],   64);
+  }
+  bf16_arg[ref_id] = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*n_i[n_tensors-1]*ld_i[n_tensors-1]*blocks_i[n_tensors-1],   64);
+
+  libxsmm_init();
+  libxsmm_matdiff_clear(&norms_out);
+
+  for (k = 0; k < n_tensors; k++) {
+    float *cur_arr = arg[k];
+    libxsmm_bfloat16 *bf16_cur_arr = bf16_arg[k];
+    libxsmm_blasint block_size = ld_i[k]*n_i[k];
+    for ( i = 0; i < n_i[k]; i++ ) {
+      for ( j = 0; j < ld_i[k]; j++ ) {
+        for ( l = 0; l < blocks_i[k]; l++) {
+          float val = (float)libxsmm_rng_f64();
+          cur_arr[j + i *ld_i[k] + l * block_size] = val;
+          libxsmm_rne_convert_fp32_bf16( &cur_arr[j + i *ld_i[k] + l * block_size], &bf16_cur_arr[j + i *ld_i[k] + l * block_size], 1 );
+          if ( datatype_mode == 1) {
+            libxsmm_convert_bf16_f32(&bf16_cur_arr[j + i *ld_i[k] + l * block_size],&cur_arr[j + i *ld_i[k] + l * block_size], 1 );
+          }
+        }
+      }
+    }
+  }
+
+  float *ref_arr = arg[ref_id];
+  float *out_arr = arg[n_tensors-1];
+  libxsmm_bfloat16 *bf16_ref_arr = bf16_arg[ref_id];
+  libxsmm_bfloat16 *bf16_out_arr = bf16_arg[n_tensors-1];
+  libxsmm_blasint block_size = ld_i[n_tensors-1]*n_i[n_tensors-1];
+  for ( i = 0; i < n_i[n_tensors-1]; i++ ) {
+    for ( j = 0; j < ld_i[n_tensors-1]; j++ ) {
+      for ( l = 0; l < blocks_i[n_tensors-1]; l++) {
+        ref_arr[j + i * ld_i[n_tensors-1] + l * block_size] = out_arr[j + i * ld_i[n_tensors-1] + l * block_size];
+        bf16_ref_arr[j + i * ld_i[n_tensors-1] + l * block_size] = bf16_out_arr[j + i * ld_i[n_tensors-1] + l * block_size];
+      }
+    }
+  }
+
+  for (k = 0; k < n_tensors-1; k++) {
+    arg_array[k].primary = arg[k];
+    bf16_arg_array[k].primary = bf16_arg[k];
+  }
+
+  /* Result = gelu(A+B) * tanh(C x D)  */
+  arg_singular_attr.type = LIBXSMM_MATRIX_ARG_TYPE_SINGULAR;
+
+  my_eqn0 = libxsmm_matrix_eqn_create();
+  arg_metadata[0].eqn_idx     = my_eqn0;
+  arg_metadata[0].in_arg_pos  = 0;
+  arg_metadata[1].eqn_idx     = my_eqn0;
+  arg_metadata[1].in_arg_pos  = 1;
+  arg_metadata[2].eqn_idx     = my_eqn0;
+  arg_metadata[2].in_arg_pos  = 2;
+  arg_metadata[3].eqn_idx     = my_eqn0;
+  arg_metadata[3].in_arg_pos  = 3;
+  op_metadata[0].eqn_idx      = my_eqn0;
+  op_metadata[0].op_arg_pos   = -1;
+
+  libxsmm_matrix_eqn_push_back_binary_op_v2(op_metadata[0], LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_DATATYPE_F32, LIBXSMM_MELTW_FLAG_BINARY_NONE);
+  libxsmm_matrix_eqn_push_back_unary_op_v2(op_metadata[0], LIBXSMM_MELTW_TYPE_UNARY_GELU, LIBXSMM_DATATYPE_F32, LIBXSMM_MELTW_FLAG_UNARY_NONE);
+  libxsmm_matrix_eqn_push_back_binary_op_v2(op_metadata[0], LIBXSMM_MELTW_TYPE_BINARY_ADD, LIBXSMM_DATATYPE_F32, LIBXSMM_MELTW_FLAG_BINARY_NONE);
+  libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata[0], arg_shape[0], arg_singular_attr);
+  libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata[1], arg_shape[1], arg_singular_attr);
+  libxsmm_matrix_eqn_push_back_unary_op_v2(op_metadata[0], LIBXSMM_MELTW_TYPE_UNARY_TANH, LIBXSMM_DATATYPE_F32, LIBXSMM_MELTW_FLAG_UNARY_NONE);
+  libxsmm_matrix_eqn_push_back_binary_op_v2(op_metadata[0], LIBXSMM_MELTW_TYPE_BINARY_MATMUL, LIBXSMM_DATATYPE_F32, LIBXSMM_MELTW_FLAG_BINARY_NONE);
+  libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata[2], arg_shape[2], arg_singular_attr);
+  libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata[3], arg_shape[3], arg_singular_attr);
+  libxsmm_matrix_eqn_tree_print( my_eqn0 );
+  func0 = libxsmm_dispatch_matrix_eqn_v2( my_eqn0, arg_shape[n_tensors-1] );
+
+  if ( in_dt == LIBXSMM_DATATYPE_F32 ) {
+    eqn_param.inputs = arg_array;
+  } else {
+    eqn_param.inputs = bf16_arg_array;
+  }
+  if ( out_dt == LIBXSMM_DATATYPE_F32 ) {
+    eqn_param.output.primary = arg[n_tensors-1];
+  } else {
+   eqn_param.output.primary  = bf16_arg[n_tensors-1];
+  }
+
+  func0(&eqn_param);
+
+  if (datatype_mode == 0 || datatype_mode == 1) {
+    eqn0_f32( arg[ref_id], m_i[n_tensors-1], n_i[n_tensors-1], ld_i[n_tensors-1],
+              arg[0], m_i[0], n_i[0], ld_i[0],
+              arg[1], m_i[1], n_i[1], ld_i[1],
+              arg[2], m_i[2], n_i[2], ld_i[2],
+              arg[3], m_i[3], n_i[3], ld_i[3] );
+  } else if (datatype_mode == 2) {
+  } else if (datatype_mode == 3) {
+  }
+
+  if (datatype_mode == 0) {
+    printf("Equation IN: F32, OUT: F32 \n");
+  } else if (datatype_mode == 1) {
+    printf("Equation IN: BF16, OUT: BF16 \n");
+  } else if (datatype_mode == 2) {
+    printf("Equation IN: F32, OUT: BF16 \n");
+  } else if (datatype_mode == 3) {
+    printf("Equation IN: BF16, OUT: F32 \n");
+  }
+
+  printf("\n\nNow testing equation 0...\n\n");
+  if (datatype_mode == 1) {
+    libxsmm_convert_bf16_f32( bf16_arg[n_tensors-1], arg[n_tensors-1], ld_i[n_tensors-1] * n_i[n_tensors-1] * blocks_i[n_tensors-1] );
+  }
+  /* compare */
+  printf("##########################################\n");
+  printf("#   Correctness  - Output                #\n");
+  printf("##########################################\n");
+  libxsmm_matdiff(&norms_out, LIBXSMM_DATATYPE_F32, ld_i[n_tensors-1] * n_i[n_tensors-1] * blocks_i[n_tensors-1], 1, arg[ref_id], arg[n_tensors-1], 0, 0);
+
+  printf("L1 reference  : %.25g\n", norms_out.l1_ref);
+  printf("L1 test       : %.25g\n", norms_out.l1_tst);
+  printf("L2 abs.error  : %.24f\n", norms_out.l2_abs);
+  printf("L2 rel.error  : %.24f\n", norms_out.l2_rel);
+  printf("Linf abs.error: %.24f\n", norms_out.linf_abs);
+  printf("Linf rel.error: %.24f\n", norms_out.linf_rel);
+  printf("Check-norm    : %.24f\n\n", norms_out.normf_rel);
+
+  /* Now benchmarking the equations */
+  if (datatype_mode == 0 || datatype_mode == 1) {
+    eqn0_f32( arg[ref_id], m_i[n_tensors-1], n_i[n_tensors-1], ld_i[n_tensors-1],
+              arg[0], m_i[0], n_i[0], ld_i[0],
+              arg[1], m_i[1], n_i[1], ld_i[1],
+              arg[2], m_i[2], n_i[2], ld_i[2],
+              arg[3], m_i[3], n_i[3], ld_i[3] );
+  } else if (datatype_mode == 2) {
+  } else if (datatype_mode == 3) {
+  }
+  l_start = libxsmm_timer_tick();
+  for (it = 0; it < iters; it++) {
+    if (datatype_mode == 0 || datatype_mode == 1) {
+      eqn0_f32( arg[ref_id], m_i[n_tensors-1], n_i[n_tensors-1], ld_i[n_tensors-1],
+                arg[0], m_i[0], n_i[0], ld_i[0],
+                arg[1], m_i[1], n_i[1], ld_i[1],
+                arg[2], m_i[2], n_i[2], ld_i[2],
+                arg[3], m_i[3], n_i[3], ld_i[3] );
+    } else if (datatype_mode == 2) {
+    } else if (datatype_mode == 3) {
+    }
+  }
+  l_end = libxsmm_timer_tick();
+  l_total = libxsmm_timer_duration(l_start, l_end);
+  printf("Compiler equation time  = %.5g\n", ((double)(l_total)));
+
+  func0(&eqn_param);
+  l_start = libxsmm_timer_tick();
+  for (it = 0; it < iters; it++) {
+    func0(&eqn_param);
+  }
+  l_end = libxsmm_timer_tick();
+  l_total2 = libxsmm_timer_duration(l_start, l_end);
+  printf("JITed TPP equation time = %.5g\n", ((double)(l_total2)));
+  printf("Speedup (%d iters) is %.5g\n", iters, l_total/l_total2);
+
+  printf("\n\nNow testing equation 1...\n\n");
+
+  /* Create copy of B since this is now Inout  */
+  float *copy_B = (float*) libxsmm_aligned_malloc( sizeof(float)*n_i[1]*ld_i[1]*blocks_i[1],   64);
+  float *orig_B = arg[1];
+  for ( i = 0; i < n_i[1]; i++ ) {
+    for ( j = 0; j < ld_i[1]; j++ ) {
+      for ( l = 0; l < blocks_i[1]; l++) {
+        copy_B[j + i * ld_i[1] + l * 0] = orig_B[j + i * ld_i[1] + l * 0];
+      }
+    }
+  }
+  arg_array[1].primary = copy_B;
+  bf16_arg_array[1].primary = copy_B;
+  arg_shape[1].type = LIBXSMM_DATATYPE_F32;
+  /* Result = gelu(A) * tanh( B + Sum Ci x Di ) */
+
+  arg_set_attr0.type = LIBXSMM_MATRIX_ARG_TYPE_SET;
+  arg_set_attr0.set_type = LIBXSMM_MATRIX_ARG_SET_TYPE_STRIDE_BASE;
+  arg_set_attr0.set_cardinality_hint = blocks_i[2];
+  if (in_dt == LIBXSMM_DATATYPE_F32) {
+    arg_set_attr0.set_stride_hint = ld_i[2] * n_i[2] * sizeof(float);
+  } else {
+    arg_set_attr0.set_stride_hint = ld_i[2] * n_i[2] * sizeof(libxsmm_bfloat16);
+  }
+
+  arg_set_attr1.type = LIBXSMM_MATRIX_ARG_TYPE_SET;
+  arg_set_attr1.set_type = LIBXSMM_MATRIX_ARG_SET_TYPE_STRIDE_BASE;
+  arg_set_attr1.set_cardinality_hint = blocks_i[3];
+  if (in_dt == LIBXSMM_DATATYPE_F32) {
+    arg_set_attr1.set_stride_hint = ld_i[3] * n_i[3] * sizeof(float);
+  } else {
+    arg_set_attr1.set_stride_hint = ld_i[3] * n_i[3] * sizeof(libxsmm_bfloat16);
+  }
+
+  brcount = blocks_i[2];
+  op_arg_arr[7].tertiary = (void*)&brcount;
+  eqn_param.ops_args = op_arg_arr;
+
+  my_eqn1 = libxsmm_matrix_eqn_create();
+  arg_metadata[0].eqn_idx     = my_eqn1;
+  arg_metadata[1].eqn_idx     = my_eqn1;
+  arg_metadata[2].eqn_idx     = my_eqn1;
+  arg_metadata[3].eqn_idx     = my_eqn1;
+  op_metadata[0].eqn_idx      = my_eqn1;
+  op_metadata[1].eqn_idx      = my_eqn1;
+  op_metadata[1].op_arg_pos   = 7;
+
+  libxsmm_matrix_eqn_push_back_binary_op_v2(op_metadata[0], LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_DATATYPE_F32, LIBXSMM_MELTW_FLAG_BINARY_NONE);
+  libxsmm_matrix_eqn_push_back_unary_op_v2(op_metadata[0], LIBXSMM_MELTW_TYPE_UNARY_GELU, LIBXSMM_DATATYPE_F32, LIBXSMM_MELTW_FLAG_UNARY_NONE);
+  libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata[0], arg_shape[0], arg_singular_attr);
+  libxsmm_matrix_eqn_push_back_unary_op_v2(op_metadata[0], LIBXSMM_MELTW_TYPE_UNARY_TANH, LIBXSMM_DATATYPE_F32, LIBXSMM_MELTW_FLAG_UNARY_NONE);
+  libxsmm_matrix_eqn_push_back_ternary_op_v2(op_metadata[1], LIBXSMM_MELTW_TYPE_TERNARY_BRGEMM, LIBXSMM_DATATYPE_F32, LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT);
+  libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata[2], arg_shape[2], arg_set_attr0);
+  libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata[3], arg_shape[3], arg_set_attr1);
+  libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata[1], arg_shape[1], arg_singular_attr);
+  libxsmm_matrix_eqn_tree_print( my_eqn1 );
+  func1 = libxsmm_dispatch_matrix_eqn_v2( my_eqn1, arg_shape[n_tensors-1] );
+  func1(&eqn_param);
+  /* Recover type of arg1  */
+  arg_shape[1].type = in_dt;
+
+  if (datatype_mode == 0 || datatype_mode == 1) {
+    eqn1_f32( arg[ref_id], m_i[n_tensors-1], n_i[n_tensors-1], ld_i[n_tensors-1],
+              arg[0], m_i[0], n_i[0], ld_i[0],
+              arg[1], m_i[1], n_i[1], ld_i[1], blocks_i[2],
+              arg[2], m_i[2], n_i[2], ld_i[2], ld_i[2] * n_i[2],
+              arg[3], m_i[3], n_i[3], ld_i[3], ld_i[3] * n_i[3]);
+  } else if (datatype_mode == 2) {
+  } else if (datatype_mode == 3) {
+  }
+
+  if (datatype_mode == 1) {
+    libxsmm_convert_bf16_f32( bf16_arg[n_tensors-1], arg[n_tensors-1], ld_i[n_tensors-1] * n_i[n_tensors-1] * blocks_i[n_tensors-1] );
+  }
+  /* compare */
+  printf("##########################################\n");
+  printf("#   Correctness  - Output                #\n");
+  printf("##########################################\n");
+  libxsmm_matdiff(&norms_out, LIBXSMM_DATATYPE_F32, ld_i[n_tensors-1] * n_i[n_tensors-1] * blocks_i[n_tensors-1], 1, arg[ref_id], arg[n_tensors-1], 0, 0);
+
+  printf("L1 reference  : %.25g\n", norms_out.l1_ref);
+  printf("L1 test       : %.25g\n", norms_out.l1_tst);
+  printf("L2 abs.error  : %.24f\n", norms_out.l2_abs);
+  printf("L2 rel.error  : %.24f\n", norms_out.l2_rel);
+  printf("Linf abs.error: %.24f\n", norms_out.linf_abs);
+  printf("Linf rel.error: %.24f\n", norms_out.linf_rel);
+  printf("Check-norm    : %.24f\n\n", norms_out.normf_rel);
+
+  /* Now benchmarking the equations */
+  if (datatype_mode == 0 || datatype_mode == 1) {
+    eqn1_f32( arg[ref_id], m_i[n_tensors-1], n_i[n_tensors-1], ld_i[n_tensors-1],
+              arg[0], m_i[0], n_i[0], ld_i[0],
+              arg[1], m_i[1], n_i[1], ld_i[1], blocks_i[2],
+              arg[2], m_i[2], n_i[2], ld_i[2], ld_i[2] * n_i[2],
+              arg[3], m_i[3], n_i[3], ld_i[3], ld_i[3] * n_i[3]);
+  } else if (datatype_mode == 2) {
+  } else if (datatype_mode == 3) {
+  }
+  l_start = libxsmm_timer_tick();
+  for (it = 0; it < iters; it++) {
+    if (datatype_mode == 0 || datatype_mode == 1) {
+      eqn1_f32( arg[ref_id], m_i[n_tensors-1], n_i[n_tensors-1], ld_i[n_tensors-1],
+                arg[0], m_i[0], n_i[0], ld_i[0],
+                arg[1], m_i[1], n_i[1], ld_i[1], blocks_i[2],
+                arg[2], m_i[2], n_i[2], ld_i[2], ld_i[2] * n_i[2],
+                arg[3], m_i[3], n_i[3], ld_i[3], ld_i[3] * n_i[3]);
+    } else if (datatype_mode == 2) {
+    } else if (datatype_mode == 3) {
+    }
+  }
+  l_end = libxsmm_timer_tick();
+  l_total = libxsmm_timer_duration(l_start, l_end);
+  printf("Compiler equation time  = %.5g\n", ((double)(l_total)));
+
+  func1(&eqn_param);
+  l_start = libxsmm_timer_tick();
+  for (it = 0; it < iters; it++) {
+    func1(&eqn_param);
+  }
+  l_end = libxsmm_timer_tick();
+  l_total2 = libxsmm_timer_duration(l_start, l_end);
+  printf("JITed TPP equation time = %.5g\n", ((double)(l_total2)));
+  printf("Speedup (%d iters) is %.5g\n", iters, l_total/l_total2);
+
+  if (datatype_mode == 0) {
+    printf("\n\nNow testing equation with fused avx512 GEMM...\n\n");
+    /* sigmoid( Sum(Ci x Di) + colbias + 1.0) */
+    float *colbias_f32_fused = (float*) libxsmm_aligned_malloc( sizeof(float)*m_i[2],   64);
+    memcpy(colbias_f32_fused, arg[2], m_i[2] * sizeof(float));
+
+    libxsmm_meqn_arg_shape  colbias_shape_fused;
+    colbias_shape_fused.m = m_i[2];
+    colbias_shape_fused.n = 1;
+    colbias_shape_fused.ld = &m_i[2];
+    colbias_shape_fused.type = in_dt;
+
+    my_eqn5 = libxsmm_matrix_eqn_create();
+    arg_metadata[2].eqn_idx     = my_eqn5;
+    arg_metadata[3].eqn_idx     = my_eqn5;
+    op_metadata[0].eqn_idx      = my_eqn5;
+    op_metadata[1].eqn_idx      = my_eqn5;
+    arg_metadata[42].eqn_idx    = my_eqn5;
+    arg_metadata[42].in_arg_pos = 42;
+
+    if (relu_sigmoid_fusion_mode == 0) {
+      /* Do nothing  */
+    } else if (relu_sigmoid_fusion_mode == 1) {
+      libxsmm_matrix_eqn_push_back_unary_op_v2(op_metadata[0], LIBXSMM_MELTW_TYPE_UNARY_RELU, LIBXSMM_DATATYPE_F32, LIBXSMM_MELTW_FLAG_UNARY_NONE);
+    } else if (relu_sigmoid_fusion_mode == 2) {
+      libxsmm_matrix_eqn_push_back_unary_op_v2(op_metadata[0], LIBXSMM_MELTW_TYPE_UNARY_SIGMOID, LIBXSMM_DATATYPE_F32 , LIBXSMM_MELTW_FLAG_UNARY_NONE);
+    }
+    libxsmm_matrix_eqn_push_back_binary_op_v2(op_metadata[0], LIBXSMM_MELTW_TYPE_BINARY_ADD, LIBXSMM_DATATYPE_F32, LIBXSMM_MELTW_FLAG_BINARY_BCAST_COL_IN_0);
+    libxsmm_matrix_eqn_push_back_unary_op_v2(op_metadata[0], LIBXSMM_MELTW_TYPE_UNARY_INC, LIBXSMM_DATATYPE_F32, LIBXSMM_MELTW_FLAG_UNARY_NONE);
+    libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata[42], colbias_shape_fused, arg_singular_attr);
+    libxsmm_matrix_eqn_push_back_binary_op_v2(op_metadata[1], LIBXSMM_MELTW_TYPE_BINARY_BRGEMM, LIBXSMM_DATATYPE_F32, LIBXSMM_MELTW_FLAG_BINARY_NONE);
+    libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata[2], arg_shape[2], arg_set_attr0);
+    libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata[3], arg_shape[3], arg_set_attr1);
+    libxsmm_matrix_eqn_tree_print( my_eqn5 );
+    func5 = libxsmm_dispatch_matrix_eqn_v2( my_eqn5, arg_shape[n_tensors-1] );
+
+    arg_array[42].primary = colbias_f32_fused;
+    func5(&eqn_param);
+
+    eqn4_f32( arg[ref_id], m_i[n_tensors-1], n_i[n_tensors-1], ld_i[n_tensors-1],
+        arg[0], m_i[0], n_i[0], ld_i[0],
+        arg[1], m_i[1], n_i[1], ld_i[1], blocks_i[2],
+        arg[2], m_i[2], n_i[2], ld_i[2], ld_i[2] * n_i[2],
+        arg[3], m_i[3], n_i[3], ld_i[3], ld_i[3] * n_i[3], colbias_f32_fused, relu_sigmoid_fusion_mode);
+
+    /* compare */
+    printf("##########################################\n");
+    printf("#   Correctness  - Output                #\n");
+    printf("##########################################\n");
+    libxsmm_matdiff(&norms_out, LIBXSMM_DATATYPE_F32, ld_i[n_tensors-1] * n_i[n_tensors-1] * blocks_i[n_tensors-1], 1, arg[ref_id], arg[n_tensors-1], 0, 0);
+
+    printf("L1 reference  : %.25g\n", norms_out.l1_ref);
+    printf("L1 test       : %.25g\n", norms_out.l1_tst);
+    printf("L2 abs.error  : %.24f\n", norms_out.l2_abs);
+    printf("L2 rel.error  : %.24f\n", norms_out.l2_rel);
+    printf("Linf abs.error: %.24f\n", norms_out.linf_abs);
+    printf("Linf rel.error: %.24f\n", norms_out.linf_rel);
+    printf("Check-norm    : %.24f\n\n", norms_out.normf_rel);
+
+    /* Now benchmarking the equations */
+    if (datatype_mode == 0 || datatype_mode == 1) {
+      eqn4_f32( arg[ref_id], m_i[n_tensors-1], n_i[n_tensors-1], ld_i[n_tensors-1],
+          arg[0], m_i[0], n_i[0], ld_i[0],
+          arg[1], m_i[1], n_i[1], ld_i[1], blocks_i[2],
+          arg[2], m_i[2], n_i[2], ld_i[2], ld_i[2] * n_i[2],
+          arg[3], m_i[3], n_i[3], ld_i[3], ld_i[3] * n_i[3], colbias_f32_fused, relu_sigmoid_fusion_mode);
+    } else if (datatype_mode == 2) {
+    } else if (datatype_mode == 3) {
+    }
+    l_start = libxsmm_timer_tick();
+    for (it = 0; it < iters; it++) {
+      if (datatype_mode == 0 || datatype_mode == 1) {
+        eqn4_f32( arg[ref_id], m_i[n_tensors-1], n_i[n_tensors-1], ld_i[n_tensors-1],
+            arg[0], m_i[0], n_i[0], ld_i[0],
+            arg[1], m_i[1], n_i[1], ld_i[1], blocks_i[2],
+            arg[2], m_i[2], n_i[2], ld_i[2], ld_i[2] * n_i[2],
+            arg[3], m_i[3], n_i[3], ld_i[3], ld_i[3] * n_i[3], colbias_f32_fused, relu_sigmoid_fusion_mode);
+      } else if (datatype_mode == 2) {
+      } else if (datatype_mode == 3) {
+      }
+    }
+    l_end = libxsmm_timer_tick();
+    l_total = libxsmm_timer_duration(l_start, l_end);
+    printf("Compiler equation time  = %.5g\n", ((double)(l_total)));
+
+    func5(&eqn_param);
+    l_start = libxsmm_timer_tick();
+    for (it = 0; it < iters; it++) {
+      func5(&eqn_param);
+    }
+    l_end = libxsmm_timer_tick();
+    l_total2 = libxsmm_timer_duration(l_start, l_end);
+    printf("JITed TPP equation time = %.5g\n", ((double)(l_total2)));
+    printf("Speedup (%d iters) is %.5g\n", iters, l_total/l_total2);
+  }
+
+  if ((datatype_mode == 1) && (n_i[2] % 2 == 0)) {
+    printf("\n\nNow testing equation 2...\n\n");
+
+    /* Result = gelu(A) * tanh( Sum Ci x Di ) */
+    arg_set_attr0.type = LIBXSMM_MATRIX_ARG_TYPE_SET;
+    arg_set_attr0.set_type = LIBXSMM_MATRIX_ARG_SET_TYPE_STRIDE_BASE;
+    arg_set_attr0.set_cardinality_hint = blocks_i[2];
+    arg_set_attr0.set_stride_hint = ld_i[2] * n_i[2] * sizeof(libxsmm_bfloat16);
+
+    arg_set_attr1.type = LIBXSMM_MATRIX_ARG_TYPE_SET;
+    arg_set_attr1.set_type = LIBXSMM_MATRIX_ARG_SET_TYPE_STRIDE_BASE;
+    arg_set_attr1.set_cardinality_hint = blocks_i[3];
+    arg_set_attr1.set_stride_hint = ld_i[3] * n_i[3] * sizeof(libxsmm_bfloat16);
+
+    brcount = blocks_i[2];
+    op_arg_arr[7].tertiary = (void*)&brcount;
+    eqn_param.ops_args = op_arg_arr;
+
+    /* Create copy of C in VNNI format */
+    libxsmm_bfloat16 *copy_C = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*n_i[2]*ld_i[2]*blocks_i[2],   64);
+    libxsmm_bfloat16 *orig_C = bf16_arg[2];
+    int ___i = 0;
+    for ( l = 0; l < blocks_i[2]; l++) {
+      for ( i = 0; i < n_i[2]/2; i++ ) {
+        for ( j = 0; j < m_i[2]; j++ ) {
+          for ( ___i = 0; ___i < 2; ___i++ ) {
+            copy_C[___i + j*2 + i * ld_i[2] * 2 + l * ld_i[2] * n_i[2]] = orig_C[j + (i*2+___i) * ld_i[2] + l * ld_i[2] * n_i[2]];
+          }
+        }
+      }
+    }
+    bf16_arg_array[2].primary = copy_C;
+
+    my_eqn2 = libxsmm_matrix_eqn_create();
+    arg_metadata[0].eqn_idx     = my_eqn2;
+    arg_metadata[2].eqn_idx     = my_eqn2;
+    arg_metadata[3].eqn_idx     = my_eqn2;
+    op_metadata[0].eqn_idx      = my_eqn2;
+    op_metadata[1].eqn_idx      = my_eqn2;
+
+    libxsmm_matrix_eqn_push_back_binary_op_v2( op_metadata[0], LIBXSMM_MELTW_TYPE_BINARY_ADD, LIBXSMM_DATATYPE_F32, LIBXSMM_MELTW_FLAG_BINARY_NONE);
+    libxsmm_matrix_eqn_push_back_unary_op_v2( op_metadata[0], LIBXSMM_MELTW_TYPE_UNARY_GELU, LIBXSMM_DATATYPE_F32, LIBXSMM_MELTW_FLAG_UNARY_NONE);
+    libxsmm_matrix_eqn_push_back_arg_v2( arg_metadata[0], arg_shape[0], arg_singular_attr);
+    libxsmm_matrix_eqn_push_back_unary_op_v2( op_metadata[0], LIBXSMM_MELTW_TYPE_UNARY_TANH, LIBXSMM_DATATYPE_F32, LIBXSMM_MELTW_FLAG_UNARY_NONE);
+    libxsmm_matrix_eqn_push_back_binary_op_v2( op_metadata[1], LIBXSMM_MELTW_TYPE_BINARY_BRGEMM_A_VNNI, LIBXSMM_DATATYPE_F32, LIBXSMM_MELTW_FLAG_BINARY_NONE);
+    libxsmm_matrix_eqn_push_back_arg_v2( arg_metadata[2], arg_shape[2], arg_set_attr0);
+    libxsmm_matrix_eqn_push_back_arg_v2( arg_metadata[3], arg_shape[3], arg_set_attr1);
+    libxsmm_matrix_eqn_tree_print( my_eqn2 );
+    func2 = libxsmm_dispatch_matrix_eqn_v2( my_eqn2, arg_shape[n_tensors-1] );
+    func2(&eqn_param);
+
+    eqn2_f32( arg[ref_id], m_i[n_tensors-1], n_i[n_tensors-1], ld_i[n_tensors-1],
+        arg[0], m_i[0], n_i[0], ld_i[0],
+        arg[1], m_i[1], n_i[1], ld_i[1], blocks_i[2],
+        arg[2], m_i[2], n_i[2], ld_i[2], ld_i[2] * n_i[2],
+        arg[3], m_i[3], n_i[3], ld_i[3], ld_i[3] * n_i[3]);
+
+    libxsmm_convert_bf16_f32( bf16_arg[n_tensors-1], arg[n_tensors-1], ld_i[n_tensors-1] * n_i[n_tensors-1] * blocks_i[n_tensors-1] );
+
+    /* compare */
+    printf("##########################################\n");
+    printf("#   Correctness  - Output                #\n");
+    printf("##########################################\n");
+    libxsmm_matdiff(&norms_out, LIBXSMM_DATATYPE_F32, ld_i[n_tensors-1] * n_i[n_tensors-1] * blocks_i[n_tensors-1], 1, arg[ref_id], arg[n_tensors-1], 0, 0);
+
+    printf("L1 reference  : %.25g\n", norms_out.l1_ref);
+    printf("L1 test       : %.25g\n", norms_out.l1_tst);
+    printf("L2 abs.error  : %.24f\n", norms_out.l2_abs);
+    printf("L2 rel.error  : %.24f\n", norms_out.l2_rel);
+    printf("Linf abs.error: %.24f\n", norms_out.linf_abs);
+    printf("Linf rel.error: %.24f\n", norms_out.linf_rel);
+    printf("Check-norm    : %.24f\n\n", norms_out.normf_rel);
+
+    /* Now benchmarking the equations */
+    if (datatype_mode == 0 || datatype_mode == 1) {
+      eqn2_f32( arg[ref_id], m_i[n_tensors-1], n_i[n_tensors-1], ld_i[n_tensors-1],
+          arg[0], m_i[0], n_i[0], ld_i[0],
+          arg[1], m_i[1], n_i[1], ld_i[1], blocks_i[2],
+          arg[2], m_i[2], n_i[2], ld_i[2], ld_i[2] * n_i[2],
+          arg[3], m_i[3], n_i[3], ld_i[3], ld_i[3] * n_i[3]);
+    } else if (datatype_mode == 2) {
+    } else if (datatype_mode == 3) {
+    }
+    l_start = libxsmm_timer_tick();
+    for (it = 0; it < iters; it++) {
+      if (datatype_mode == 0 || datatype_mode == 1) {
+        eqn2_f32( arg[ref_id], m_i[n_tensors-1], n_i[n_tensors-1], ld_i[n_tensors-1],
+            arg[0], m_i[0], n_i[0], ld_i[0],
+            arg[1], m_i[1], n_i[1], ld_i[1], blocks_i[2],
+            arg[2], m_i[2], n_i[2], ld_i[2], ld_i[2] * n_i[2],
+            arg[3], m_i[3], n_i[3], ld_i[3], ld_i[3] * n_i[3]);
+      } else if (datatype_mode == 2) {
+      } else if (datatype_mode == 3) {
+      }
+    }
+    l_end = libxsmm_timer_tick();
+    l_total = libxsmm_timer_duration(l_start, l_end);
+    printf("Compiler equation time  = %.5g\n", ((double)(l_total)));
+
+    func2(&eqn_param);
+    l_start = libxsmm_timer_tick();
+    for (it = 0; it < iters; it++) {
+      func2(&eqn_param);
+    }
+    l_end = libxsmm_timer_tick();
+    l_total2 = libxsmm_timer_duration(l_start, l_end);
+    printf("JITed TPP equation time = %.5g\n", ((double)(l_total2)));
+    printf("Speedup (%d iters) is %.5g\n", iters, l_total/l_total2);
+
+
+    printf("\n\nNow testing equation 3...\n\n");
+
+    /* Result = Sum(Ci x Di) + gelu(A) */
+    arg_set_attr0.type = LIBXSMM_MATRIX_ARG_TYPE_SET;
+    arg_set_attr0.set_type = LIBXSMM_MATRIX_ARG_SET_TYPE_STRIDE_BASE;
+    arg_set_attr0.set_cardinality_hint = blocks_i[2];
+    arg_set_attr0.set_stride_hint = ld_i[2] * n_i[2] * sizeof(libxsmm_bfloat16);
+
+    arg_set_attr1.type = LIBXSMM_MATRIX_ARG_TYPE_SET;
+    arg_set_attr1.set_type = LIBXSMM_MATRIX_ARG_SET_TYPE_STRIDE_BASE;
+    arg_set_attr1.set_cardinality_hint = blocks_i[3];
+    arg_set_attr1.set_stride_hint = ld_i[3] * n_i[3] * sizeof(libxsmm_bfloat16);
+
+    brcount = blocks_i[2];
+    op_arg_arr[7].tertiary = (void*)&brcount;
+    eqn_param.ops_args = op_arg_arr;
+
+    my_eqn3 = libxsmm_matrix_eqn_create();
+    arg_metadata[0].eqn_idx     = my_eqn3;
+    arg_metadata[2].eqn_idx     = my_eqn3;
+    arg_metadata[3].eqn_idx     = my_eqn3;
+    op_metadata[0].eqn_idx      = my_eqn3;
+    op_metadata[1].eqn_idx      = my_eqn3;
+
+    libxsmm_matrix_eqn_push_back_unary_op_v2(op_metadata[0], LIBXSMM_MELTW_TYPE_UNARY_IDENTITY, LIBXSMM_DATATYPE_BF16, LIBXSMM_MELTW_FLAG_UNARY_NONE);
+    libxsmm_matrix_eqn_push_back_ternary_op_v2(op_metadata[1], LIBXSMM_MELTW_TYPE_TERNARY_BRGEMM_A_VNNI, LIBXSMM_DATATYPE_BF16, LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT);
+    libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata[2], arg_shape[2], arg_set_attr0);
+    libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata[3], arg_shape[3], arg_set_attr1);
+    libxsmm_matrix_eqn_push_back_unary_op_v2(op_metadata[0], LIBXSMM_MELTW_TYPE_UNARY_IDENTITY, LIBXSMM_DATATYPE_BF16, LIBXSMM_MELTW_FLAG_UNARY_NONE);
+    libxsmm_matrix_eqn_push_back_unary_op_v2(op_metadata[0], LIBXSMM_MELTW_TYPE_UNARY_GELU, LIBXSMM_DATATYPE_F32, LIBXSMM_MELTW_FLAG_UNARY_NONE);
+    libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata[0], arg_shape[0], arg_singular_attr);
+
+    libxsmm_matrix_eqn_tree_print( my_eqn3 );
+    func3 = libxsmm_dispatch_matrix_eqn_v2( my_eqn3, arg_shape[n_tensors-1] );
+    func3(&eqn_param);
+
+    eqn3_f32( arg[ref_id], m_i[n_tensors-1], n_i[n_tensors-1], ld_i[n_tensors-1],
+        arg[0], m_i[0], n_i[0], ld_i[0],
+        arg[1], m_i[1], n_i[1], ld_i[1], blocks_i[2],
+        arg[2], m_i[2], n_i[2], ld_i[2], ld_i[2] * n_i[2],
+        arg[3], m_i[3], n_i[3], ld_i[3], ld_i[3] * n_i[3]);
+
+    libxsmm_convert_bf16_f32( bf16_arg[n_tensors-1], arg[n_tensors-1], ld_i[n_tensors-1] * n_i[n_tensors-1] * blocks_i[n_tensors-1] );
+
+    /* compare */
+    printf("##########################################\n");
+    printf("#   Correctness  - Output                #\n");
+    printf("##########################################\n");
+    libxsmm_matdiff(&norms_out, LIBXSMM_DATATYPE_F32, ld_i[n_tensors-1] * n_i[n_tensors-1] * blocks_i[n_tensors-1], 1, arg[ref_id], arg[n_tensors-1], 0, 0);
+
+    printf("L1 reference  : %.25g\n", norms_out.l1_ref);
+    printf("L1 test       : %.25g\n", norms_out.l1_tst);
+    printf("L2 abs.error  : %.24f\n", norms_out.l2_abs);
+    printf("L2 rel.error  : %.24f\n", norms_out.l2_rel);
+    printf("Linf abs.error: %.24f\n", norms_out.linf_abs);
+    printf("Linf rel.error: %.24f\n", norms_out.linf_rel);
+    printf("Check-norm    : %.24f\n\n", norms_out.normf_rel);
+
+    /* Now benchmarking the equations */
+    if (datatype_mode == 0 || datatype_mode == 1) {
+      eqn3_f32( arg[ref_id], m_i[n_tensors-1], n_i[n_tensors-1], ld_i[n_tensors-1],
+          arg[0], m_i[0], n_i[0], ld_i[0],
+          arg[1], m_i[1], n_i[1], ld_i[1], blocks_i[2],
+          arg[2], m_i[2], n_i[2], ld_i[2], ld_i[2] * n_i[2],
+          arg[3], m_i[3], n_i[3], ld_i[3], ld_i[3] * n_i[3]);
+    } else if (datatype_mode == 2) {
+    } else if (datatype_mode == 3) {
+    }
+    l_start = libxsmm_timer_tick();
+    for (it = 0; it < iters; it++) {
+      if (datatype_mode == 0 || datatype_mode == 1) {
+        eqn3_f32( arg[ref_id], m_i[n_tensors-1], n_i[n_tensors-1], ld_i[n_tensors-1],
+            arg[0], m_i[0], n_i[0], ld_i[0],
+            arg[1], m_i[1], n_i[1], ld_i[1], blocks_i[2],
+            arg[2], m_i[2], n_i[2], ld_i[2], ld_i[2] * n_i[2],
+            arg[3], m_i[3], n_i[3], ld_i[3], ld_i[3] * n_i[3]);
+      } else if (datatype_mode == 2) {
+      } else if (datatype_mode == 3) {
+      }
+    }
+    l_end = libxsmm_timer_tick();
+    l_total = libxsmm_timer_duration(l_start, l_end);
+    printf("Compiler equation time  = %.5g\n", ((double)(l_total)));
+
+    func3(&eqn_param);
+    l_start = libxsmm_timer_tick();
+    for (it = 0; it < iters; it++) {
+      func3(&eqn_param);
+    }
+    l_end = libxsmm_timer_tick();
+    l_total2 = libxsmm_timer_duration(l_start, l_end);
+    printf("JITed TPP equation time = %.5g\n", ((double)(l_total2)));
+    printf("Speedup (%d iters) is %.5g\n", iters, l_total/l_total2);
+
+
+    printf("\n\nNow testing equation 4...\n\n");
+
+    /* sigmoid( Sum(Ci x Di) + colbias + 1.0) */
+
+    libxsmm_bfloat16 *colbias = (libxsmm_bfloat16*) libxsmm_aligned_malloc( sizeof(libxsmm_bfloat16)*m_i[2],   64);
+    float *colbias_f32 = (float*) libxsmm_aligned_malloc( sizeof(float)*m_i[2],   64);
+    libxsmm_rne_convert_fp32_bf16( arg[2], colbias, m_i[2] );
+    libxsmm_convert_bf16_f32(colbias, colbias_f32, m_i[2] );
+
+    libxsmm_meqn_arg_shape  colbias_shape_bf16;
+    colbias_shape_bf16.m = m_i[2];
+    colbias_shape_bf16.n = 1;
+    colbias_shape_bf16.ld = &m_i[2];
+    colbias_shape_bf16.type = in_dt;
+
+    my_eqn4 = libxsmm_matrix_eqn_create();
+    arg_metadata[2].eqn_idx     = my_eqn4;
+    arg_metadata[3].eqn_idx     = my_eqn4;
+    arg_metadata[42].eqn_idx    = my_eqn4;
+    arg_metadata[42].in_arg_pos = 42;
+    op_metadata[0].eqn_idx      = my_eqn4;
+    op_metadata[1].eqn_idx      = my_eqn4;
+
+    if (relu_sigmoid_fusion_mode == 0) {
+      /* Do nothing  */
+    } else if (relu_sigmoid_fusion_mode == 1) {
+      libxsmm_matrix_eqn_push_back_unary_op_v2(op_metadata[0], LIBXSMM_MELTW_TYPE_UNARY_RELU, LIBXSMM_DATATYPE_F32, LIBXSMM_MELTW_FLAG_UNARY_NONE);
+    } else if (relu_sigmoid_fusion_mode == 2) {
+      libxsmm_matrix_eqn_push_back_unary_op_v2(op_metadata[0], LIBXSMM_MELTW_TYPE_UNARY_SIGMOID, LIBXSMM_DATATYPE_F32, LIBXSMM_MELTW_FLAG_UNARY_NONE);
+    }
+    libxsmm_matrix_eqn_push_back_binary_op_v2(op_metadata[0], LIBXSMM_MELTW_TYPE_BINARY_ADD, LIBXSMM_DATATYPE_F32, LIBXSMM_MELTW_FLAG_BINARY_BCAST_COL_IN_0);
+    libxsmm_matrix_eqn_push_back_unary_op_v2(op_metadata[0], LIBXSMM_MELTW_TYPE_UNARY_INC, LIBXSMM_DATATYPE_F32, LIBXSMM_MELTW_FLAG_UNARY_NONE);
+    libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata[42], colbias_shape_bf16, arg_singular_attr );
+    libxsmm_matrix_eqn_push_back_binary_op_v2(op_metadata[1], LIBXSMM_MELTW_TYPE_BINARY_BRGEMM_A_VNNI, LIBXSMM_DATATYPE_BF16, LIBXSMM_MELTW_FLAG_BINARY_NONE);
+    libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata[2], arg_shape[2], arg_set_attr0);
+    libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata[3], arg_shape[3], arg_set_attr1);
+    libxsmm_matrix_eqn_tree_print( my_eqn4 );
+    func4 = libxsmm_dispatch_matrix_eqn_v2( my_eqn4, arg_shape[n_tensors-1] );
+    bf16_arg_array[42].primary = colbias;
+
+    func4(&eqn_param);
+
+    eqn4_f32( arg[ref_id], m_i[n_tensors-1], n_i[n_tensors-1], ld_i[n_tensors-1],
+        arg[0], m_i[0], n_i[0], ld_i[0],
+        arg[1], m_i[1], n_i[1], ld_i[1], blocks_i[2],
+        arg[2], m_i[2], n_i[2], ld_i[2], ld_i[2] * n_i[2],
+        arg[3], m_i[3], n_i[3], ld_i[3], ld_i[3] * n_i[3], colbias_f32, relu_sigmoid_fusion_mode);
+
+    libxsmm_convert_bf16_f32( bf16_arg[n_tensors-1], arg[n_tensors-1], ld_i[n_tensors-1] * n_i[n_tensors-1] * blocks_i[n_tensors-1] );
+
+    /* compare */
+    printf("##########################################\n");
+    printf("#   Correctness  - Output                #\n");
+    printf("##########################################\n");
+    libxsmm_matdiff(&norms_out, LIBXSMM_DATATYPE_F32, ld_i[n_tensors-1] * n_i[n_tensors-1] * blocks_i[n_tensors-1], 1, arg[ref_id], arg[n_tensors-1], 0, 0);
+
+    printf("L1 reference  : %.25g\n", norms_out.l1_ref);
+    printf("L1 test       : %.25g\n", norms_out.l1_tst);
+    printf("L2 abs.error  : %.24f\n", norms_out.l2_abs);
+    printf("L2 rel.error  : %.24f\n", norms_out.l2_rel);
+    printf("Linf abs.error: %.24f\n", norms_out.linf_abs);
+    printf("Linf rel.error: %.24f\n", norms_out.linf_rel);
+    printf("Check-norm    : %.24f\n\n", norms_out.normf_rel);
+
+    /* Now benchmarking the equations */
+    if (datatype_mode == 0 || datatype_mode == 1) {
+      eqn4_f32( arg[ref_id], m_i[n_tensors-1], n_i[n_tensors-1], ld_i[n_tensors-1],
+          arg[0], m_i[0], n_i[0], ld_i[0],
+          arg[1], m_i[1], n_i[1], ld_i[1], blocks_i[2],
+          arg[2], m_i[2], n_i[2], ld_i[2], ld_i[2] * n_i[2],
+          arg[3], m_i[3], n_i[3], ld_i[3], ld_i[3] * n_i[3], colbias_f32, relu_sigmoid_fusion_mode);
+    } else if (datatype_mode == 2) {
+    } else if (datatype_mode == 3) {
+    }
+    l_start = libxsmm_timer_tick();
+    for (it = 0; it < iters; it++) {
+      if (datatype_mode == 0 || datatype_mode == 1) {
+        eqn4_f32( arg[ref_id], m_i[n_tensors-1], n_i[n_tensors-1], ld_i[n_tensors-1],
+            arg[0], m_i[0], n_i[0], ld_i[0],
+            arg[1], m_i[1], n_i[1], ld_i[1], blocks_i[2],
+            arg[2], m_i[2], n_i[2], ld_i[2], ld_i[2] * n_i[2],
+            arg[3], m_i[3], n_i[3], ld_i[3], ld_i[3] * n_i[3], colbias_f32, relu_sigmoid_fusion_mode);
+      } else if (datatype_mode == 2) {
+      } else if (datatype_mode == 3) {
+      }
+    }
+    l_end = libxsmm_timer_tick();
+    l_total = libxsmm_timer_duration(l_start, l_end);
+    printf("Compiler equation time  = %.5g\n", ((double)(l_total)));
+
+    func4(&eqn_param);
+    l_start = libxsmm_timer_tick();
+    for (it = 0; it < iters; it++) {
+      func4(&eqn_param);
+    }
+    l_end = libxsmm_timer_tick();
+    l_total2 = libxsmm_timer_duration(l_start, l_end);
+    printf("JITed TPP equation time = %.5g\n", ((double)(l_total2)));
+    printf("Speedup (%d iters) is %.5g\n", iters, l_total/l_total2);
+  }
+
+  return 0;
+}

--- a/samples/equation/equation_simple.c
+++ b/samples/equation/equation_simple.c
@@ -6,7 +6,7 @@
 * Further information: https://github.com/hfp/libxsmm/                        *
 * SPDX-License-Identifier: BSD-3-Clause                                       *
 ******************************************************************************/
-/* Alexander Heinecke (Intel Corp.)
+/* Evangelos Georganas (Intel Corp.)
 ******************************************************************************/
 #include <libxsmm.h>
 #include <stdlib.h>

--- a/samples/equation/equation_softmax.c
+++ b/samples/equation/equation_softmax.c
@@ -601,7 +601,7 @@ int main( int argc, char* argv[] ) {
   func3 = libxsmm_dispatch_matrix_eqn( S3, S1, &ld, LIBXSMM_DATATYPE_F32, my_eqn3 );
 #else
   my_eqn3 = libxsmm_matrix_eqn_create();
-  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn3, LIBXSMM_MELTW_TYPE_TERNARY_NMULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_SCALAR_IN_0 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32 );
+  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn3, LIBXSMM_MELTW_TYPE_TERNARY_NMULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_SCALAR_IN_0 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32);
   libxsmm_matrix_eqn_push_back_unary_op( my_eqn3, LIBXSMM_MELTW_TYPE_UNARY_REDUCE_X_OP_ADD, LIBXSMM_MELTW_FLAG_UNARY_REDUCE_ROWS, LIBXSMM_DATATYPE_F32 );
   libxsmm_matrix_eqn_push_back_unary_op( my_eqn3, LIBXSMM_MELTW_TYPE_UNARY_REDUCE_X_OP_ADD, LIBXSMM_MELTW_FLAG_UNARY_REDUCE_COLS, LIBXSMM_DATATYPE_F32 );
   libxsmm_matrix_eqn_push_back_arg( my_eqn3, S3, S1, tmp_ld, 0, 0, LIBXSMM_DATATYPE_F32 );

--- a/samples/equation/equation_splitSGD.c
+++ b/samples/equation/equation_splitSGD.c
@@ -169,7 +169,7 @@ int main( int argc, char* argv[] ) {
   /* Split sgd via equation  */
   my_eqn0 = libxsmm_matrix_eqn_create();
   libxsmm_matrix_eqn_push_back_unary_op( my_eqn0, LIBXSMM_MELTW_TYPE_UNARY_UNPACK_TO_BLOCKS, LIBXSMM_MELTW_FLAG_UNARY_NONE, LIBXSMM_DATATYPE_F32 );
-  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn0, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_SCALAR_IN_1 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32 );
+  libxsmm_matrix_eqn_push_back_ternary_op( my_eqn0, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_SCALAR_IN_1 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT, LIBXSMM_DATATYPE_F32);
   libxsmm_matrix_eqn_push_back_arg( my_eqn0, M, N, ld, 3, 0, LIBXSMM_DATATYPE_BF16 ); /* This is the "gradient" weights   */
   libxsmm_matrix_eqn_push_back_arg( my_eqn0, 1, 1, 1, 2, 0, LIBXSMM_DATATYPE_F32 );   /* This is the scalar learning rate */
   libxsmm_matrix_eqn_push_back_binary_op( my_eqn0, LIBXSMM_MELTW_TYPE_BINARY_PACK, LIBXSMM_MELTW_FLAG_BINARY_NONE, LIBXSMM_DATATYPE_F32 );

--- a/samples/xgemm/Makefile
+++ b/samples/xgemm/Makefile
@@ -46,7 +46,7 @@ OBJECTS := $(CPPOBJS) $(CXXOBJS) $(CCXOBJS) $(COBJCTS)
 FTNSRCS := $(FXXSRCS) $(F77SRCS) $(F90SRCS)
 MODULES := $(addsuffix .mod,$(basename $(FTNSRCS))) $(addsuffix .modmic,$(basename $(FTNSRCS)))
 FTNOBJS := $(FXXOBJS) $(F77OBJS) $(F90OBJS)
-XFILES := $(OUTDIR)/$(OUTNAME) $(OUTDIR)/kernel $(OUTDIR)/bf16sgemm $(OUTDIR)/kernel_parallel
+XFILES := $(OUTDIR)/$(OUTNAME) $(OUTDIR)/kernel $(OUTDIR)/kernel_fused_ops $(OUTDIR)/bf16sgemm $(OUTDIR)/kernel_parallel
 
 .PHONY: all
 all: $(XFILES)
@@ -59,6 +59,9 @@ $(OUTDIR)/$(OUTNAME): $(OUTDIR)/.make $(BLDDIR)/$(OUTNAME)-c.o $(LIBDEP) $(EXTDE
 
 $(OUTDIR)/kernel: $(OUTDIR)/.make $(BLDDIR)/kernel-c.o $(LIBDEP)
 	$(LD) -o $@ $(BLDDIR)/kernel-c.o $(MAINLIB) $(SLDFLAGS) $(LDFLAGS) $(CLDFLAGS)
+
+$(OUTDIR)/kernel_fused_ops: $(OUTDIR)/.make $(BLDDIR)/kernel_fused_ops-c.o $(LIBDEP)
+	$(LD) -o $@ $(BLDDIR)/kernel_fused_ops-c.o $(MAINLIB) $(SLDFLAGS) $(LDFLAGS) $(CLDFLAGS)
 
 $(OUTDIR)/kernel_parallel: $(OUTDIR)/.make $(BLDDIR)/kernel_parallel-c.o $(LIBDEP)
 	$(LD) -o $@ $(BLDDIR)/kernel_parallel-c.o $(MAINLIB) $(SLDFLAGS) $(LDFLAGS) $(CLDFLAGS)

--- a/samples/xgemm/kernel_fused_ops.c
+++ b/samples/xgemm/kernel_fused_ops.c
@@ -1,0 +1,1358 @@
+/******************************************************************************
+* Copyright (c) Intel Corporation - All rights reserved.                      *
+* This file is part of the LIBXSMM library.                                   *
+*                                                                             *
+* For information on the license, see the LICENSE file.                       *
+* Further information: https://github.com/hfp/libxsmm/                        *
+* SPDX-License-Identifier: BSD-3-Clause                                       *
+******************************************************************************/
+/* Evangelos Georganas, Alexander Heinecke (Intel Corp.)
+******************************************************************************/
+#include <libxsmm.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <string.h>
+# if defined(__APPLE__) && defined(__arm64__)
+#include <pthread.h>
+# endif
+
+#define USE_GEMM_EXT_FRONTEND
+
+#define COLBIAS_ADD     1
+#define RELU_NOBITMASK  1
+#define RELU_BITMASK    2
+#define SIGMOID         3
+
+typedef struct fusion_args {
+  char *colbias;
+  char *relu_bitmask;
+} fusion_args;
+
+typedef struct gemm_def {
+  libxsmm_datatype in_type;
+  libxsmm_datatype out_type;
+  libxsmm_datatype comp_type;
+  libxsmm_blasint m;
+  libxsmm_blasint n;
+  libxsmm_blasint k;
+  libxsmm_blasint lda;
+  libxsmm_blasint ldb;
+  libxsmm_blasint ldc;
+  double alpha;
+  double beta;
+  int trans_a;
+  int trans_b;
+  int vnni_a;
+  int vnni_b;
+  int vnni_c;
+  int unsigned_a;
+  int unsigned_b;
+  int unsigned_c;
+  int aligned_a;
+  int aligned_c;
+  int prefetch;
+  int br_type;
+  libxsmm_blasint br_count;
+  int br_unroll;
+  int tc_config;
+  float scf;
+  int binary_postop;
+  int unary_postop;
+} gemm_def;
+
+float fsigmoid(float x) {
+  return (LIBXSMM_TANHF(x/2.0f) + 1.0f)/2.0f;
+}
+
+void relu_fwd_f32_f32_gold(libxsmm_blasint M, libxsmm_blasint N, libxsmm_blasint ldi, libxsmm_blasint ldo, libxsmm_blasint ldo_mask, float *in, float *out, float alpha, unsigned char *out_mask, unsigned char type, libxsmm_blasint use_bitmask) {
+  libxsmm_blasint i, j;
+  if ( (type != 2) && (use_bitmask > 0)) {
+    memset(out_mask, 0, ldo_mask*N);
+    for ( j = 0; j < N; ++j ) {
+      for ( i = 0; i < M; ++i ) {
+        out_mask[(j*ldo_mask) + i/8] |= (unsigned char)(( in[(j*ldi) + i] < 0.0f ) ? 0x0 : (1 << (i%8)) );
+      }
+    }
+  }
+  for ( j = 0; j < N; ++j ) {
+    for ( i = 0; i < M; ++i ) {
+      if ( type == 0 ) {
+        out[(j*ldo) + i] = ( in[(j*ldi) + i] < 0.0f ) ? 0.0f : in[(j*ldi) + i];
+      } else if ( type == 1 ) {
+        out[(j*ldo) + i] = ( in[(j*ldi) + i] < 0.0f ) ? alpha*in[(j*ldi) + i] : in[(j*ldi) + i];
+      } else if ( type == 2 ) {
+        out[(j*ldo) + i] = ( in[(j*ldi) + i] < 0.0f ) ? alpha * (expf(in[(j*ldi) + i])-1.0) : in[(j*ldi) + i];
+      }
+    }
+  }
+}
+
+void relu_fwd_bf16_bf16_gold(libxsmm_blasint M, libxsmm_blasint N, libxsmm_blasint ldi, libxsmm_blasint ldo, libxsmm_blasint ldo_mask, libxsmm_bfloat16 *in, libxsmm_bfloat16 *out, float alpha, unsigned char *out_mask, unsigned char type, libxsmm_blasint use_bitmask) {
+  libxsmm_blasint i, j;
+  if ( (type != 2) && (use_bitmask > 0)) {
+    memset(out_mask, 0, ldo_mask*N);
+    for ( j = 0; j < N; ++j ) {
+      for ( i = 0; i < M; ++i ) {
+        out_mask[(j*ldo_mask) + i/8] |= (unsigned char)(( (in[(j*ldi) + i] & 0x8000) == 0x8000 ) ? 0x0 : (1 << (i%8)) );
+      }
+    }
+  }
+  for ( j = 0; j < N; ++j ) {
+    for ( i = 0; i < M; ++i ) {
+      if ( type == 0 ) {
+        out[(j*ldo) + i] = ( (in[(j*ldi) + i] & 0x8000) == 0x8000 ) ? 0 : in[(j*ldi) + i];
+      } else if ( type == 1 ) {
+        union libxsmm_bfloat16_hp bf16_hp;
+        union libxsmm_bfloat16_hp bf16_hp_out;
+        bf16_hp.i[0] = 0;
+        bf16_hp.i[1] = in[(j*ldi) + i];
+        bf16_hp_out.f = ( (in[(j*ldi) + i] & 0x8000) == 0x8000 ) ? alpha*bf16_hp.f : bf16_hp.f;
+        out[(j*ldo) + i] = bf16_hp_out.i[1];
+      } else if ( type == 2 ) {
+        float in_f;
+        libxsmm_bfloat16 res;
+        union libxsmm_bfloat16_hp bf16_hp;
+        bf16_hp.i[1] = in[(j*ldi) + i];
+        bf16_hp.i[0] = 0;
+        in_f = bf16_hp.f;
+        in_f = alpha * (expf(in_f)-1.0);
+        libxsmm_rne_convert_fp32_bf16( &in_f, &res, 1 );
+        out[(j*ldo) + i] = ( (in[(j*ldi) + i] & 0x8000) == 0x8000 ) ? res : in[(j*ldi) + i];
+      }
+    }
+  }
+}
+
+void apply_colbias_add(const gemm_def *i_gemm_def, void *l_c_gold, void *l_colbias) {
+  unsigned int ldc = i_gemm_def->ldc;
+  unsigned int m = i_gemm_def->m;
+  unsigned int n = i_gemm_def->n;
+  libxsmm_blasint i, j;
+  if (i_gemm_def->out_type == LIBXSMM_DATATYPE_F32) {
+    float* f_c_gold  = (float*)l_c_gold;
+    float* f_colbias = (float*)l_colbias;
+
+    for (j = 0; j < n; j++) {
+      for (i = 0; i < m; i++) {
+        f_c_gold[i + j * ldc] = f_c_gold[i + j * ldc] + f_colbias[i];
+      }
+    }
+  } else if (i_gemm_def->out_type  == LIBXSMM_DATATYPE_BF16 ) {
+    libxsmm_bfloat16* h_c_gold  = (libxsmm_bfloat16*)l_c_gold;
+    libxsmm_bfloat16* h_colbias = (libxsmm_bfloat16*)l_colbias;
+    for (j = 0; j < n; j++) {
+      for (i = 0; i < m; i++) {
+        union libxsmm_bfloat16_hp tmp_c;
+        union libxsmm_bfloat16_hp tmp_colb;
+        float res = 0.0;
+        tmp_c.i[0] = 0;
+        tmp_c.i[1] = h_c_gold[i + j * ldc];
+        tmp_colb.i[0] = 0;
+        tmp_colb.i[1] = h_colbias[i];
+        res = tmp_c.f + tmp_colb.f;
+        libxsmm_rne_convert_fp32_bf16( &res, &h_c_gold[i + j * ldc], 1 );
+      }
+    }
+  }
+}
+
+void apply_relu(const gemm_def *i_gemm_def, void *l_c_gold, void *l_relu_bitmask_gold, libxsmm_blasint use_bitmask) {
+  unsigned int ldc = i_gemm_def->ldc;
+  unsigned int m = i_gemm_def->m;
+  unsigned int n = i_gemm_def->n;
+  libxsmm_blasint i, j;
+  if (i_gemm_def->out_type == LIBXSMM_DATATYPE_F32) {
+    float* f_c_gold  = (float*)l_c_gold;
+    relu_fwd_f32_f32_gold(m, n, ldc, ldc, ldc/8, f_c_gold, f_c_gold, 0, (unsigned char *)l_relu_bitmask_gold, 0, use_bitmask);
+  } else if (i_gemm_def->out_type == LIBXSMM_DATATYPE_BF16) {
+    libxsmm_bfloat16* h_c_gold  = (libxsmm_bfloat16*)l_c_gold;
+    relu_fwd_bf16_bf16_gold(m, n, ldc, ldc, ldc/8, h_c_gold, h_c_gold, 0, (unsigned char *)l_relu_bitmask_gold, 0, use_bitmask);
+  }
+}
+
+void apply_sigmoid(const gemm_def *i_gemm_def, void *l_c_gold) {
+  unsigned int ldc = i_gemm_def->ldc;
+  unsigned int m = i_gemm_def->m;
+  unsigned int n = i_gemm_def->n;
+  libxsmm_blasint i, j;
+  if (i_gemm_def->out_type == LIBXSMM_DATATYPE_F32) {
+    float* f_c_gold  = (float*)l_c_gold;
+    for (j = 0; j < n; j++) {
+      for (i = 0; i < m; i++) {
+        f_c_gold[i + j * ldc] = fsigmoid(f_c_gold[i + j * ldc]);
+      }
+    }
+  } else if (i_gemm_def->out_type == LIBXSMM_DATATYPE_BF16) {
+    libxsmm_bfloat16* h_c_gold  = (libxsmm_bfloat16*)l_c_gold;
+    for (j = 0; j < n; j++) {
+      for (i = 0; i < m; i++) {
+        union libxsmm_bfloat16_hp tmp_c;
+        float res = 0.0;
+        tmp_c.i[0] = 0;
+        tmp_c.i[1] = h_c_gold[i + j * ldc];
+        res = fsigmoid(tmp_c.f);
+        libxsmm_rne_convert_fp32_bf16( &res, &h_c_gold[i + j * ldc], 1 );
+      }
+    }
+  }
+}
+
+void init_random_matrix( libxsmm_datatype dtype, void* data, libxsmm_blasint br, libxsmm_blasint ld, libxsmm_blasint n ) {
+  double* d_data = (double*) data;
+  float* f_data = (float*) data;
+  libxsmm_bfloat16* bf_data = (libxsmm_bfloat16*) data;
+  int* i_data = (int*) data;
+  short* s_data = (short*) data;
+  char* c_data = (char*) data;
+  unsigned int l_r, l_i, l_j;
+
+  for (l_r = 0; l_r < br; l_r++) {
+    for (l_i = 0; l_i < ld; l_i++) {
+      for (l_j = 0; l_j < n; l_j++) {
+        if ( dtype == LIBXSMM_DATATYPE_F64 ) {
+          d_data[(l_r * ld * n) + (l_j * ld) + l_i] = libxsmm_rng_f64();
+        } else if ( dtype == LIBXSMM_DATATYPE_F32 ) {
+          f_data[(l_r * ld * n) + (l_j * ld) + l_i] = (float)(0.05 - libxsmm_rng_f64()/10.0);
+        } else if ( dtype == LIBXSMM_DATATYPE_BF16 ) {
+          union libxsmm_bfloat16_hp tmp;
+          tmp.f = (float)(0.05 - libxsmm_rng_f64()/10.0);
+          bf_data[(l_r * ld * n) + (l_j * ld) + l_i] = tmp.i[1];
+        } else if ( dtype == LIBXSMM_DATATYPE_I32 ) {
+          i_data[(l_r * ld * n) + (l_j * ld) + l_i] = (int)  (libxsmm_rng_f64() * 20.0);
+        } else if ( dtype == LIBXSMM_DATATYPE_I16 ) {
+          s_data[(l_r * ld * n) + (l_j * ld) + l_i] = (short)(libxsmm_rng_f64() * 20.0);
+        } else if ( dtype == LIBXSMM_DATATYPE_I8 ) {
+          c_data[(l_r * ld * n) + (l_j * ld) + l_i] = (char) (libxsmm_rng_f64() * 20.0);
+        } else {
+        }
+      }
+    }
+  }
+}
+
+void init_zero_matrix( libxsmm_datatype dtype, void* data, libxsmm_blasint br, libxsmm_blasint ld, libxsmm_blasint n ) {
+  char* l_data = (char*) data;
+  memset( l_data, 0x0, br*ld*n*LIBXSMM_TYPESIZE(dtype) );
+}
+
+void init_garbage_matrix( libxsmm_datatype dtype, void* data, libxsmm_blasint br, libxsmm_blasint ld, libxsmm_blasint n ) {
+  char* l_data = (char*) data;
+  memset( l_data, 0xdeadbeef, br*ld*n*LIBXSMM_TYPESIZE(dtype) );
+}
+
+void ref_matmul( gemm_def* i_gemm_def, void* a, void* b, void* c ) {
+  unsigned int l_r, l_j, l_i, l_s, l_k2;
+  unsigned int lda = i_gemm_def->lda;
+  unsigned int ldb = i_gemm_def->ldb;
+  unsigned int ldc = i_gemm_def->ldc;
+  unsigned int m = i_gemm_def->m;
+  unsigned int n = i_gemm_def->n;
+  unsigned int k = i_gemm_def->k;
+
+  if ( (i_gemm_def->in_type   == LIBXSMM_DATATYPE_F64) &&
+       (i_gemm_def->out_type  == LIBXSMM_DATATYPE_F64) &&
+       (i_gemm_def->comp_type == LIBXSMM_DATATYPE_F64)    ) {
+    double* d_a = (double*)a;
+    double* d_b = (double*)b;
+    double* d_c = (double*)c;
+
+    for (l_r = 0; l_r < i_gemm_def->br_count; l_r++) {
+      for (l_j = 0; l_j < n; l_j++) {
+        for (l_i = 0; l_i < m; l_i++) {
+          if ( (i_gemm_def->beta == 0) && (l_r == 0) ) {
+            d_c[(l_j * ldc) + l_i] = 0.0;
+          }
+          for (l_s = 0; l_s < k; l_s++) {
+            if ( i_gemm_def->trans_b == 0 ) {
+              d_c[(l_j * ldc) + l_i] += d_a[(l_r * lda * k) + ((l_s * lda) + l_i)] * d_b[(l_r * ldb * n) + ((l_j * ldb) + l_s)];
+            } else {
+              d_c[(l_j * ldc) + l_i] += d_a[(l_r * lda * k) + ((l_s * lda) + l_i)] * d_b[(l_r * ldb * k) + ((l_s * ldb) + l_j)];
+            }
+          }
+        }
+      }
+    }
+  } else if ( (i_gemm_def->in_type   == LIBXSMM_DATATYPE_F32) &&
+              (i_gemm_def->out_type  == LIBXSMM_DATATYPE_F32) &&
+              (i_gemm_def->comp_type == LIBXSMM_DATATYPE_F32)    ) {
+    float* f_a = (float*)a;
+    float* f_b = (float*)b;
+    float* f_c = (float*)c;
+
+    for (l_r = 0; l_r < i_gemm_def->br_count; l_r++) {
+      for (l_j = 0; l_j < n; l_j++) {
+        for (l_i = 0; l_i < m; l_i++) {
+          if ( (i_gemm_def->beta == 0) && (l_r == 0) ) {
+            f_c[(l_j * ldc) + l_i] = 0.0;
+          }
+          for (l_s = 0; l_s < k; l_s++) {
+            if ( i_gemm_def->trans_b == 0 ) {
+              f_c[(l_j * ldc) + l_i] += f_a[(l_r * lda * k) + ((l_s * lda) + l_i)] * f_b[(l_r * ldb * n) + ((l_j * ldb) + l_s)];
+            } else {
+              f_c[(l_j * ldc) + l_i] += f_a[(l_r * lda * k) + ((l_s * lda) + l_i)] * f_b[(l_r * ldb * k) + ((l_s * ldb) + l_j)];
+            }
+          }
+        }
+      }
+    }
+  } else if ( (i_gemm_def->in_type   == LIBXSMM_DATATYPE_I16) &&
+              (i_gemm_def->out_type  == LIBXSMM_DATATYPE_I32) &&
+              (i_gemm_def->comp_type == LIBXSMM_DATATYPE_I32)    ) {
+    short* s_a = (short*)a;
+    short* s_b = (short*)b;
+    int*   i_c = (int*)c;
+    int l_k_block = 2;
+
+    for (l_r = 0; l_r < i_gemm_def->br_count; l_r++) {
+      for (l_j = 0; l_j < n; l_j++) {
+        for (l_i = 0; l_i < m; l_i++) {
+          if ( (i_gemm_def->beta == 0) && (l_r == 0) ) {
+            i_c[(l_j * ldc) + l_i] = 0;
+          }
+          for (l_s = 0; l_s < (k / l_k_block); l_s++) {
+            for (l_k2 = 0; l_k2 < l_k_block; l_k2++) {
+              i_c[(l_j * ldc) + l_i] += s_a[(l_r * lda * k) + (l_s * (lda*l_k_block)) + (l_i*l_k_block) + l_k2] *
+                                        s_b[(l_r * ldb * n) + (l_j * ldb) + (l_s*l_k_block) + l_k2];
+            }
+          }
+        }
+      }
+    }
+  } else if ( (i_gemm_def->in_type   == LIBXSMM_DATATYPE_I8)  &&
+              (i_gemm_def->out_type  == LIBXSMM_DATATYPE_I32)  &&
+              (i_gemm_def->comp_type == LIBXSMM_DATATYPE_I32) &&
+              (i_gemm_def->unsigned_a == 1) && (i_gemm_def->unsigned_b == 0) ) {
+    unsigned char* c_a = (unsigned char*)a;
+    char*          c_b = (char*)b;
+    int*           i_c = (int*)c;
+    int l_k_block = 4;
+
+    for (l_r = 0; l_r < i_gemm_def->br_count; l_r++) {
+      for (l_j = 0; l_j < n; l_j++) {
+        for (l_i = 0; l_i < m; l_i++) {
+          if ( (i_gemm_def->beta == 0) && (l_r == 0) ) {
+            i_c[(l_j * ldc) + l_i] = 0;
+          }
+          for (l_s = 0; l_s < (k / l_k_block); l_s++) {
+            for (l_k2 = 0; l_k2 < l_k_block; l_k2++) {
+              i_c[(l_j * ldc) + l_i] += c_a[(l_r * lda * k) + (l_s * (lda*l_k_block)) + (l_i*l_k_block) + l_k2] *
+                                        c_b[(l_r * ldb * n) + (l_j * ldb) + (l_s*l_k_block) + l_k2];
+            }
+          }
+        }
+      }
+    }
+  } else if ( (i_gemm_def->in_type   == LIBXSMM_DATATYPE_I8)  &&
+              (i_gemm_def->out_type  == LIBXSMM_DATATYPE_I32)  &&
+              (i_gemm_def->comp_type == LIBXSMM_DATATYPE_I32) &&
+              (i_gemm_def->unsigned_a == 0) && (i_gemm_def->unsigned_b == 1) ) {
+    char*          c_a = (char*)a;
+    unsigned char* c_b = (unsigned char*)b;
+    int*           i_c = (int*)c;
+    int l_k_block = 4;
+
+    for (l_r = 0; l_r < i_gemm_def->br_count; l_r++) {
+      for (l_j = 0; l_j < n; l_j++) {
+        for (l_i = 0; l_i < m; l_i++) {
+          if ( (i_gemm_def->beta == 0) && (l_r == 0) ) {
+            i_c[(l_j * ldc) + l_i] = 0;
+          }
+          for (l_s = 0; l_s < (k / l_k_block); l_s++) {
+            for (l_k2 = 0; l_k2 < l_k_block; l_k2++) {
+              i_c[(l_j * ldc) + l_i] += c_a[(l_r * lda * k) + (l_s * (lda*l_k_block)) + (l_i*l_k_block) + l_k2] *
+                                        c_b[(l_r * ldb * n) + (l_j * ldb) + (l_s*l_k_block) + l_k2];
+            }
+          }
+        }
+      }
+    }
+  } else if ( (i_gemm_def->in_type   == LIBXSMM_DATATYPE_I8)  &&
+              (i_gemm_def->out_type  == LIBXSMM_DATATYPE_I8)  &&
+              (i_gemm_def->comp_type == LIBXSMM_DATATYPE_I32) &&
+              (i_gemm_def->unsigned_a == 0) && (i_gemm_def->unsigned_b == 1) && (i_gemm_def->unsigned_c == 1) ) {
+    char*          c_a = (char*)a;
+    unsigned char* c_b = (unsigned char*)b;
+    unsigned char* c_c = (unsigned char*)c;
+    int l_k_block = 4;
+
+    for (l_r = 0; l_r < i_gemm_def->br_count; l_r++) {
+      for (l_j = 0; l_j < n; l_j++) {
+        for (l_i = 0; l_i < m; l_i++) {
+          int tmp;
+          float ftmp;
+          if ( (i_gemm_def->beta == 0) && (l_r == 0) ) {
+            tmp = 0;
+          } else {
+            tmp = (int)c_c[(l_j * ldc) + l_i];
+          }
+          for (l_s = 0; l_s < (k / l_k_block); l_s++) {
+            for (l_k2 = 0; l_k2 < l_k_block; l_k2++) {
+              tmp += c_a[(l_r * lda * k) + (l_s * (lda*l_k_block)) + (l_i*l_k_block) + l_k2] *
+                     c_b[(l_r * ldb * n) + (l_j * ldb) + (l_s*l_k_block) + l_k2];
+            }
+          }
+          ftmp = (float)tmp;
+          ftmp *= i_gemm_def->scf;
+          c_c[(l_j * ldc) + l_i] = (unsigned char)ftmp;
+        }
+      }
+    }
+  } else if ( (i_gemm_def->in_type   == LIBXSMM_DATATYPE_BF16) &&
+              (i_gemm_def->out_type  == LIBXSMM_DATATYPE_F32)  &&
+              (i_gemm_def->comp_type == LIBXSMM_DATATYPE_F32)     ) {
+    libxsmm_bfloat16* h_a = (libxsmm_bfloat16*)a;
+    libxsmm_bfloat16* h_b = (libxsmm_bfloat16*)b;
+    float*            f_c = (float*)c;
+    int l_k_block = ( i_gemm_def->vnni_a != 0) ?  2 : 1;
+
+    for (l_r = 0; l_r < i_gemm_def->br_count; l_r++) {
+      for (l_j = 0; l_j < n; l_j++) {
+        for (l_i = 0; l_i < m; l_i++) {
+          if ( (i_gemm_def->beta == 0) && (l_r == 0) ) {
+            f_c[(l_j * ldc) + l_i] = 0.0f;
+          }
+          for (l_s = 0; l_s < (k / l_k_block); l_s++) {
+            for (l_k2 = 0; l_k2 < l_k_block; l_k2++) {
+              union libxsmm_bfloat16_hp tmp_a_f;
+              union libxsmm_bfloat16_hp tmp_b_f;
+              tmp_a_f.i[0] = 0;
+              tmp_a_f.i[1] = h_a[(l_r * lda * k) + (l_s * (lda*l_k_block)) + (l_i*l_k_block) + l_k2];
+              tmp_b_f.i[0] = 0;
+              tmp_b_f.i[1] = h_b[(l_r * ldb * n) + (l_j * ldb) + (l_s*l_k_block) + l_k2];
+
+              f_c[(l_j * ldc) + l_i] += tmp_a_f.f * tmp_b_f.f;
+            }
+          }
+        }
+      }
+    }
+  } else if ( (i_gemm_def->in_type   == LIBXSMM_DATATYPE_BF16) &&
+              (i_gemm_def->out_type  == LIBXSMM_DATATYPE_BF16) &&
+              (i_gemm_def->comp_type == LIBXSMM_DATATYPE_F32)     ) {
+    libxsmm_bfloat16* h_a = (libxsmm_bfloat16*)a;
+    libxsmm_bfloat16* h_b = (libxsmm_bfloat16*)b;
+    libxsmm_bfloat16* h_c = (libxsmm_bfloat16*)c;
+    int l_k_block = ( i_gemm_def->vnni_a != 0) ?  2 : 1;
+    float acc = 0.0f;
+    libxsmm_bfloat16 h_acc;
+
+    for (l_r = 0; l_r < i_gemm_def->br_count; l_r++) {
+      for (l_j = 0; l_j < n; l_j++) {
+        for (l_i = 0; l_i < m; l_i++) {
+          if ( (i_gemm_def->beta == 0) && (l_r == 0) ) {
+            acc = 0.0f;
+          } else {
+            union libxsmm_bfloat16_hp tmp;
+            tmp.i[0] = 0;
+            tmp.i[1] = h_c[(l_j * ldc) + l_i];
+            acc = tmp.f;
+          }
+          for (l_s = 0; l_s < (k / l_k_block); l_s++) {
+            for (l_k2 = 0; l_k2 < l_k_block; l_k2++) {
+              union libxsmm_bfloat16_hp tmp_a_f;
+              union libxsmm_bfloat16_hp tmp_b_f;
+              tmp_a_f.i[0] = 0;
+              tmp_a_f.i[1] = h_a[(l_r * lda * k) + (l_s * (lda*l_k_block)) + (l_i*l_k_block) + l_k2];
+              tmp_b_f.i[0] = 0;
+              tmp_b_f.i[1] = h_b[(l_r * ldb * n) + (l_j * ldb) + (l_s*l_k_block) + l_k2];
+
+              acc += tmp_a_f.f * tmp_b_f.f;
+            }
+          }
+          libxsmm_rne_convert_fp32_bf16( &acc, &h_acc, 1 );
+          h_c[(l_j * ldc) + l_i] = h_acc;
+        }
+      }
+    }
+  }
+}
+
+void fused_matmul( gemm_def* i_gemm_def, void* l_a, void* l_b, void* l_c_gold, fusion_args *ref_fusion_arguments ) {
+
+  /* Run matmul */
+  ref_matmul( i_gemm_def, l_a, l_b, l_c_gold );
+
+  /* Perform binary postop if requested */
+  if (i_gemm_def->binary_postop == COLBIAS_ADD) {
+    apply_colbias_add(i_gemm_def, l_c_gold, ref_fusion_arguments->colbias);
+  }
+  /* Perform unary postop if requested */
+  if (i_gemm_def->unary_postop == RELU_NOBITMASK) {
+    apply_relu(i_gemm_def, l_c_gold, ref_fusion_arguments->relu_bitmask, 0);
+  } else if (i_gemm_def->unary_postop == RELU_BITMASK) {
+    apply_relu(i_gemm_def, l_c_gold, ref_fusion_arguments->relu_bitmask, 1);
+  } else if (i_gemm_def->unary_postop == SIGMOID) {
+    apply_sigmoid(i_gemm_def, l_c_gold);
+  }
+}
+
+double check_matrix( libxsmm_datatype dtype, void* data_gold, void* data, libxsmm_blasint ld, libxsmm_blasint m, libxsmm_blasint n ) {
+  libxsmm_matdiff_info l_diff;
+  double max_error = 0.0;
+
+  libxsmm_matdiff_clear(&l_diff);
+
+  if ( dtype == LIBXSMM_DATATYPE_F64 ) {
+    libxsmm_matdiff(&l_diff, LIBXSMM_DATATYPE_F64, m, n, data_gold, data, &ld, &ld);
+    max_error = l_diff.linf_abs;
+  } else if ( dtype == LIBXSMM_DATATYPE_F32 ) {
+    libxsmm_matdiff(&l_diff, LIBXSMM_DATATYPE_F32, m, n, data_gold, data, &ld, &ld);
+    max_error = l_diff.linf_abs;
+  } else if ( dtype == LIBXSMM_DATATYPE_BF16 ) {
+    unsigned int l_i, l_j;
+    libxsmm_bfloat16* h_data =      (libxsmm_bfloat16*)data;
+    libxsmm_bfloat16* h_data_gold = (libxsmm_bfloat16*)data_gold;
+    for (l_i = 0; l_i < m; l_i++) {
+      for (l_j = 0; l_j < n; l_j++) {
+        union libxsmm_bfloat16_hp tmp_c;
+        union libxsmm_bfloat16_hp tmp_gold;
+        double l_fabs;
+
+        tmp_c.i[1] = h_data[(l_j * ld) + l_i];
+        tmp_c.i[0] = 0;
+        tmp_gold.i[1] = h_data_gold[(l_j * ld) + l_i];
+        tmp_gold.i[0] = 0;
+        l_fabs = fabs((double)tmp_gold.f - (double)tmp_c.f);
+#if 1
+        if (max_error < l_fabs) max_error = l_fabs;
+#else
+        if (max_error < l_fabs) {
+          max_error = l_fabs;
+          printf("vals are %.5g and %.5g\n",(double)tmp_gold.f,(double)tmp_c.f);
+        }
+#endif
+      }
+    }
+  } else if ( dtype == LIBXSMM_DATATYPE_I32 ) {
+    unsigned int l_i, l_j;
+    int* l_data = (int*)data;
+    int* l_data_gold = (int*)data_gold;
+    for (l_i = 0; l_i < m; l_i++) {
+      for (l_j = 0; l_j < n; l_j++) {
+        const double l_fabs = fabs((double)l_data_gold[(l_j * ld) + l_i] - (double)l_data[(l_j * ld) + l_i]);
+        if (max_error < l_fabs) max_error = l_fabs;
+      }
+    }
+  } else if ( dtype == LIBXSMM_DATATYPE_I8 ) {
+    unsigned int l_i, l_j;
+    unsigned char* l_data      = (unsigned char*)data;
+    unsigned char* l_data_gold = (unsigned char*)data_gold;
+    for (l_i = 0; l_i < m; l_i++) {
+      for (l_j = 0; l_j < n; l_j++) {
+        const double l_fabs = fabs((double)l_data_gold[(l_j * ld) + l_i] - (double)l_data[(l_j * ld) + l_i]);
+        if (max_error < l_fabs) max_error = l_fabs;
+      }
+    }
+  } else {
+    max_error = 100.0;
+  }
+
+  return max_error;
+}
+
+void check_matrix_norms( libxsmm_datatype dtype, void* data_gold, void* data, libxsmm_blasint ld, libxsmm_blasint m, libxsmm_blasint n  ) {
+  libxsmm_matdiff_info norms, diff;
+  libxsmm_matdiff_clear(&norms);
+  libxsmm_matdiff_clear(&diff);
+  float *gold_c = (float*) libxsmm_aligned_malloc( ld * n * sizeof(float), 64);
+  float *comp_c = (float*) libxsmm_aligned_malloc( ld * n * sizeof(float), 64);
+
+  if (dtype == LIBXSMM_DATATYPE_F32) {
+    memcpy(gold_c, data_gold, ld * n * sizeof(float));
+    memcpy(comp_c, data     , ld * n * sizeof(float));
+  }
+  if (dtype == LIBXSMM_DATATYPE_BF16) {
+    libxsmm_convert_bf16_f32( data_gold, gold_c, ld*n );
+    libxsmm_convert_bf16_f32( data     , comp_c, ld*n );
+  }
+
+  /* compare */
+  libxsmm_matdiff(&norms, LIBXSMM_DATATYPE_F32, ld*n, 1, gold_c, comp_c, 0, 0);
+  printf("\n##########################################\n");
+  printf("#       Correctness norm-checking        #\n");
+  printf("##########################################\n");
+  printf("L1 reference  : %.25g\n", norms.l1_ref);
+  printf("L1 test       : %.25g\n", norms.l1_tst);
+  printf("L2 abs.error  : %.24f\n", norms.l2_abs);
+  printf("L2 rel.error  : %.24f\n", norms.l2_rel);
+  printf("Linf abs.error: %.24f\n", norms.linf_abs);
+  printf("Linf rel.error: %.24f\n", norms.linf_rel);
+  printf("Check-norm    : %.24f\n", norms.normf_rel);
+  libxsmm_matdiff_reduce(&diff, &norms);
+
+  libxsmm_free(gold_c);
+  libxsmm_free(comp_c);
+}
+
+double jit_matmul( const gemm_def*    i_gemm_def,
+                   const void*        i_a,
+                   const void*        i_b,
+                   void*              o_c,
+                   void*              o_c_perf,
+                   const int          i_reps,
+                   const unsigned int i_print_jit_info,
+                   fusion_args        *i_fusion_arguments ) {
+  /* define function pointer */
+  libxsmm_xmmfunction l_test_jit = { NULL };
+  libxsmm_xmmfunction cfg_tr = { NULL };
+  libxsmm_xmmfunction rls_tr = { NULL };
+  libxsmm_timer_tickint l_start;
+  libxsmm_mmkernel_info l_info;
+  libxsmm_gemm_shape l_shape;
+  libxsmm_gemm_batch_reduce_config l_brconfig;
+  libxsmm_gemm_ext_unary_argops l_argops;
+  libxsmm_gemm_ext_binary_postops l_postops;
+  libxsmm_bitfield l_flags = LIBXSMM_GEMM_FLAGS('N', 'N');
+  libxsmm_bitfield l_prefetch_flags = 0;
+#if defined(USE_GEMM_EXT_FRONTEND)
+  libxsmm_gemm_ext_param gemm_param;
+#else
+  libxsmm_gemm_param gemm_param;
+#endif
+  double l_jittime, l_runtime;
+  size_t l_t, l_r;
+  char** l_a_addr = (char**)malloc(i_gemm_def->br_count*sizeof(char*));
+  char** l_b_addr = (char**)malloc(i_gemm_def->br_count*sizeof(char*));
+  unsigned long long* l_a_offs = (unsigned long long*)malloc(i_gemm_def->br_count*sizeof(unsigned long long));
+  unsigned long long* l_b_offs = (unsigned long long*)malloc(i_gemm_def->br_count*sizeof(unsigned long long));
+  double l_beta = i_gemm_def->beta;
+  unsigned long long l_br = (unsigned long long)i_gemm_def->br_count;
+  int l_cfg_flags = 0;
+  int l_rls_flags = 0;
+
+  if (0 == i_gemm_def) {
+    fprintf(stderr, "JIT: unsupported descriptor arguments or data type!\n");
+    return EXIT_FAILURE;
+  }
+
+  /* setup brgemm offsets */
+  if ( i_gemm_def->br_type == 2 ) {
+    for ( l_r = 0 ; l_r < i_gemm_def->br_count; l_r++ ) {
+      l_a_offs[l_r] = l_r * (size_t)i_gemm_def->lda * (size_t)i_gemm_def->k * LIBXSMM_TYPESIZE(i_gemm_def->in_type);
+      if (i_gemm_def->trans_b == 0) {
+        l_b_offs[l_r] = l_r * (size_t)i_gemm_def->ldb * (size_t)i_gemm_def->n * LIBXSMM_TYPESIZE(i_gemm_def->in_type);
+      } else {
+        l_b_offs[l_r] = l_r * (size_t)i_gemm_def->ldb * (size_t)i_gemm_def->k * LIBXSMM_TYPESIZE(i_gemm_def->in_type);
+      }
+    }
+  }
+
+  /* set up the flags */
+  if ( i_gemm_def->trans_b != 0 ) {
+    l_flags |= LIBXSMM_GEMM_FLAG_TRANS_B;
+  }
+  if ( i_gemm_def->trans_a != 0 ) {
+    fprintf(stderr, "trans_a needs to be 0\n");
+    return EXIT_FAILURE;
+  }
+  if ( i_gemm_def->vnni_a != 0 ) {
+    l_flags |= LIBXSMM_GEMM_FLAG_VNNI_A;
+  }
+  if ( i_gemm_def->unsigned_a != 0 ) {
+    l_flags |= LIBXSMM_GEMM_FLAG_A_UNSIGNED;
+  }
+  if ( i_gemm_def->unsigned_b != 0 ) {
+    l_flags |= LIBXSMM_GEMM_FLAG_B_UNSIGNED;
+  }
+
+  l_flags |= (0 != i_gemm_def->aligned_a ? LIBXSMM_GEMM_FLAG_ALIGN_A : 0);
+  l_flags |= (0 != i_gemm_def->aligned_c ? LIBXSMM_GEMM_FLAG_ALIGN_C : 0);
+  l_flags |= ( l_beta == 0 ) ? LIBXSMM_GEMM_FLAG_BETA_0 : 0;
+
+  /* setting update GEMM struct */
+  l_shape.m = i_gemm_def->m;
+  l_shape.n = i_gemm_def->n;
+  l_shape.k = i_gemm_def->k;
+  l_shape.lda = (void*)&(i_gemm_def->lda);
+  l_shape.ldb = (void*)&(i_gemm_def->ldb);
+  l_shape.ldc = (void*)&(i_gemm_def->ldc);
+  l_shape.a_in_type = i_gemm_def->in_type;
+  l_shape.b_in_type = i_gemm_def->in_type;
+  l_shape.out_type = i_gemm_def->out_type;
+  l_shape.comp_type = i_gemm_def->comp_type;
+
+  /* setting BRGEMM config strucut */
+  if (i_gemm_def->br_type == 1) {
+    l_brconfig.br_type = LIBXSMM_GEMM_BATCH_REDUCE_ADDRESS;
+    l_brconfig.br_stride_a_hint = 0;
+    l_brconfig.br_stride_b_hint = 0;
+    l_brconfig.br_unroll_hint = ( i_gemm_def->br_unroll == 0 ) ? 0 : i_gemm_def->br_count;
+  } else if (i_gemm_def->br_type == 2) {
+    l_brconfig.br_type = LIBXSMM_GEMM_BATCH_REDUCE_OFFSET;
+    l_brconfig.br_stride_a_hint = 0;
+    l_brconfig.br_stride_b_hint = 0;
+    l_brconfig.br_unroll_hint = ( i_gemm_def->br_unroll == 0 ) ? 0 : i_gemm_def->br_count;
+  } else if (i_gemm_def->br_type == 3) {
+    l_brconfig.br_type = LIBXSMM_GEMM_BATCH_REDUCE_STRIDE;
+    l_brconfig.br_stride_a_hint = i_gemm_def->lda*i_gemm_def->k*LIBXSMM_TYPESIZE(i_gemm_def->in_type);
+    l_brconfig.br_stride_b_hint = (i_gemm_def->trans_b == 0) ? i_gemm_def->ldb*i_gemm_def->n*LIBXSMM_TYPESIZE(i_gemm_def->in_type) : i_gemm_def->ldb*i_gemm_def->k*LIBXSMM_TYPESIZE(i_gemm_def->in_type);
+    l_brconfig.br_unroll_hint = ( i_gemm_def->br_unroll == 0 ) ? 0 : i_gemm_def->br_count;
+  } else {
+    l_brconfig.br_type = LIBXSMM_GEMM_BATCH_REDUCE_NONE;
+    l_brconfig.br_stride_a_hint = 0;
+    l_brconfig.br_stride_b_hint = 0;
+    l_brconfig.br_unroll_hint = 0;
+  }
+
+  /* setting prefetch flags */
+  l_prefetch_flags = i_gemm_def->prefetch;
+
+  /* setting ext strcuts to 0 */
+  memset( &l_argops, 0, sizeof(libxsmm_gemm_ext_unary_argops) );
+  memset( &l_postops, 0, sizeof(libxsmm_gemm_ext_binary_postops) );
+
+  if (i_gemm_def->binary_postop == COLBIAS_ADD) {
+    l_postops.d_in_type      = i_gemm_def->out_type;
+    l_postops.d_binary_flags = LIBXSMM_MELTW_FLAG_BINARY_BCAST_COL_IN_0;
+    l_postops.d_binary_type  = LIBXSMM_MELTW_TYPE_BINARY_ADD;
+    l_postops.ldd            = NULL;
+  }
+
+  if (i_gemm_def->unary_postop == SIGMOID) {
+    l_argops.cp_unary_type  = LIBXSMM_MELTW_TYPE_UNARY_SIGMOID;
+  }
+
+  if (i_gemm_def->unary_postop == RELU_NOBITMASK) {
+    l_argops.cp_unary_type  = LIBXSMM_MELTW_TYPE_UNARY_RELU;
+  }
+
+  if (i_gemm_def->unary_postop == RELU_BITMASK) {
+    l_argops.cp_unary_type  = LIBXSMM_MELTW_TYPE_UNARY_RELU;
+    l_argops.cp_unary_flags = LIBXSMM_MELTW_FLAG_UNARY_BITMASK_2BYTEMULT;
+  }
+
+  l_start = libxsmm_timer_tick();
+  if (i_gemm_def->tc_config) {
+    l_cfg_flags = LIBXSMM_GEMM_FLAG_NO_RESET_TILECONFIG | l_flags;
+    l_rls_flags = LIBXSMM_GEMM_FLAG_NO_SETUP_TILECONFIG | l_flags;
+    l_flags |= (LIBXSMM_GEMM_FLAG_NO_SETUP_TILECONFIG | LIBXSMM_GEMM_FLAG_NO_RESET_TILECONFIG);
+    cfg_tr.gemm = libxsmm_dispatch_gemm_v2( l_shape, l_cfg_flags, l_prefetch_flags, l_brconfig );
+    rls_tr.gemm = libxsmm_dispatch_gemm_v2( l_shape, l_rls_flags, l_prefetch_flags, l_brconfig );
+  }
+#if defined(USE_GEMM_EXT_FRONTEND)
+  l_test_jit.gemm_ext = libxsmm_dispatch_gemm_ext_v2( l_shape, l_flags, l_prefetch_flags, l_brconfig, l_argops, l_postops );
+#else
+  l_test_jit.gemm = libxsmm_dispatch_gemm_v2( l_shape, l_flags, l_prefetch_flags, l_brconfig );
+#endif
+  l_jittime = libxsmm_timer_duration(l_start, libxsmm_timer_tick());
+  if (l_test_jit.xmm == 0) {
+    printf("JIT failed, please run with LIBXSMM_VERBOSE=-1 and/or with debug mode LIBXSMM library!\n");
+    exit(EXIT_FAILURE);
+  }
+
+  /* receive kernel information */
+  libxsmm_get_mmkernel_info(l_test_jit, &l_info);
+
+  /* run external tileconfig */
+  if (i_gemm_def->tc_config) {
+    cfg_tr.gemm( NULL );
+  }
+
+  /* reset GEMM paramater */
+#if defined(USE_GEMM_EXT_FRONTEND)
+  memset( &gemm_param, 0, sizeof(libxsmm_gemm_ext_param) );
+#else
+  memset( &gemm_param, 0, sizeof(libxsmm_gemm_param) );
+#endif
+
+  if (i_gemm_def->binary_postop == COLBIAS_ADD) {
+    gemm_param.d.primary = (void*)i_fusion_arguments->colbias;
+  }
+
+  if (i_gemm_def->unary_postop == RELU_BITMASK) {
+    gemm_param.c.secondary  = (void*) i_fusion_arguments->relu_bitmask;
+  }
+
+  gemm_param.op.tertiary = &l_br;
+  gemm_param.c.primary = (void*)o_c;
+  gemm_param.c.tertiary = (void*)(( i_gemm_def->unsigned_c != 0 ) ? &(i_gemm_def->scf) : NULL);
+  /* run correctness */
+  if (i_gemm_def->br_type == 0) {
+    gemm_param.a.primary = (void*)i_a;
+    gemm_param.b.primary = (void*)i_b;
+    if ( l_info.prefetch != LIBXSMM_GEMM_PREFETCH_NONE ) {
+      gemm_param.a.quaternary = (void*)i_a;
+      gemm_param.b.quaternary = (void*)i_b;
+      gemm_param.c.quaternary = (void*)o_c;
+    }
+#if defined(USE_GEMM_EXT_FRONTEND)
+    l_test_jit.gemm_ext( &gemm_param );
+#else
+    l_test_jit.gemm( &gemm_param );
+#endif
+  } else if (i_gemm_def->br_type == 1) {
+    gemm_param.a.primary = l_a_addr;
+    gemm_param.b.primary = l_b_addr;
+    for ( l_r = 0 ; l_r < i_gemm_def->br_count; l_r++ ) {
+      l_a_addr[l_r] = (char*)i_a + (l_r * (size_t)i_gemm_def->lda * (size_t)i_gemm_def->k * LIBXSMM_TYPESIZE(i_gemm_def->in_type));
+      if (i_gemm_def->trans_b == 0) {
+        l_b_addr[l_r] = (char*)i_b + (l_r * (size_t)i_gemm_def->ldb * (size_t)i_gemm_def->n * LIBXSMM_TYPESIZE(i_gemm_def->in_type));
+      } else {
+        l_b_addr[l_r] = (char*)i_b + (l_r * (size_t)i_gemm_def->ldb * (size_t)i_gemm_def->k * LIBXSMM_TYPESIZE(i_gemm_def->in_type));
+      }
+    }
+#if defined(USE_GEMM_EXT_FRONTEND)
+    l_test_jit.gemm_ext( &gemm_param );
+#else
+    l_test_jit.gemm( &gemm_param );
+#endif
+  } else if (i_gemm_def->br_type == 2) {
+    gemm_param.a.primary = (void*)i_a;
+    gemm_param.a.secondary = l_a_offs;
+    gemm_param.b.primary = (void*)i_b;
+    gemm_param.b.secondary = l_b_offs;
+#if defined(USE_GEMM_EXT_FRONTEND)
+    l_test_jit.gemm_ext( &gemm_param );
+#else
+    l_test_jit.gemm( &gemm_param );
+#endif
+  } else if (i_gemm_def->br_type == 3) {
+    gemm_param.a.primary = (void*)i_a;
+    gemm_param.b.primary = (void*)i_b;
+#if defined(USE_GEMM_EXT_FRONTEND)
+    l_test_jit.gemm_ext( &gemm_param );
+#else
+    l_test_jit.gemm( &gemm_param );
+#endif
+  }
+
+  /* run performance */
+  gemm_param.c.primary = (void*)o_c_perf;
+  l_start = libxsmm_timer_tick();
+  if (i_gemm_def->br_type == 0) {
+    gemm_param.a.primary = (void*)i_a;
+    gemm_param.b.primary = (void*)i_b;
+    if ( l_info.prefetch != LIBXSMM_GEMM_PREFETCH_NONE ) {
+      gemm_param.a.quaternary = (void*)i_a;
+      gemm_param.b.quaternary = (void*)i_b;
+      gemm_param.c.quaternary = (void*)o_c_perf;
+    }
+    for (l_t = 0; l_t < i_reps; l_t++) {
+#if defined(USE_GEMM_EXT_FRONTEND)
+      l_test_jit.gemm_ext( &gemm_param );
+#else
+      l_test_jit.gemm( &gemm_param );
+#endif
+    }
+  } else if (i_gemm_def->br_type == 1) {
+    gemm_param.a.primary = l_a_addr;
+    gemm_param.b.primary = l_b_addr;
+    for (l_t = 0; l_t < i_reps; l_t++) {
+      for ( l_r = 0 ; l_r < i_gemm_def->br_count; l_r++ ) {
+        l_a_addr[l_r] = (char*)i_a + (l_r * (size_t)i_gemm_def->lda * (size_t)i_gemm_def->k * LIBXSMM_TYPESIZE(i_gemm_def->in_type));
+        if (i_gemm_def->trans_b == 0) {
+          l_b_addr[l_r] = (char*)i_b + (l_r * (size_t)i_gemm_def->ldb * (size_t)i_gemm_def->n * LIBXSMM_TYPESIZE(i_gemm_def->in_type));
+        } else {
+          l_b_addr[l_r] = (char*)i_b + (l_r * (size_t)i_gemm_def->ldb * (size_t)i_gemm_def->k * LIBXSMM_TYPESIZE(i_gemm_def->in_type));
+        }
+      }
+#if defined(USE_GEMM_EXT_FRONTEND)
+      l_test_jit.gemm_ext( &gemm_param );
+#else
+      l_test_jit.gemm( &gemm_param );
+#endif
+    }
+  } else if (i_gemm_def->br_type == 2) {
+    gemm_param.a.primary = (void*)i_a;
+    gemm_param.a.secondary = l_a_offs;
+    gemm_param.b.primary = (void*)i_b;
+    gemm_param.b.secondary = l_b_offs;
+    for (l_t = 0; l_t < i_reps; l_t++) {
+#if defined(USE_GEMM_EXT_FRONTEND)
+      l_test_jit.gemm_ext( &gemm_param );
+#else
+      l_test_jit.gemm( &gemm_param );
+#endif
+    }
+  } else if (i_gemm_def->br_type == 3) {
+    gemm_param.a.primary = (void*)i_a;
+    gemm_param.b.primary = (void*)i_b;
+    for (l_t = 0; l_t < i_reps; l_t++) {
+#if defined(USE_GEMM_EXT_FRONTEND)
+      l_test_jit.gemm_ext( &gemm_param );
+#else
+      l_test_jit.gemm( &gemm_param );
+#endif
+    }
+  }
+  l_runtime = libxsmm_timer_duration(l_start, libxsmm_timer_tick());
+
+  /* run external tilerelease */
+  if (i_gemm_def->tc_config) {
+    rls_tr.gemm( NULL );
+  }
+
+  if ( i_print_jit_info == 0 ) {
+    printf("function pointer address: %llx\n", (unsigned long long)l_test_jit.xmm);
+    printf("%fs for creating jit\n", l_jittime);
+  }
+
+  free( (void*)l_a_addr );
+  free( (void*)l_b_addr );
+  free( (void*)l_a_offs );
+  free( (void*)l_b_offs );
+
+  return l_runtime;
+}
+
+void print_help(void) {
+  printf("\n\n");
+  printf("1. Usage (dense*dense=dense, correctness and performance):\n");
+  printf("    M\n");
+  printf("    N\n");
+  printf("    K\n");
+  printf("    LDA\n");
+  printf("    LDB\n");
+  printf("    LDC\n");
+  printf("    alpha: 1\n");
+  printf("    beta: 0 or 1\n");
+  printf("    0: unaligned A, otherwise aligned\n");
+  printf("    0: unaligned C, otherwise aligned\n");
+  printf("    0: A normal, 1: A trans\n");
+  printf("    0: B normal, 1: B trans\n");
+  printf("    PREFETCH: nopf (none), pfsigonly, BL2viaC, AL2, curAL2, AL2_BL2viaC, curAL2_BL2viaC\n");
+  printf("    PRECISION: SP, DP, I16I32, USI8I32, SUI8I32, SUI8UI8, BF16F32, BF16, BF16F32_FLAT, BF16_FLAT\n");
+  printf("    BRGEMM: nobr, addrbr, offsbr, strdbr\n");
+  printf("    BRsize: 1 - N\n");
+  printf("    BRunroll: 0/1\n");
+  printf("    #repetitions\n");
+  printf("    tile configuration: 1 - external, 0 - internal\n");
+  printf("    post_gemm_binary: 0 - none, 1 - colbias_add\n");
+  printf("    post_gemm_unary: 0 - none, 1 - relu_nobitmask, 2 - relu_bitmask, 3 - sigmoid \n");
+  printf("\n\n");
+  printf("2. Usage (dense*dense=dense, performance only option available):\n");
+  printf("    filename with space-sperated sizes (M N K LDA LDB LDC)\n");
+  printf("    alpha: 1\n");
+  printf("    beta: 0 or 1\n");
+  printf("    0: unaligned A, otherwise aligned\n");
+  printf("    0: unaligned C, otherwise aligned\n");
+  printf("    0: A normal, 1: A trans\n");
+  printf("    0: B normal, 1: B trans\n");
+  printf("    PRECISION: SP, DP, I16I32, USI8I32, SUI8I32, SUI8UI8, BF16F32, BF16, BF16F32_FLAT, BF16_FLAT\n");
+  printf("    BRGEMM: nobr, addrbr, offsbr, strdbr\n");
+  printf("    BRsize: 1 - N\n");
+  printf("    BRunroll: 0/1\n");
+  printf("    #repetitions\n");
+  printf("    0: no check, otherwise: run check\n");
+  printf("    tile configuration: 1 - external, 0 - internal\n");
+  printf("    post_gemm_binary: 0 - none, 1 - colbias_add\n");
+  printf("    post_gemm_unary: 0 - none, 1 - relu_nobitmask, 2 - relu_bitmask, 3 - sigmoid \n");
+  printf("\n\n");
+}
+
+int main(int argc, char* argv []) {
+  char* l_precision = NULL;
+  libxsmm_blasint l_lda = 0, l_ldb = 0, l_ldc = 0;
+  libxsmm_blasint l_m = 0, l_n = 0, l_k = 0;
+  int l_aligned_a = 0;
+  int l_aligned_c = 0;
+  int l_trans_a = 0;
+  int l_trans_b = 0;
+  double l_alpha = 0;
+  double l_beta = 0;
+  int l_br = 1;
+  int l_br_type = 0;
+  int l_br_unroll = 0;
+  double l_runtime_libxsmm = 0;
+  int l_file_input = 0;
+  char* l_file_name = NULL;
+  FILE *l_file_handle = NULL;
+  int l_run_check = 0;
+  double l_total_max_error = 0.0;
+  int l_tc_config = 0;
+  int l_reps;
+  int l_binary_postop;
+  int l_unary_postop;
+  libxsmm_gemm_prefetch_type l_prefetch = LIBXSMM_GEMM_PREFETCH_NONE;
+  gemm_def l_gemm_def;
+
+# if defined(__APPLE__) && defined(__arm64__)
+#  if 1
+  pthread_set_qos_class_self_np( QOS_CLASS_USER_INTERACTIVE, 0 );
+#  else
+  pthread_set_qos_class_self_np( QOS_CLASS_BACKGROUND, 0 );
+#  endif
+# endif
+
+  /* check argument count for a valid range */
+  if ( argc == 22 ) {
+    /* xgemm sizes */
+    l_m = atoi(argv[1]);
+    l_n = atoi(argv[2]);
+    l_k = atoi(argv[3]);
+    l_lda = atoi(argv[4]);
+    l_ldb = atoi(argv[5]);
+    l_ldc = atoi(argv[6]);
+
+    /* some sugar */
+    l_alpha = atof(argv[7]);
+    l_beta = atof(argv[8]);
+    l_aligned_a = atoi(argv[9]);
+    l_aligned_c = atoi(argv[10]);
+    l_trans_a = atoi(argv[11]);
+    l_trans_b = atoi(argv[12]);
+
+    /* arch specific stuff */
+    l_precision = argv[14];
+    l_br = atoi(argv[16]);
+    l_br_unroll = atoi(argv[17]);
+    l_reps = atoi(argv[18]);
+    l_tc_config = atoi(argv[19]);
+    l_binary_postop = atoi(argv[20]);
+    l_unary_postop = atoi(argv[21]);
+
+    /* set value of prefetch flag */
+    if (strcmp("nopf", argv[13]) == 0) {
+      l_prefetch = LIBXSMM_GEMM_PREFETCH_NONE;
+    }
+    else if (strcmp("pfsigonly", argv[13]) == 0) {
+      l_prefetch = LIBXSMM_GEMM_PREFETCH_SIGONLY;
+    }
+    else if (strcmp("BL2viaC", argv[13]) == 0) {
+      l_prefetch = LIBXSMM_GEMM_PREFETCH_BL2_VIA_C;
+    }
+    else if (strcmp("curAL2", argv[13]) == 0) {
+      l_prefetch = LIBXSMM_GEMM_PREFETCH_AL2_AHEAD;
+    }
+    else if (strcmp("curAL2_BL2viaC", argv[13]) == 0) {
+      l_prefetch = LIBXSMM_GEMM_PREFETCH_AL2BL2_VIA_C_AHEAD;
+    }
+    else if (strcmp("AL2", argv[13]) == 0) {
+      l_prefetch = LIBXSMM_GEMM_PREFETCH_AL2;
+    }
+    else if (strcmp("AL2_BL2viaC", argv[13]) == 0) {
+      l_prefetch = LIBXSMM_GEMM_PREFETCH_AL2BL2_VIA_C;
+    }
+    else {
+      print_help();
+      return EXIT_FAILURE;
+    }
+
+    if (strcmp("nobr", argv[15]) == 0) {
+      l_br_type = 0;
+    }
+    else if (strcmp("addrbr", argv[15]) == 0) {
+      l_br_type = 1;
+    }
+    else if (strcmp("offsbr", argv[15]) == 0) {
+      l_br_type = 2;
+    }
+    else if (strcmp("strdbr", argv[15]) == 0) {
+      l_br_type = 3;
+    }
+    else {
+      print_help();
+      return EXIT_FAILURE;
+    }
+
+    l_file_input = 0;
+    l_run_check = 1;
+  } else if ( argc == 17 ) {
+    l_file_input = 1;
+    l_file_name = argv[1];
+    l_alpha = atof(argv[2]);
+    l_beta = atof(argv[3]);
+    l_aligned_a = atoi(argv[4]);
+    l_aligned_c = atoi(argv[5]);
+    l_trans_a = atoi(argv[6]);
+    l_trans_b = atoi(argv[7]);
+    l_precision = argv[8];
+    l_br = atoi(argv[10]);
+    l_br_unroll = atoi(argv[11]);
+    l_tc_config = atoi(argv[14]);
+    l_binary_postop = atoi(argv[15]);
+    l_unary_postop = atoi(argv[16]);
+
+    if (strcmp("nobr", argv[9]) == 0) {
+      l_br_type = 0;
+    }
+    else if (strcmp("addrbr", argv[9]) == 0) {
+      l_br_type = 1;
+    }
+    else if (strcmp("offsbr", argv[9]) == 0) {
+      l_br_type = 2;
+    }
+    else if (strcmp("strdbr", argv[9]) == 0) {
+      l_br_type = 3;
+    }
+    else {
+      print_help();
+      return EXIT_FAILURE;
+    }
+    l_reps = atoi(argv[12]);
+    l_run_check = atoi(argv[13]);
+    l_prefetch = LIBXSMM_GEMM_PREFETCH_NONE;
+  } else {
+    print_help();
+    return EXIT_FAILURE;
+  }
+
+  const char *env_arch = getenv("LIBXSMM_TARGET");
+  const int is_env_SPR = (
+      env_arch == libxsmm_stristr(env_arch, "spr") ||
+      env_arch == libxsmm_stristr(env_arch, "amx"));
+  int arch_cpuid = libxsmm_cpuid();
+
+  if ((!is_env_SPR && arch_cpuid < LIBXSMM_X86_AVX512_SPR)
+       && (l_tc_config)) {
+    printf("Warning: external tile configuration will be ingnored\n");
+    l_tc_config = 0;
+  }
+
+  l_br = (l_br < 1) ? 1 : l_br;
+  l_br = (l_br_type == 0) ? 1 : l_br;
+  l_br_unroll = (l_br_type == 0) ? 0 : l_br_unroll;
+
+  /* check alpha */
+  if ( LIBXSMM_NEQ(l_alpha, 1.0) ) {
+    fprintf(stderr, "JIT: alpha needs to be 1.0!\n");
+    exit(EXIT_FAILURE);
+  }
+
+  /* check beta */
+  if ( LIBXSMM_NEQ(l_beta, 0.0) && LIBXSMM_NEQ(l_beta, 1.0) ) {
+    fprintf(stderr, "JIT: beta needs to be 0.0 or 1.0!\n");
+    exit(EXIT_FAILURE);
+  }
+
+  /* setting static GEMM parameters */
+  l_gemm_def.alpha = l_alpha;
+  l_gemm_def.beta = l_beta;
+  l_gemm_def.trans_a = l_trans_a;
+  l_gemm_def.trans_b = l_trans_b;
+  l_gemm_def.vnni_a = 0;
+  l_gemm_def.vnni_b = 0;
+  l_gemm_def.vnni_c = 0;
+  l_gemm_def.unsigned_a = 0;
+  l_gemm_def.unsigned_b = 0;
+  l_gemm_def.unsigned_c = 0;
+  l_gemm_def.aligned_a = l_aligned_a;
+  l_gemm_def.aligned_c = l_aligned_c;
+  l_gemm_def.prefetch = l_prefetch;
+  l_gemm_def.br_type = l_br_type;
+  l_gemm_def.br_count = l_br;
+  l_gemm_def.br_unroll = l_br_unroll;
+  l_gemm_def.tc_config = l_tc_config;
+  l_gemm_def.scf = 0.0;
+  l_gemm_def.binary_postop = l_binary_postop;
+  l_gemm_def.unary_postop  = l_unary_postop;
+
+  /* setting precision in GEMM struct */
+  if ( (strcmp(l_precision, "DP") == 0) ) {
+    l_gemm_def.in_type = LIBXSMM_DATATYPE_F64;
+    l_gemm_def.out_type = LIBXSMM_DATATYPE_F64;
+    l_gemm_def.comp_type = LIBXSMM_DATATYPE_F64;
+  } else if ( (strcmp(l_precision, "SP") == 0) ) {
+    l_gemm_def.in_type = LIBXSMM_DATATYPE_F32;
+    l_gemm_def.out_type = LIBXSMM_DATATYPE_F32;
+    l_gemm_def.comp_type = LIBXSMM_DATATYPE_F32;
+  } else if ( (strcmp(l_precision, "I16I32") == 0) ) {
+    l_gemm_def.in_type = LIBXSMM_DATATYPE_I16;
+    l_gemm_def.out_type = LIBXSMM_DATATYPE_I32;
+    l_gemm_def.comp_type = LIBXSMM_DATATYPE_I32;
+    l_gemm_def.vnni_a = 1;
+    l_gemm_def.trans_a = 0;
+    l_gemm_def.trans_b = 0;
+  } else if (strcmp(l_precision, "USI8I32") == 0) {
+    l_gemm_def.in_type = LIBXSMM_DATATYPE_I8;
+    l_gemm_def.out_type = LIBXSMM_DATATYPE_I32;
+    l_gemm_def.comp_type = LIBXSMM_DATATYPE_I32;
+    l_gemm_def.vnni_a = 1;
+    l_gemm_def.trans_a = 0;
+    l_gemm_def.trans_b = 0;
+    l_gemm_def.unsigned_a = 1;
+  } else if (strcmp(l_precision, "SUI8I32") == 0) {
+    l_gemm_def.in_type = LIBXSMM_DATATYPE_I8;
+    l_gemm_def.out_type = LIBXSMM_DATATYPE_I32;
+    l_gemm_def.comp_type = LIBXSMM_DATATYPE_I32;
+    l_gemm_def.vnni_a = 1;
+    l_gemm_def.trans_a = 0;
+    l_gemm_def.trans_b = 0;
+    l_gemm_def.unsigned_b = 1;
+  } else if (strcmp(l_precision, "SUI8UI8") == 0) {
+    l_gemm_def.in_type = LIBXSMM_DATATYPE_I8;
+    l_gemm_def.out_type = LIBXSMM_DATATYPE_I32;
+    l_gemm_def.comp_type = LIBXSMM_DATATYPE_I32;
+    l_gemm_def.vnni_a = 1;
+    l_gemm_def.trans_a = 0;
+    l_gemm_def.trans_b = 0;
+    l_gemm_def.unsigned_b = 1;
+    l_gemm_def.unsigned_c = 1;
+    l_gemm_def.scf = 1.0f;
+  } else if (strcmp(l_precision, "BF16F32") == 0) {
+    l_gemm_def.in_type = LIBXSMM_DATATYPE_BF16;
+    l_gemm_def.out_type = LIBXSMM_DATATYPE_F32;
+    l_gemm_def.comp_type = LIBXSMM_DATATYPE_F32;
+    l_gemm_def.vnni_a = 1;
+    l_gemm_def.trans_a = 0;
+    l_gemm_def.trans_b = 0;
+  } else if (strcmp(l_precision, "BF16") == 0) {
+    l_gemm_def.in_type = LIBXSMM_DATATYPE_BF16;
+    l_gemm_def.out_type = LIBXSMM_DATATYPE_BF16;
+    l_gemm_def.comp_type = LIBXSMM_DATATYPE_F32;
+    l_gemm_def.vnni_a = 1;
+    l_gemm_def.trans_a = 0;
+    l_gemm_def.trans_b = 0;
+  } else if (strcmp(l_precision, "BF16F32_FLAT") == 0) {
+    l_gemm_def.in_type = LIBXSMM_DATATYPE_BF16;
+    l_gemm_def.out_type = LIBXSMM_DATATYPE_F32;
+    l_gemm_def.comp_type = LIBXSMM_DATATYPE_F32;
+  } else if (strcmp(l_precision, "BF16_FLAT") == 0) {
+    l_gemm_def.in_type = LIBXSMM_DATATYPE_BF16;
+    l_gemm_def.out_type = LIBXSMM_DATATYPE_BF16;
+    l_gemm_def.comp_type = LIBXSMM_DATATYPE_F32;
+  } else {
+    fprintf(stderr, "Unsupported precision %s!\n", l_precision);
+    exit(EXIT_FAILURE);
+  }
+
+  /* Test if valid precision for fusion ops  */
+  if ( !((strcmp(l_precision, "SP") == 0) ||
+        (strcmp(l_precision, "BF16F32") == 0) ||
+        (strcmp(l_precision, "BF16") == 0) ||
+        (strcmp(l_precision, "BF16F32_FLAT") == 0) ||
+        (strcmp(l_precision, "BF16_FLAT") == 0)) ) {
+    fprintf(stderr, "Unsupported precision for fused xgemm kernel %s!\n", l_precision);
+    exit(EXIT_FAILURE);
+  }
+
+  if ( l_file_input != 0 ) {
+    l_file_handle = fopen( l_file_name, "r" );
+  } else {
+    if ( l_trans_b == 0 ) {
+      printf("------------------------------------------------\n");
+      printf("RUNNING (%ix%i) X (%ix%i) = (%ix%i), %s, BR=%i\n", l_m, l_k, l_k, l_n, l_m, l_n, l_precision, l_br);
+      printf("------------------------------------------------\n");
+    } else {
+      printf("------------------------------------------------\n");
+      printf("RUNNING (%ix%i) X (%ix%i)^T = (%ix%i), %s, BR=%i\n", l_m, l_k, l_k, l_n, l_m, l_n, l_precision, l_br);
+      printf("------------------------------------------------\n");
+    }
+  }
+
+  unsigned int l_keep_going = 0;
+  do {
+    double error = 0.0;
+    double error_bitmask = 0.0;
+    char *l_a, *l_b, *l_c, *l_c_perf, *l_c_gold, *l_colbias, *l_relu_bitmask, *l_relu_bitmask_gold;
+    fusion_args fusion_arguments;
+    fusion_args ref_fusion_arguments;
+
+    if ( l_file_input != 0 ) {
+      char l_line[512];
+      if ( fgets( l_line, 512, l_file_handle) == NULL ) {
+        l_keep_going = 0;
+        break;
+      } else {
+        l_keep_going = 1;
+      }
+      if ( 6 != sscanf( l_line, "%i %i %i %i %i %i", &l_m, &l_n, &l_k, &l_lda, &l_ldb, &l_ldc ) ) exit(EXIT_FAILURE);
+    }
+
+    l_gemm_def.m = l_m;
+    l_gemm_def.n = l_n;
+    l_gemm_def.k = l_k;
+    l_gemm_def.lda = l_lda;
+    l_gemm_def.ldb = l_ldb;
+    l_gemm_def.ldc = l_ldc;
+
+    l_a      = (char*)libxsmm_aligned_malloc((size_t)l_lda * (size_t)l_k * (size_t)l_br * LIBXSMM_TYPESIZE(l_gemm_def.in_type), 64);
+    if (l_gemm_def.trans_b == 0) {
+      l_b      = (char*)libxsmm_aligned_malloc((size_t)l_ldb * (size_t)l_n * (size_t)l_br * LIBXSMM_TYPESIZE(l_gemm_def.in_type), 64);
+    } else {
+      l_b      = (char*)libxsmm_aligned_malloc((size_t)l_ldb * (size_t)l_k * (size_t)l_br * LIBXSMM_TYPESIZE(l_gemm_def.in_type), 64);
+    }
+    l_c                 = (char*)libxsmm_aligned_malloc((size_t)l_ldc * (size_t)l_n * LIBXSMM_TYPESIZE(l_gemm_def.out_type), 64);
+    l_c_perf            = (char*)libxsmm_aligned_malloc((size_t)l_ldc * (size_t)l_n * LIBXSMM_TYPESIZE(l_gemm_def.out_type), 64);
+    l_c_gold            = (char*)libxsmm_aligned_malloc((size_t)l_ldc * (size_t)l_n * LIBXSMM_TYPESIZE(l_gemm_def.out_type), 64);
+    l_colbias           = (char*)libxsmm_aligned_malloc((size_t)l_ldc * LIBXSMM_TYPESIZE(l_gemm_def.out_type), 64);
+    l_relu_bitmask      = (char*)libxsmm_aligned_malloc(((size_t)l_ldc/8) * (size_t)l_n, 64);
+    l_relu_bitmask_gold = (char*)libxsmm_aligned_malloc(((size_t)l_ldc/8) * (size_t)l_n, 64);
+    fusion_arguments.colbias      = l_colbias;
+    fusion_arguments.relu_bitmask = l_relu_bitmask;
+    ref_fusion_arguments.colbias      = l_colbias;
+    ref_fusion_arguments.relu_bitmask = l_relu_bitmask_gold;
+
+    init_random_matrix( l_gemm_def.in_type, l_a, l_br, l_lda, l_k );
+    if (l_gemm_def.trans_b == 0) {
+      init_random_matrix( l_gemm_def.in_type, l_b, l_br, l_ldb, l_n );
+    } else {
+      init_random_matrix( l_gemm_def.in_type, l_b, l_br, l_ldb, l_k );
+    }
+    if ( l_beta == 0 ) {
+      init_garbage_matrix( l_gemm_def.out_type, l_c,      1, l_ldc, l_n );
+      init_garbage_matrix( l_gemm_def.out_type, l_c_perf, 1, l_ldc, l_n );
+      init_garbage_matrix( l_gemm_def.out_type, l_c_gold, 1, l_ldc, l_n );
+    } else {
+      init_zero_matrix( l_gemm_def.out_type, l_c,      1, l_ldc, l_n );
+      init_zero_matrix( l_gemm_def.out_type, l_c_perf, 1, l_ldc, l_n );
+      init_zero_matrix( l_gemm_def.out_type, l_c_gold, 1, l_ldc, l_n );
+    }
+
+    init_random_matrix( LIBXSMM_DATATYPE_I8, l_relu_bitmask, 1, l_ldc/8, l_n );
+    init_random_matrix( l_gemm_def.out_type, l_colbias, 1, l_ldc, 1 );
+    memcpy(l_relu_bitmask_gold, l_relu_bitmask, (l_ldc/8) * l_n * sizeof(char));
+
+    /* run gold solution */
+    fused_matmul( &l_gemm_def, l_a, l_b, l_c_gold, &ref_fusion_arguments );
+
+    /* run LIBXSMM solution */
+    l_runtime_libxsmm = jit_matmul( &l_gemm_def, l_a, l_b, l_c, l_c_perf, l_reps, l_file_input, &fusion_arguments);
+
+    /* run compare */
+    error = check_matrix( l_gemm_def.out_type, l_c_gold, l_c, l_ldc, l_m, l_n );
+    if (l_unary_postop == RELU_BITMASK) {
+      error_bitmask = check_matrix( LIBXSMM_DATATYPE_I8, l_relu_bitmask_gold, l_relu_bitmask, l_ldc/8, l_m/8, l_n );
+    }
+
+    if ( l_file_input == 0 ) {
+      printf("%fs for libxsmm\n", l_runtime_libxsmm);
+      printf("%f GFLOPS for libxsmm\n", ((double)((double)l_reps * (double)l_m * (double)l_n * (double)l_k * (double)l_br) * 2.0) / (l_runtime_libxsmm * 1.0e9));
+      printf("max. error: %f\n", error);
+      if (l_unary_postop == RELU_BITMASK) {
+        printf("max. error relu bitmask: %f\n", error_bitmask);
+      }
+
+      check_matrix_norms( l_gemm_def.out_type, l_c_gold, l_c, l_ldc, l_m, l_n );
+
+    } else {
+      if ( l_run_check == 1 ) {
+        printf("%i %i %i %i %i %i %i %i %i %s %f %f\n", l_m, l_n, l_k, l_lda, l_ldb, l_ldc, l_br, l_br_type, l_br_unroll, l_precision, ((double)((double)l_reps * (double)l_m * (double)l_n * (double)l_k * (double)l_br) * 2.0) / (l_runtime_libxsmm * 1.0e9), error );
+        } else {
+        printf("%i %i %i %i %i %i %i %i %i %s %f\n", l_m, l_n, l_k, l_lda, l_ldb, l_ldc, l_br, l_br_type, l_br_unroll, l_precision, ((double)((double)l_reps * (double)l_m * (double)l_n * (double)l_k * (double)l_br) * 2.0) / (l_runtime_libxsmm * 1.0e9) );
+      }
+    }
+
+    if ( (l_total_max_error < error) && (l_run_check == 1) ) {
+      l_total_max_error = error;
+    }
+
+    libxsmm_free(l_a);
+    libxsmm_free(l_b);
+    libxsmm_free(l_c);
+    libxsmm_free(l_c_perf);
+    libxsmm_free(l_c_gold);
+    libxsmm_free(l_colbias);
+    libxsmm_free(l_relu_bitmask);
+    libxsmm_free(l_relu_bitmask_gold);
+  } while ( l_keep_going );
+
+  if ( l_file_input != 0 ) {
+    fclose( l_file_handle );
+  } else {
+    printf("------------------------------------------------\n");
+  }
+
+  /* Print total max error */
+  printf("\n\n Total Max Error %f\n\n", l_total_max_error );
+
+  if ( l_total_max_error >= 0.00005 && l_br_type == 0) {
+    return EXIT_FAILURE;
+  } else if ( l_total_max_error >= 0.0005 && l_br_type > 0) {
+    return EXIT_FAILURE;
+  } else {
+    return EXIT_SUCCESS;
+  }
+}
+

--- a/src/generator_common.h
+++ b/src/generator_common.h
@@ -1279,6 +1279,7 @@ LIBXSMM_EXTERN_C typedef struct libxsmm_micro_kernel_config {
   unsigned int decompress_A;
   unsigned int vnni_cvt_output_ext_buf;
   unsigned int norm_to_normT_B_ext_buf;
+  unsigned int has_colbias_act_fused;
 
   /* Register names/logistics for fusion boo-keeping  */
   unsigned int reserved_zmms;
@@ -1311,6 +1312,8 @@ LIBXSMM_EXTERN_C typedef struct libxsmm_micro_kernel_config {
 
   /* Auxiliary arrays for micro-kernel iteration space traversal */
   int use_paired_tilestores;
+  int m_tiles;
+  int n_tiles;
   int _im[4];
   int _in[4];
   int _C_tile_id[4];
@@ -1638,7 +1641,7 @@ LIBXSMM_EXTERN_C typedef struct libxsmm_matequation_kernel_config_struct {
   unsigned int                      contains_binary_op;
   unsigned int                      contains_ternary_op;
   unsigned int                      tmp_size;
-  libxsmm_matrix_eqn_arg            *arg_info;
+  libxsmm_matrix_eqn_arg_v2         *arg_info;
   unsigned int                      reserved_zmms;
   unsigned int                      reserved_mask_regs;
   unsigned int                      register_block_size;
@@ -1740,7 +1743,23 @@ typedef enum libxsmm_meqn_stack_var {
   LIBXSMM_MEQN_STACK_VAR_CONST_6            =  26,
   LIBXSMM_MEQN_STACK_VAR_CONST_7            =  27,
   LIBXSMM_MEQN_STACK_VAR_CONST_8            =  28,
-  LIBXSMM_MEQN_STACK_VAR_CONST_9            =  29
+  LIBXSMM_MEQN_STACK_VAR_CONST_9            =  29,
+  LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR16 =  30,
+  LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR17 =  31,
+  LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR18 =  32,
+  LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR19 =  33,
+  LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR20 =  34,
+  LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR21 =  35,
+  LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR22 =  36,
+  LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR23 =  37,
+  LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR24 =  38,
+  LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR25 =  39,
+  LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR26 =  40,
+  LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR27 =  41,
+  LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR28 =  42,
+  LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR29 =  43,
+  LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR30 =  44,
+  LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR31 =  45
 } libxsmm_meqn_stack_var;
 
 /* Auxiliary stack variable enumeration in GEMM */

--- a/src/generator_common_x86.c
+++ b/src/generator_common_x86.c
@@ -15,6 +15,113 @@
 #include "libxsmm_main.h"
 
 LIBXSMM_API_INTERN
+void libxsmm_generator_x86_save_gpr_regs(libxsmm_generated_code*   io_generated_code,
+    const unsigned short    i_save_bitmask) {
+  if ( ( i_save_bitmask & 0x1 ) == 0x1 ) {
+    libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_RAX );
+  }
+  if ( ( i_save_bitmask & 0x2 ) == 0x2 ) {
+    libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_RCX );
+  }
+  if ( ( i_save_bitmask & 0x4 ) == 0x4 ) {
+    libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_RDX );
+  }
+  if ( ( i_save_bitmask & 0x8 ) == 0x8 ) {
+    libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_RBX );
+  }
+  if ( ( i_save_bitmask & 0x10 ) == 0x10 ) {
+    libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_RSP );
+  }
+  if ( ( i_save_bitmask & 0x20 ) == 0x20 ) {
+    libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_RBP );
+  }
+  if ( ( i_save_bitmask & 0x40 ) == 0x40 ) {
+    libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_RSI );
+  }
+  if ( ( i_save_bitmask & 0x80 ) == 0x80 ) {
+    libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_RDI );
+  }
+  if ( ( i_save_bitmask & 0x100 ) == 0x100 ) {
+    libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_R8 );
+  }
+  if ( ( i_save_bitmask & 0x200 ) == 0x200 ) {
+    libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_R9 );
+  }
+  if ( ( i_save_bitmask & 0x400 ) == 0x400 ) {
+    libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_R10 );
+  }
+  if ( ( i_save_bitmask & 0x800 ) == 0x800 ) {
+    libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_R11 );
+  }
+  if ( ( i_save_bitmask & 0x1000 ) == 0x1000 ) {
+    libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_R12 );
+  }
+  if ( ( i_save_bitmask & 0x2000 ) == 0x2000 ) {
+    libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_R13 );
+  }
+  if ( ( i_save_bitmask & 0x4000 ) == 0x4000 ) {
+    libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_R14 );
+  }
+  if ( ( i_save_bitmask & 0x8000 ) == 0x8000 ) {
+    libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_R15 );
+  }
+}
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_x86_restore_gpr_regs(libxsmm_generated_code*   io_generated_code,
+    const unsigned short    i_restore_bitmask) {
+
+  if ( ( i_restore_bitmask & 0x8000 ) == 0x8000 ) {
+    libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_R15 );
+  }
+  if ( ( i_restore_bitmask & 0x4000 ) == 0x4000 ) {
+    libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_R14 );
+  }
+  if ( ( i_restore_bitmask & 0x2000 ) == 0x2000 ) {
+    libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_R13 );
+  }
+  if ( ( i_restore_bitmask & 0x1000 ) == 0x1000 ) {
+    libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_R12 );
+  }
+  if ( ( i_restore_bitmask & 0x800 ) == 0x800 ) {
+    libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_R11 );
+  }
+  if ( ( i_restore_bitmask & 0x400 ) == 0x400 ) {
+    libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_R10 );
+  }
+  if ( ( i_restore_bitmask & 0x200 ) == 0x200 ) {
+    libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_R9 );
+  }
+  if ( ( i_restore_bitmask & 0x100 ) == 0x100 ) {
+    libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_R8 );
+  }
+  if ( ( i_restore_bitmask & 0x80 ) == 0x80 ) {
+    libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_RDI );
+  }
+  if ( ( i_restore_bitmask & 0x40 ) == 0x40 ) {
+    libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_RSI );
+  }
+  if ( ( i_restore_bitmask & 0x20 ) == 0x20 ) {
+    libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_RBP );
+  }
+  if ( ( i_restore_bitmask & 0x10 ) == 0x10 ) {
+    libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_RSP );
+  }
+  if ( ( i_restore_bitmask & 0x8 ) == 0x8 ) {
+    libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_RBX );
+  }
+  if ( ( i_restore_bitmask & 0x4 ) == 0x4 ) {
+    libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_RDX );
+  }
+  if ( ( i_restore_bitmask & 0x2 ) == 0x2 ) {
+    libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_RCX );
+  }
+  if ( ( i_restore_bitmask & 0x1 ) == 0x1 ) {
+    libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_RAX );
+  }
+}
+
+LIBXSMM_API_INTERN
 void libxsmm_x86_instruction_unified_vec_move( libxsmm_generated_code* io_generated_code,
                                                 const unsigned int      i_vmove_instr,
                                                 const unsigned int      i_gp_reg_base,
@@ -1231,7 +1338,6 @@ void libxsmm_generator_tanh_ps_rational_78_avx( libxsmm_generated_code*         
             i_vec_x,
             0, 0, 0, (i_mask_lo) << 4);
 }
-
 
 LIBXSMM_API_INTERN
 void libxsmm_generator_prepare_coeffs_sigmoid_ps_rational_78_avx512( libxsmm_generated_code*                        io_generated_code,

--- a/src/generator_common_x86.h
+++ b/src/generator_common_x86.h
@@ -14,6 +14,15 @@
 
 #include "generator_common.h"
 
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_x86_save_gpr_regs(libxsmm_generated_code*   io_generated_code,
+    const unsigned short    i_save_bitmask);
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_x86_restore_gpr_regs(libxsmm_generated_code*   io_generated_code,
+    const unsigned short    i_restore_bitmask);
+
 LIBXSMM_API_INTERN
 void libxsmm_generator_hinstrps_avx( libxsmm_generated_code*                        io_generated_code,
     unsigned int                                   instr,

--- a/src/generator_gemm.c
+++ b/src/generator_gemm.c
@@ -231,11 +231,14 @@ void libxsmm_generator_gemm_kernel( libxsmm_generated_code*        io_generated_
   }
 
   /* right now we only support eltwise fusion on SPR and BF16 */
+  /* TODO: EVANGELOS -- AMMEND  */
+#if 0
   if ( ( (io_generated_code->arch < LIBXSMM_X86_AVX512_SPR) || (LIBXSMM_DATATYPE_BF16 != LIBXSMM_GETENUM_INP( l_xgemm_desc_mod.datatype )) ) &&
        ( l_xgemm_desc_mod.meltw_operation != LIBXSMM_MELTW_OPERATION_NONE ) ) {
     LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_ARCH );
     return;
   }
+#endif
 
   /* check if alignment is not possible */
   if ( 0 != (l_xgemm_desc_mod.lda % l_vector_length) ) {
@@ -255,12 +258,12 @@ void libxsmm_generator_gemm_kernel( libxsmm_generated_code*        io_generated_
            ( LIBXSMM_DATATYPE_I8 == LIBXSMM_GETENUM_INP( l_xgemm_desc_mod.datatype ) ) ) &&
          ((l_xgemm_desc_mod.flags & LIBXSMM_GEMM_FLAG_VNNI_A) != 0) ) {
       if (l_emu_amx == 0) {
-        libxsmm_generator_gemm_amx_kernel( io_generated_code, &l_xgemm_desc_mod );
+        libxsmm_generator_gemm_amx_kernel_wrapper( io_generated_code, &l_xgemm_desc_mod );
       } else {
         /* let's recheck CPU to even emulation AVX512_BF16 */
         io_generated_code->arch = libxsmm_cpuid();
         l_xgemm_desc_mod.c3 = 0;
-        libxsmm_generator_gemm_amx_kernel_emu( io_generated_code, &l_xgemm_desc_mod );
+        libxsmm_generator_gemm_amx_kernel_emu_wrapper( io_generated_code, &l_xgemm_desc_mod );
       }
     } else {
       if (l_emu_amx != 0) {

--- a/src/generator_gemm_amx.c
+++ b/src/generator_gemm_amx.c
@@ -921,7 +921,6 @@ void libxsmm_generator_gemm_load_C_amx( libxsmm_generated_code*            io_ge
   }
 }
 
-
 LIBXSMM_API_INTERN
 void libxsmm_generator_gemm_store_C_amx( libxsmm_generated_code*            io_generated_code,
     libxsmm_gp_reg_mapping*            i_gp_reg_mapping,
@@ -1037,46 +1036,7 @@ void libxsmm_generator_gemm_amx_setup_fusion_infra( libxsmm_generated_code*     
   unsigned int reserved_zmms      = 0;
   unsigned int reserved_mask_regs = 1;
   LIBXSMM_UNUSED(i_gp_reg_mapping);
-
-  i_micro_kernel_config->fused_bcolbias       = 0;
-  i_micro_kernel_config->fused_scolbias       = 0;
-  i_micro_kernel_config->fused_relu           = 0;
-  i_micro_kernel_config->fused_relu_nobitmask = 0;
-  i_micro_kernel_config->fused_relu_bwd       = 0;
-  i_micro_kernel_config->fused_sigmoid        = 0;
-  i_micro_kernel_config->overwrite_C          = 0;
-  i_micro_kernel_config->vnni_format_C        = 0;
-
-  /* TODO: Add support fror more fusions  */
-  if ((i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_COLBIAS_ACT) || (i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_COLBIAS_ACT_DECOMPRESS_A) ||
-      (i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_ACT_TRANSFORM_C_NORM_TO_VNNI_EXT_BUFFER)) {
-    if ((i_xgemm_desc->meltw_flags & LIBXSMM_MELTW_FLAG_OVERWRITE_C) > 0) {
-      i_micro_kernel_config->overwrite_C = 1;
-    }
-    if ((i_xgemm_desc->meltw_flags & LIBXSMM_MELTW_FLAG_ACT_RELU) > 0) {
-      i_micro_kernel_config->fused_relu = 1;
-    }
-    if ((i_xgemm_desc->meltw_flags & LIBXSMM_MELTW_FLAG_ACT_RELU_NOBITMASK) > 0) {
-      i_micro_kernel_config->fused_relu_nobitmask = 1;
-    }
-    if ((i_xgemm_desc->meltw_flags & LIBXSMM_MELTW_FLAG_ACT_RELU_BWD) > 0) {
-      i_micro_kernel_config->fused_relu_bwd = 1;
-    }
-    if ((i_xgemm_desc->meltw_flags & LIBXSMM_MELTW_FLAG_ACT_SIGM) > 0) {
-      i_micro_kernel_config->fused_sigmoid = 1;
-    }
-    if ((i_xgemm_desc->meltw_flags & LIBXSMM_MELTW_FLAG_COLBIAS) > 0) {
-      if (i_xgemm_desc->meltw_datatype_aux == LIBXSMM_DATATYPE_BF16) {
-        i_micro_kernel_config->fused_bcolbias = 1;
-      }
-      if (i_xgemm_desc->meltw_datatype_aux == LIBXSMM_DATATYPE_F32) {
-        i_micro_kernel_config->fused_scolbias = 1;
-      }
-    }
-  } else {
-    i_micro_kernel_config->overwrite_C    = 1;
-    i_micro_kernel_config->vnni_format_C  = ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_VNNI_C) > 0) ? 1 : 0;
-  }
+  LIBXSMM_UNUSED(i_xgemm_desc);
 
   if (i_micro_kernel_config->vnni_cvt_output_ext_buf == 1) {
     if (i_micro_kernel_config->vnni_format_C == 1) {
@@ -1123,463 +1083,15 @@ void libxsmm_generator_gemm_amx_setup_fusion_infra( libxsmm_generated_code*     
   }
 
   if (i_micro_kernel_config->fused_sigmoid == 1) {
-    float pade78_sigm_array[16] = { 2027025.0f, 270270.0f, 6930.0f, 36.0f, 945945.0f, 51975.0f,  630.0f, 4.97f, -4.97f,  1.0f, -1.0f, 0.5f, 0.0f, 0.0f, 0.0f, 0.0f };
     reserved_zmms       += 15;
     reserved_mask_regs  += 2;
-    i_micro_kernel_config->vec_x2        = reserved_zmms - 1;
-    i_micro_kernel_config->vec_nom       = reserved_zmms - 2;
-    i_micro_kernel_config->vec_denom     = reserved_zmms - 3;
-    i_micro_kernel_config->vec_c0        = reserved_zmms - 4;
-    i_micro_kernel_config->vec_c1        = reserved_zmms - 5;
-    i_micro_kernel_config->vec_c2        = reserved_zmms - 6;
-    i_micro_kernel_config->vec_c3        = reserved_zmms - 7;
-    i_micro_kernel_config->vec_c1_d      = reserved_zmms - 8;
-    i_micro_kernel_config->vec_c2_d      = reserved_zmms - 9;
-    i_micro_kernel_config->vec_c3_d      = reserved_zmms - 10;
-    i_micro_kernel_config->vec_hi_bound  = reserved_zmms - 11;
-    i_micro_kernel_config->vec_lo_bound  = reserved_zmms - 12;
-    i_micro_kernel_config->vec_ones      = reserved_zmms - 13;
-    i_micro_kernel_config->vec_neg_ones  = reserved_zmms - 14;
-    i_micro_kernel_config->vec_halves    = reserved_zmms - 15;
-
-    libxsmm_x86_instruction_full_vec_load_of_constants ( io_generated_code, (const unsigned char *) pade78_sigm_array, "pade78_sigm_array_", i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_c0);
-    libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_GEMM_SCRATCH_PTR, temp_reg );
-    libxsmm_x86_instruction_vec_move( io_generated_code,
-        i_micro_kernel_config->instruction_set,
-        LIBXSMM_X86_INSTR_VMOVUPS,
-        temp_reg,
-        LIBXSMM_X86_GP_REG_UNDEF, 0, 0,
-        i_micro_kernel_config->vector_name,
-        i_micro_kernel_config->vec_c0, 0, 1, 1 );
-
-    libxsmm_x86_instruction_vec_move( io_generated_code, i_micro_kernel_config->instruction_set, LIBXSMM_X86_INSTR_VBROADCASTSS, temp_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,
-        0, i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_c0, 0, 1, 0 );
-    libxsmm_x86_instruction_vec_move( io_generated_code, i_micro_kernel_config->instruction_set, LIBXSMM_X86_INSTR_VBROADCASTSS, temp_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,
-        4, i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_c1, 0, 1, 0 );
-    libxsmm_x86_instruction_vec_move( io_generated_code, i_micro_kernel_config->instruction_set, LIBXSMM_X86_INSTR_VBROADCASTSS, temp_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,
-        8, i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_c2, 0, 1, 0 );
-    libxsmm_x86_instruction_vec_move( io_generated_code, i_micro_kernel_config->instruction_set, LIBXSMM_X86_INSTR_VBROADCASTSS, temp_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,
-        12, i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_c3, 0, 1, 0 );
-    libxsmm_x86_instruction_vec_move( io_generated_code, i_micro_kernel_config->instruction_set, LIBXSMM_X86_INSTR_VBROADCASTSS, temp_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,
-        16, i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_c1_d, 0, 1, 0 );
-    libxsmm_x86_instruction_vec_move( io_generated_code, i_micro_kernel_config->instruction_set, LIBXSMM_X86_INSTR_VBROADCASTSS, temp_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,
-        20, i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_c2_d, 0, 1, 0 );
-    libxsmm_x86_instruction_vec_move( io_generated_code, i_micro_kernel_config->instruction_set, LIBXSMM_X86_INSTR_VBROADCASTSS, temp_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,
-        24, i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_c3_d, 0, 1, 0 );
-    libxsmm_x86_instruction_vec_move( io_generated_code, i_micro_kernel_config->instruction_set, LIBXSMM_X86_INSTR_VBROADCASTSS, temp_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,
-        28, i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_hi_bound, 0, 1, 0 );
-    libxsmm_x86_instruction_vec_move( io_generated_code, i_micro_kernel_config->instruction_set, LIBXSMM_X86_INSTR_VBROADCASTSS, temp_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,
-        32, i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_lo_bound, 0, 1, 0 );
-    libxsmm_x86_instruction_vec_move( io_generated_code, i_micro_kernel_config->instruction_set, LIBXSMM_X86_INSTR_VBROADCASTSS, temp_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,
-        36, i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_ones, 0, 1, 0 );
-    libxsmm_x86_instruction_vec_move( io_generated_code, i_micro_kernel_config->instruction_set, LIBXSMM_X86_INSTR_VBROADCASTSS, temp_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,
-        40, i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_neg_ones, 0, 1, 0 );
-    libxsmm_x86_instruction_vec_move( io_generated_code, i_micro_kernel_config->instruction_set, LIBXSMM_X86_INSTR_VBROADCASTSS, temp_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,
-        44, i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_halves, 0, 1, 0 );
-
-    i_micro_kernel_config->mask_hi  = reserved_mask_regs - 1;
-    i_micro_kernel_config->mask_lo  = reserved_mask_regs - 2;
+    libxsmm_generator_gemm_prepare_coeffs_sigmoid_ps_rational_78_avx_avx512( io_generated_code, i_micro_kernel_config, reserved_zmms, reserved_mask_regs, temp_reg );
   }
 
   i_micro_kernel_config->reserved_zmms      = reserved_zmms;
   i_micro_kernel_config->reserved_mask_regs = reserved_mask_regs;
 }
 
-
-LIBXSMM_API_INTERN
-void libxsmm_generator_gemm_amx_setup_stack_frame( libxsmm_generated_code*            io_generated_code,
-    const libxsmm_gemm_descriptor*      i_xgemm_desc,
-    const libxsmm_gp_reg_mapping*       i_gp_reg_mapping,
-    libxsmm_micro_kernel_config*        i_micro_kernel_config,
-    int                                 m_tiles,
-    int                                 n_tiles ) {
-
-  int is_stride_brgemm  = ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE) > 0) ? 1 : 0;
-  int is_offset_brgemm  = ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET) > 0) ? 1 : 0;
-  int is_address_brgemm = ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS) > 0) ? 1 : 0;
-  int is_brgemm         = ((is_stride_brgemm == 1) || (is_offset_brgemm == 1) || (is_address_brgemm == 1)) ? 1 : 0;
-  int has_scf           = ((LIBXSMM_DATATYPE_I8 == LIBXSMM_GETENUM_INP( i_xgemm_desc->datatype )) && (LIBXSMM_DATATYPE_I8 == LIBXSMM_GETENUM_OUT( i_xgemm_desc->datatype ))) ? 1 : 0;
-  int has_A_pf_ptr      = (i_xgemm_desc->prefetch == LIBXSMM_GEMM_PREFETCH_AL2_AHEAD || i_xgemm_desc->prefetch == LIBXSMM_GEMM_PREFETCH_AL2BL2_VIA_C_AHEAD) ? 1 : 0;
-  int has_B_pf_ptr      = (i_xgemm_desc->prefetch == LIBXSMM_GEMM_PREFETCH_BL2_VIA_C || i_xgemm_desc->prefetch == LIBXSMM_GEMM_PREFETCH_AL2BL2_VIA_C_AHEAD ||
-      i_xgemm_desc->prefetch == LIBXSMM_GEMM_PREFETCH_AL2BL2_VIA_C || i_xgemm_desc->prefetch == LIBXSMM_PREFETCH_AL2CL2BL2_VIA_C ) ? 1 : 0;
-  int has_colbias_act_fused = 0;
-  int has_eltwise_fused     = 0;
-  unsigned int eltwise_struct_ptr_reg = LIBXSMM_X86_GP_REG_R11;
-  unsigned int temp_reg               = LIBXSMM_X86_GP_REG_R10;
-  unsigned int gemm_scratch_size      = 0;
-  unsigned int scratch_pad_size       = 0;
-  i_micro_kernel_config->decompress_A       = 0;
-  i_micro_kernel_config->sparsity_factor_A  = 1;
-  i_micro_kernel_config->vnni_cvt_output_ext_buf = 0;
-  i_micro_kernel_config->norm_to_normT_B_ext_buf = 0;
-  i_micro_kernel_config->stride_b_trans          = 0;
-
-  LIBXSMM_UNUSED(i_gp_reg_mapping);
-  LIBXSMM_UNUSED(m_tiles);
-
-  /* Determine if we have to decompress A...  */
-  if ((i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_DECOMPRESS_A) || (i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_COLBIAS_ACT_DECOMPRESS_A)) {
-    i_micro_kernel_config->decompress_A = 1;
-    i_micro_kernel_config->sparsity_factor_A = i_xgemm_desc->meltw_param;
-  }
-
-  if ((i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_COLBIAS_ACT) || (i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_COLBIAS_ACT_DECOMPRESS_A)) {
-    if ((i_xgemm_desc->meltw_flags & LIBXSMM_MELTW_FLAG_ACT_RELU_BWD) > 0) {
-      i_micro_kernel_config->fused_relu_bwd = 1;
-    }
-    has_colbias_act_fused = 1;
-    if (i_xgemm_desc->meltw_flags == (unsigned int)LIBXSMM_MELTW_FLAG_NONE) {
-      has_colbias_act_fused = 0;
-    }
-  }
-
-  if ((i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_TRANSFORM_C_NORM_TO_VNNI_EXT_BUFFER) ||
-      (i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_ACT_TRANSFORM_C_NORM_TO_VNNI_EXT_BUFFER)) {
-    i_micro_kernel_config->vnni_cvt_output_ext_buf = 1;
-    if ((i_xgemm_desc->meltw_flags & LIBXSMM_MELTW_FLAG_ACT_RELU_BWD) > 0) {
-      i_micro_kernel_config->fused_relu_bwd = 1;
-    }
-  }
-
-  if ((i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_TRANSFORM_B_NORM_TO_NORMT_EXT_BUFFER) ||
-      (i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_COLBIAS_ACT_TRANSFORM_B_NORM_TO_NORMT_EXT_BUFFER)) {
-    i_micro_kernel_config->norm_to_normT_B_ext_buf = 1;
-  }
-
-  has_eltwise_fused = ((has_colbias_act_fused == 1)) ? 1: 0;
-  i_micro_kernel_config->fused_eltwise = has_eltwise_fused;
-  if (i_micro_kernel_config->decompress_A == 1) {
-    has_eltwise_fused = 1;
-    i_micro_kernel_config->fused_eltwise = 1;
-  }
-
-  if (i_micro_kernel_config->vnni_cvt_output_ext_buf == 1) {
-    has_eltwise_fused = 1;
-    i_micro_kernel_config->fused_eltwise = 1;
-  }
-
-  if (i_micro_kernel_config->norm_to_normT_B_ext_buf == 1) {
-    has_eltwise_fused = 1;
-    i_micro_kernel_config->fused_eltwise = 1;
-    i_micro_kernel_config->stride_b_trans = i_xgemm_desc->meltw_ldy;
-  }
-
-  if (i_micro_kernel_config->fused_relu_bwd == 1) {
-    has_eltwise_fused = 1;
-    i_micro_kernel_config->fused_eltwise = 1;
-  }
-
-  libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_RBP );
-  libxsmm_x86_instruction_alu_reg( io_generated_code, i_micro_kernel_config->alu_mov_instruction, LIBXSMM_X86_GP_REG_RSP, LIBXSMM_X86_GP_REG_RBP);
-  libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_sub_instruction, LIBXSMM_X86_GP_REG_RSP, 88 );
-
-  if (is_brgemm == 0) {
-    /* GEMM (A, B, C, [scf, eltwise_struct, Apf, Bpf] */
-    if (has_scf == 1) {
-      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_INT8_SCF, LIBXSMM_X86_GP_REG_RCX );
-      if (has_eltwise_fused == 1) {
-        eltwise_struct_ptr_reg = LIBXSMM_X86_GP_REG_R8;
-        if (has_A_pf_ptr == 1) {
-          libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, LIBXSMM_X86_GP_REG_R9 );
-          if (has_B_pf_ptr == 1) {
-            libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, temp_reg );
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
-          }
-        } else {
-          if (has_B_pf_ptr == 1) {
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R9 );
-          }
-        }
-      } else {
-        if (has_A_pf_ptr == 1) {
-          libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, LIBXSMM_X86_GP_REG_R8 );
-          if (has_B_pf_ptr == 1) {
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R9 );
-          }
-        } else {
-          if (has_B_pf_ptr == 1) {
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R8 );
-          }
-        }
-      }
-    } else {
-      if (has_eltwise_fused == 1) {
-        eltwise_struct_ptr_reg = LIBXSMM_X86_GP_REG_RCX;
-        if (has_A_pf_ptr == 1) {
-          libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, LIBXSMM_X86_GP_REG_R8 );
-          if (has_B_pf_ptr == 1) {
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R9 );
-          }
-        } else {
-          if (has_B_pf_ptr == 1) {
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R8 );
-          }
-        }
-      } else {
-        if (has_A_pf_ptr == 1) {
-          libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, LIBXSMM_X86_GP_REG_RCX );
-          if (has_B_pf_ptr == 1) {
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R8 );
-          }
-        } else {
-          if (has_B_pf_ptr == 1) {
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_RCX );
-          }
-        }
-      }
-    }
-  } else {
-    if (i_micro_kernel_config->decompress_A == 1) {
-      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction, LIBXSMM_X86_GP_REG_RCX, LIBXSMM_X86_GP_REG_UNDEF, 0, 0, temp_reg, 0 );
-      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_BRCOUNT, temp_reg );
-    }
-
-    if ((is_stride_brgemm == 1) || (is_address_brgemm == 1)) {
-      /* BRGEMM_ADDR/STRIDE (A, B, C, cnt, [scf, eltwise_struct, Apf, Bpf] */
-      if (has_scf == 1) {
-        libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_INT8_SCF, LIBXSMM_X86_GP_REG_R8 );
-        if (has_eltwise_fused == 1) {
-          eltwise_struct_ptr_reg = LIBXSMM_X86_GP_REG_R9;
-          if (has_A_pf_ptr == 1) {
-            libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, temp_reg );
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, temp_reg );
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_8, temp_reg );
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
-            }
-          } else {
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, temp_reg );
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
-            }
-          }
-        } else {
-          if (has_A_pf_ptr == 1) {
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, LIBXSMM_X86_GP_REG_R9 );
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, temp_reg );
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
-            }
-          } else {
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R9 );
-            }
-          }
-        }
-      } else {
-        if (has_eltwise_fused == 1) {
-          eltwise_struct_ptr_reg = LIBXSMM_X86_GP_REG_R8;
-          if (has_A_pf_ptr == 1) {
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, LIBXSMM_X86_GP_REG_R9 );
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, temp_reg );
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
-            }
-          } else {
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R9 );
-            }
-          }
-        } else {
-          if (has_A_pf_ptr == 1) {
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, LIBXSMM_X86_GP_REG_R8 );
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R9 );
-            }
-          } else {
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R8 );
-            }
-          }
-        }
-      }
-    } else {
-      /* BRGEMM_OFFS (A, B, C, cnt, A_off, B_off, [scf, eltwise struct, Apf, Bpf] */
-      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_A_OFFS_BRGEMM_PTR, LIBXSMM_X86_GP_REG_R8 );
-      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_B_OFFS_BRGEMM_PTR, LIBXSMM_X86_GP_REG_R9 );
-      if (has_scf == 1) {
-        libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, temp_reg );
-        libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_INT8_SCF, temp_reg );
-        if (has_eltwise_fused == 1) {
-          libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_8, eltwise_struct_ptr_reg );
-          if (has_A_pf_ptr == 1) {
-            libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_9, temp_reg );
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, temp_reg );
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_10, temp_reg );
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
-            }
-          } else {
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_9, temp_reg );
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
-            }
-          }
-        } else {
-          if (has_A_pf_ptr == 1) {
-            libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_8, temp_reg );
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, temp_reg );
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_9, temp_reg );
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
-            }
-          } else {
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_8, temp_reg );
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
-            }
-          }
-        }
-      } else {
-        if (has_eltwise_fused == 1) {
-          libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, eltwise_struct_ptr_reg );
-          if (has_A_pf_ptr == 1) {
-            libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_8, temp_reg );
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, temp_reg );
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_9, temp_reg );
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
-            }
-          } else {
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_8, temp_reg );
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
-            }
-          }
-        } else {
-          if (has_A_pf_ptr == 1) {
-            libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, temp_reg );
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, temp_reg );
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_8, temp_reg );
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
-            }
-          } else {
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, temp_reg );
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
-            }
-          }
-        }
-      }
-    }
-  }
-
-  if (has_eltwise_fused == 1) {
-    if (has_colbias_act_fused == 1) {
-      /* TODO: Optimize this copy to operate only in used fileds form struct... */
-      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction, eltwise_struct_ptr_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,   0, temp_reg, 0 );
-      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_BIAS_PTR, temp_reg );
-      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction, eltwise_struct_ptr_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,   8, temp_reg, 0 );
-      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_OUTPUT_PTR, temp_reg );
-    }
-    if (i_micro_kernel_config->decompress_A == 1) {
-      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction, eltwise_struct_ptr_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,   16, temp_reg, 0 );
-      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_BITMAP_PTR, temp_reg );
-      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction, eltwise_struct_ptr_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,   24, temp_reg, 0 );
-      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_DECOMPRESS_BUF, temp_reg );
-    }
-    if (i_micro_kernel_config->vnni_cvt_output_ext_buf == 1) {
-      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction, eltwise_struct_ptr_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,   8, temp_reg, 0 );
-      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_OUTPUT_PTR, temp_reg );
-    }
-    if (i_micro_kernel_config->fused_relu_bwd == 1) {
-      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction, eltwise_struct_ptr_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,   32, temp_reg, 0 );
-      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_RELU_BITMASK_PTR, temp_reg );
-    }
-    if (i_micro_kernel_config->norm_to_normT_B_ext_buf == 1) {
-      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction, eltwise_struct_ptr_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,   16, temp_reg, 0 );
-      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_TRANS_EXT_BUF_B, temp_reg );
-    }
-  }
-
-  /* The stack now looks like this:
-   *      10th param (if applicable)                <-- RBP+40
-   *      9th param (if applicable)                 <-- RBP+32
-   *      8th param (if applicable)                 <-- RBP+24
-   *      7th param (if applicable)                 <-- RBP+16
-   *      Return address                            <-- RBP+8
-   *      Entry/saved RBP                           <-- RBP
-   *      prefetch A ptr                            <-- RBP-8
-   *      prefetch B ptr                            <-- RBP-16
-   *      Offset A array ptr                        <-- RBP-24
-   *      Offset B array ptr                        <-- RBP-32
-   *      Int8 scaling factor                       <-- RBP-40
-   *      GEMM_scratch ptr in stack (to be filled)  <-- RBP-48
-   *      Eltwise bias ptr                          <-- RBP-56
-   *      Eltwise output_ptr                        <-- RBP-64
-   *      Eltwise buf1_ptr                          <-- RBP-72
-   *      Eltwise buf2_ptr                          <-- RBP-80
-   *      Batch-reduce count                        <-- RBP-88, RSP
-   *
-   */
-
-  /* Now align RSP to 64 byte boundary  */
-  libxsmm_x86_instruction_alu_imm_i64( io_generated_code, i_micro_kernel_config->alu_mov_instruction, temp_reg, 0xFFFFFFFFFFFFFFC0 );
-  libxsmm_x86_instruction_alu_reg( io_generated_code, LIBXSMM_X86_INSTR_ANDQ, temp_reg, LIBXSMM_X86_GP_REG_RSP);
-
-  /* Now alllocate in stack required GEMM scratch if necessary*/
-  if (LIBXSMM_DATATYPE_F32 != LIBXSMM_GETENUM_OUT( i_xgemm_desc->datatype )) {
-    int expand_scratch_factor = (n_tiles == 1) ? 2 : 1;
-    gemm_scratch_size = expand_scratch_factor * i_xgemm_desc->n * i_xgemm_desc->ldc * 4/*i_micro_kernel_config->datatype_size*/;
-    scratch_pad_size  = (gemm_scratch_size % 64 == 0) ? 0 : ((gemm_scratch_size + 63)/64) * 64 - gemm_scratch_size;
-    gemm_scratch_size += scratch_pad_size;
-  }
-
-  if (gemm_scratch_size > 0) {
-    libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_sub_instruction, LIBXSMM_X86_GP_REG_RSP, gemm_scratch_size );
-    libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_GEMM_SCRATCH_PTR, LIBXSMM_X86_GP_REG_RSP );
-  }
-
-  /* Now push to RSP the callee-save registers  */
-  libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_RBX );
-  libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_R12 );
-  libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_R13 );
-  libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_R14 );
-  libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_R15 );
-
-  /* The stack at exit of setup looks like this:
-   *
-   *      10th param (if applicable)            <-- RBP+40
-   *      9th param (if applicable)             <-- RBP+32
-   *      8th param (if applicable)             <-- RBP+24
-   *      7th param (if applicable)             <-- RBP+16
-   *      Return address                        <-- RBP+8
-   *      Entry/saved RBP                       <-- RBP
-   *      prefetch A ptr                        <-- RBP-8
-   *      prefetch B ptr                        <-- RBP-16
-   *      Offset A array ptr                    <-- RBP-24
-   *      Offset B array ptr                    <-- RBP-32
-   *      Int8 scaling factor                   <-- RBP-40
-   *      GEMM_scratch ptr in stack             <-- RBP-48
-   *      Eltwise bias ptr                      <-- RBP-56
-   *      Eltwise output_ptr                    <-- RBP-64
-   *      Eltwise buf1_ptr                      <-- RBP-72
-   *      Eltwise buf2_ptr                      <-- RBP-80
-   *      Batch-reduce count                    <-- RBP-88, RSP
-   *      [ Potentianl  pad for 64b align ]
-   *      GEMM scratch, 64b aligned             <-- (RBP-48) contains this address
-   *      Callee-saved registers                <-- RSP
-   *
-   */
-
-}
-
-LIBXSMM_API_INTERN
-void libxsmm_generator_gemm_amx_destroy_stack_frame( libxsmm_generated_code*            io_generated_code,
-    const libxsmm_gemm_descriptor*      i_xgemm_desc,
-    const libxsmm_gp_reg_mapping*       i_gp_reg_mapping,
-    const libxsmm_micro_kernel_config*  i_micro_kernel_config ) {
-  LIBXSMM_UNUSED(i_xgemm_desc);
-  LIBXSMM_UNUSED(i_gp_reg_mapping);
-  libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_R15 );
-  libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_R14 );
-  libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_R13 );
-  libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_R12 );
-  libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_RBX );
-  libxsmm_x86_instruction_alu_reg( io_generated_code, i_micro_kernel_config->alu_mov_instruction, LIBXSMM_X86_GP_REG_RBP, LIBXSMM_X86_GP_REG_RSP);
-  libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_RBP );
-}
 
 LIBXSMM_API_INTERN
 void libxsmm_generator_gemm_init_micro_kernel_config_tileblocking(libxsmm_gemm_descriptor*      i_xgemm_desc,
@@ -1948,23 +1460,11 @@ void libxsmm_generator_gemm_amx_adjust_n_advancement( libxsmm_generated_code* io
   }
 }
 
+
 LIBXSMM_API_INTERN
-void libxsmm_generator_gemm_amx_kernel( libxsmm_generated_code* io_generated_code, const libxsmm_gemm_descriptor* i_xgemm_desc_const ) {
-  libxsmm_micro_kernel_config l_micro_kernel_config;
+void libxsmm_generator_gemm_amx_kernel_wrapper( libxsmm_generated_code* io_generated_code, const libxsmm_gemm_descriptor* i_xgemm_desc_const ) {
   libxsmm_loop_label_tracker l_loop_label_tracker;
   libxsmm_gp_reg_mapping l_gp_reg_mapping;
-  /* Allow descriptor to be modified if need be  */
-  libxsmm_gemm_descriptor l_xgemm_desc_mod = *i_xgemm_desc_const;
-  libxsmm_gemm_descriptor *i_xgemm_desc = &l_xgemm_desc_mod;
-  unsigned int m0 = 0, m1 = 0;
-
-  /* AMX specific blocking info */
-  libxsmm_blocking_info_t m_blocking_info[2], n_blocking_info[2];
-  unsigned int m_tiles, n_tiles;
-  unsigned int n_gemm_code_blocks = 0;
-
-  libxsmm_tile_config tile_config;
-  LIBXSMM_MEMZERO127(&tile_config);
 
   /* define gp register mapping */
   libxsmm_reset_x86_gp_reg_mapping( &l_gp_reg_mapping );
@@ -1977,7 +1477,7 @@ void libxsmm_generator_gemm_amx_kernel( libxsmm_generated_code* io_generated_cod
   l_gp_reg_mapping.gp_reg_a_prefetch = LIBXSMM_X86_GP_REG_RCX;
   l_gp_reg_mapping.gp_reg_b_prefetch = LIBXSMM_X86_GP_REG_R8;
   /* If we are generating the batchreduce kernel, then we rename the registers  */
-  if (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS) {
+  if (i_xgemm_desc_const->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS) {
     l_gp_reg_mapping.gp_reg_a = LIBXSMM_X86_GP_REG_RAX;
     l_gp_reg_mapping.gp_reg_a_ptrs = LIBXSMM_X86_GP_REG_RDI;
     l_gp_reg_mapping.gp_reg_b = LIBXSMM_X86_GP_REG_RBX;
@@ -1987,7 +1487,7 @@ void libxsmm_generator_gemm_amx_kernel( libxsmm_generated_code* io_generated_cod
     l_gp_reg_mapping.gp_reg_a_prefetch = LIBXSMM_X86_GP_REG_R8;
     l_gp_reg_mapping.gp_reg_b_prefetch = LIBXSMM_X86_GP_REG_R9;
     l_gp_reg_mapping.gp_reg_reduce_loop = LIBXSMM_X86_GP_REG_R10;
-  } else if (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET) {
+  } else if (i_xgemm_desc_const->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET) {
     l_gp_reg_mapping.gp_reg_a_base = LIBXSMM_X86_GP_REG_RDI;
     l_gp_reg_mapping.gp_reg_a_offset = LIBXSMM_X86_GP_REG_R8;
     l_gp_reg_mapping.gp_reg_a = LIBXSMM_X86_GP_REG_RAX;
@@ -1997,7 +1497,7 @@ void libxsmm_generator_gemm_amx_kernel( libxsmm_generated_code* io_generated_cod
     l_gp_reg_mapping.gp_reg_c = LIBXSMM_X86_GP_REG_RDX;
     l_gp_reg_mapping.gp_reg_reduce_count = LIBXSMM_X86_GP_REG_RCX;
     l_gp_reg_mapping.gp_reg_reduce_loop = LIBXSMM_X86_GP_REG_R10;
-  } else if (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE) {
+  } else if (i_xgemm_desc_const->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE) {
     l_gp_reg_mapping.gp_reg_a_base = LIBXSMM_X86_GP_REG_RDI;
     l_gp_reg_mapping.gp_reg_a = LIBXSMM_X86_GP_REG_R8;
     l_gp_reg_mapping.gp_reg_b_base = LIBXSMM_X86_GP_REG_RSI;
@@ -2021,6 +1521,35 @@ void libxsmm_generator_gemm_amx_kernel( libxsmm_generated_code* io_generated_cod
   /* define loop_label_tracker */
   libxsmm_reset_loop_label_tracker( &l_loop_label_tracker );
 
+  /* open asm */
+  libxsmm_x86_instruction_open_stream_v2( io_generated_code, 0, 0 );
+
+  /* call Intel AMX kernel */
+  libxsmm_generator_gemm_amx_kernel( io_generated_code, &l_loop_label_tracker, &l_gp_reg_mapping, i_xgemm_desc_const );
+
+  /* close asm */
+  libxsmm_x86_instruction_close_stream_v2( io_generated_code, 0 );
+}
+
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_amx_kernel( libxsmm_generated_code*            io_generated_code,
+                                                                           libxsmm_loop_label_tracker*    io_loop_label_tracker,
+                                                                           libxsmm_gp_reg_mapping*  i_gp_reg_mapping,
+                                                                           const libxsmm_gemm_descriptor* i_xgemm_desc_const ) {
+  libxsmm_micro_kernel_config l_micro_kernel_config;
+  /* Allow descriptor to be modified if need be  */
+  libxsmm_gemm_descriptor l_xgemm_desc_mod = *i_xgemm_desc_const;
+  libxsmm_gemm_descriptor *i_xgemm_desc = &l_xgemm_desc_mod;
+  unsigned int m0 = 0, m1 = 0;
+
+  /* AMX specific blocking info */
+  libxsmm_blocking_info_t m_blocking_info[2], n_blocking_info[2];
+  unsigned int n_gemm_code_blocks = 0;
+
+  libxsmm_tile_config tile_config;
+  LIBXSMM_MEMZERO127(&tile_config);
+
   /* define the micro kernel code gen properties */
   libxsmm_generator_gemm_init_micro_kernel_config_fullvector( &l_micro_kernel_config, io_generated_code->arch, i_xgemm_desc, 0 );
 
@@ -2039,56 +1568,49 @@ void libxsmm_generator_gemm_amx_kernel( libxsmm_generated_code* io_generated_cod
   /* Here compute the 2D blocking info based on the M and N values  */
   libxsmm_generator_gemm_init_micro_kernel_config_tileblocking(i_xgemm_desc, &l_micro_kernel_config, m_blocking_info, n_blocking_info, & tile_config );
 
-  /* open asm */
-  libxsmm_x86_instruction_open_stream_v2( io_generated_code, 0, 1 );
+  /* Setup stack frame...  */
+  l_micro_kernel_config.m_tiles = m_blocking_info[0].tiles;
+  l_micro_kernel_config.n_tiles = n_blocking_info[0].tiles;
 
   /* implementing load from struct */
   if ( (((LIBXSMM_GEMM_FLAG_NO_RESET_TILECONFIG & i_xgemm_desc->flags) == 0) && ((LIBXSMM_GEMM_FLAG_NO_SETUP_TILECONFIG & i_xgemm_desc->flags) == 0)) ||
-      (((LIBXSMM_GEMM_FLAG_NO_RESET_TILECONFIG & i_xgemm_desc->flags) != 0) && ((LIBXSMM_GEMM_FLAG_NO_SETUP_TILECONFIG & i_xgemm_desc->flags) != 0))     ) {
+       (((LIBXSMM_GEMM_FLAG_NO_RESET_TILECONFIG & i_xgemm_desc->flags) != 0) && ((LIBXSMM_GEMM_FLAG_NO_SETUP_TILECONFIG & i_xgemm_desc->flags) != 0))) {
     if ( ((LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI) ||
          ((LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI) ) {
-      /* saving help1 as we are still before callee save handling */
-      libxsmm_x86_instruction_push_reg( io_generated_code, l_gp_reg_mapping.gp_reg_help_1 );
-      /* RDI holds the pointer to the strcut, so lets first move this one into help_1 */
-      libxsmm_x86_instruction_alu_reg( io_generated_code, LIBXSMM_X86_INSTR_MOVQ, l_gp_reg_mapping.gp_reg_param_struct, l_gp_reg_mapping.gp_reg_help_1 );
+      /* RDI holds the pointer to the strcut, so lets first move this one into R15 */
+      libxsmm_x86_instruction_alu_reg( io_generated_code, LIBXSMM_X86_INSTR_MOVQ, i_gp_reg_mapping->gp_reg_param_struct, i_gp_reg_mapping->gp_reg_help_1 );
       /* A pointer */
       libxsmm_x86_instruction_alu_mem( io_generated_code, l_micro_kernel_config.alu_mov_instruction,
-                                       l_gp_reg_mapping.gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 32, LIBXSMM_X86_GP_REG_RDI, 0 );
+                                       i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 32, LIBXSMM_X86_GP_REG_RDI, 0 );
       /* B pointer */
       libxsmm_x86_instruction_alu_mem( io_generated_code, l_micro_kernel_config.alu_mov_instruction,
-                                       l_gp_reg_mapping.gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 64, LIBXSMM_X86_GP_REG_RSI, 0 );
+                                       i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 64, LIBXSMM_X86_GP_REG_RSI, 0 );
       /* C pointer */
       libxsmm_x86_instruction_alu_mem( io_generated_code, l_micro_kernel_config.alu_mov_instruction,
-                                       l_gp_reg_mapping.gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 96, l_gp_reg_mapping.gp_reg_c, 0 );
+                                       i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 96, i_gp_reg_mapping->gp_reg_c, 0 );
       /* batch reduce count & offsett arrays*/
       if ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS) || (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE) || (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET)) {
         libxsmm_x86_instruction_alu_mem( io_generated_code, l_micro_kernel_config.alu_mov_instruction,
-                                         l_gp_reg_mapping.gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 16, l_gp_reg_mapping.gp_reg_reduce_count, 0 );
+                                         i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 16, i_gp_reg_mapping->gp_reg_reduce_count, 0 );
         if ( i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET ) {
           libxsmm_x86_instruction_alu_mem( io_generated_code, l_micro_kernel_config.alu_mov_instruction,
-                                           l_gp_reg_mapping.gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 40, l_gp_reg_mapping.gp_reg_a_offset, 0 );
+              i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 40, i_gp_reg_mapping->gp_reg_a_offset, 0 );
           libxsmm_x86_instruction_alu_mem( io_generated_code, l_micro_kernel_config.alu_mov_instruction,
-                                           l_gp_reg_mapping.gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 72, l_gp_reg_mapping.gp_reg_b_offset, 0 );
+              i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 72, i_gp_reg_mapping->gp_reg_b_offset, 0 );
         }
       }
-      /* check values for gemm_ext */
-      if ( ((LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI) ) {
-        if ( (i_xgemm_desc->meltw_operation != LIBXSMM_MELTW_OPERATION_NONE) || (i_xgemm_desc->eltw_ap_op != LIBXSMM_MELTW_OPERATION_NONE) ||
-             (i_xgemm_desc->eltw_bp_op != LIBXSMM_MELTW_OPERATION_NONE) || (i_xgemm_desc->eltw_cp_op != LIBXSMM_MELTW_OPERATION_NONE) ) {
-          LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_INVALID_GEMM_CONFIG );
-          return;
-        }
-      }
-      /* restoring help1 */
-      libxsmm_x86_instruction_pop_reg( io_generated_code, l_gp_reg_mapping.gp_reg_help_1 );
     }
   }
 
-  /* Setup stack frame...  */
-  m_tiles = m_blocking_info[0].tiles;
-  n_tiles = n_blocking_info[0].tiles;
-  libxsmm_generator_gemm_amx_setup_stack_frame( io_generated_code, i_xgemm_desc, &l_gp_reg_mapping, &l_micro_kernel_config, m_tiles, n_tiles );
-  libxsmm_generator_gemm_amx_setup_fusion_infra( io_generated_code, i_xgemm_desc, &l_gp_reg_mapping, &l_micro_kernel_config );
+  if ( ((LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI) ||
+       ((LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI) ) {
+    libxsmm_generator_gemm_setup_fusion_microkernel_properties_v2(i_xgemm_desc, &l_micro_kernel_config );
+  } else {
+    libxsmm_generator_gemm_setup_fusion_microkernel_properties(i_xgemm_desc, &l_micro_kernel_config );
+  }
+
+  libxsmm_generator_gemm_setup_stack_frame( io_generated_code, i_xgemm_desc, i_gp_reg_mapping, &l_micro_kernel_config);
+  libxsmm_generator_gemm_amx_setup_fusion_infra( io_generated_code, i_xgemm_desc, i_gp_reg_mapping, &l_micro_kernel_config );
   libxsmm_generator_gemm_amx_setup_masking_infra( io_generated_code, &l_micro_kernel_config );
 
   if ((((LIBXSMM_GEMM_FLAG_NO_RESET_TILECONFIG & i_xgemm_desc->flags) != 0) && ((LIBXSMM_GEMM_FLAG_NO_SETUP_TILECONFIG & i_xgemm_desc->flags) == 0)) ||
@@ -2106,22 +1628,22 @@ void libxsmm_generator_gemm_amx_kernel( libxsmm_generated_code* io_generated_cod
   if ( (((LIBXSMM_GEMM_FLAG_NO_RESET_TILECONFIG & i_xgemm_desc->flags) == 0) && ((LIBXSMM_GEMM_FLAG_NO_SETUP_TILECONFIG & i_xgemm_desc->flags) == 0)) ||
       (((LIBXSMM_GEMM_FLAG_NO_RESET_TILECONFIG & i_xgemm_desc->flags) != 0) && ((LIBXSMM_GEMM_FLAG_NO_SETUP_TILECONFIG & i_xgemm_desc->flags) != 0))     ) {
     /* Set the LD registers for A and B matrices */
-    libxsmm_x86_instruction_alu_imm(io_generated_code, l_micro_kernel_config.alu_mov_instruction, l_gp_reg_mapping.gp_reg_lda, (i_xgemm_desc->lda * 4/*l_micro_kernel_config.datatype_size*/)/4);
-    libxsmm_x86_instruction_alu_imm(io_generated_code, l_micro_kernel_config.alu_mov_instruction, l_gp_reg_mapping.gp_reg_ldb, (i_xgemm_desc->ldb * 4/*l_micro_kernel_config.datatype_size*/)/4);
-    libxsmm_x86_instruction_alu_imm(io_generated_code, l_micro_kernel_config.alu_mov_instruction, l_gp_reg_mapping.gp_reg_ldc, (i_xgemm_desc->ldc * 4/*l_micro_kernel_config.datatype_size*/)/4);
+    libxsmm_x86_instruction_alu_imm(io_generated_code, l_micro_kernel_config.alu_mov_instruction, i_gp_reg_mapping->gp_reg_lda, (i_xgemm_desc->lda * 4/*l_micro_kernel_config.datatype_size*/)/4);
+    libxsmm_x86_instruction_alu_imm(io_generated_code, l_micro_kernel_config.alu_mov_instruction, i_gp_reg_mapping->gp_reg_ldb, (i_xgemm_desc->ldb * 4/*l_micro_kernel_config.datatype_size*/)/4);
+    libxsmm_x86_instruction_alu_imm(io_generated_code, l_micro_kernel_config.alu_mov_instruction, i_gp_reg_mapping->gp_reg_ldc, (i_xgemm_desc->ldc * 4/*l_micro_kernel_config.datatype_size*/)/4);
 
     /* Load the actual batch-reduce trip count */
     if ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS) || (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET) || (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE)) {
       libxsmm_x86_instruction_alu_mem( io_generated_code,
           l_micro_kernel_config.alu_mov_instruction,
-          l_gp_reg_mapping.gp_reg_reduce_count,
+          i_gp_reg_mapping->gp_reg_reduce_count,
           LIBXSMM_X86_GP_REG_UNDEF, 0,
           0,
-          l_gp_reg_mapping.gp_reg_reduce_count,
+          i_gp_reg_mapping->gp_reg_reduce_count,
           0 );
     }
 
-    libxsmm_generator_gemm_amx_kernel_nloop(io_generated_code, &l_loop_label_tracker, &l_gp_reg_mapping, &l_micro_kernel_config, i_xgemm_desc, n_blocking_info, m_blocking_info);
+    libxsmm_generator_gemm_amx_kernel_nloop(io_generated_code, io_loop_label_tracker, i_gp_reg_mapping, &l_micro_kernel_config, i_xgemm_desc, n_blocking_info, m_blocking_info);
   }
 
   /* Conditionally perform a tilerelease */
@@ -2158,20 +1680,20 @@ void libxsmm_generator_gemm_amx_kernel( libxsmm_generated_code* io_generated_cod
 
       if (l_micro_kernel_config.n_loop_exists > 0) {
         /* We should adjust n advancements in C/B etc. Also advance by M since all M adjustments have been revoked by the n loop footer */
-        libxsmm_generator_gemm_amx_adjust_n_advancement(io_generated_code, &l_loop_label_tracker, i_xgemm_desc, &l_gp_reg_mapping, &l_micro_kernel_config, -1 * i_xgemm_desc->n );
-        libxsmm_generator_gemm_amx_adjust_m_advancement(io_generated_code, &l_loop_label_tracker, i_xgemm_desc, &l_gp_reg_mapping, &l_micro_kernel_config, m0 );
+        libxsmm_generator_gemm_amx_adjust_n_advancement(io_generated_code, io_loop_label_tracker, i_xgemm_desc, i_gp_reg_mapping, &l_micro_kernel_config, -1 * i_xgemm_desc->n );
+        libxsmm_generator_gemm_amx_adjust_m_advancement(io_generated_code, io_loop_label_tracker, i_xgemm_desc, i_gp_reg_mapping, &l_micro_kernel_config, m0 );
       } else if (l_micro_kernel_config.m_loop_exists == 0) {
         /* We should advance by M since no advancements have been made  */
-        libxsmm_generator_gemm_amx_adjust_m_advancement(io_generated_code, &l_loop_label_tracker, i_xgemm_desc, &l_gp_reg_mapping, &l_micro_kernel_config, m0 );
+        libxsmm_generator_gemm_amx_adjust_m_advancement(io_generated_code, io_loop_label_tracker, i_xgemm_desc, i_gp_reg_mapping, &l_micro_kernel_config, m0 );
       } else {
         /* Nothing should be done since the M loop exists and has made the proper advancements in the M direction */
       }
 
-      libxsmm_x86_instruction_alu_imm(io_generated_code, l_micro_kernel_config.alu_mov_instruction, l_gp_reg_mapping.gp_reg_lda, (i_xgemm_desc->lda * 4/*l_micro_kernel_config.datatype_size*/)/4);
-      libxsmm_x86_instruction_alu_imm(io_generated_code, l_micro_kernel_config.alu_mov_instruction, l_gp_reg_mapping.gp_reg_ldb, (i_xgemm_desc->ldb * 4/*l_micro_kernel_config.datatype_size*/)/4);
-      libxsmm_x86_instruction_alu_imm(io_generated_code, l_micro_kernel_config.alu_mov_instruction, l_gp_reg_mapping.gp_reg_ldc, (i_xgemm_desc->ldc * 4/*l_micro_kernel_config.datatype_size*/)/4);
+      libxsmm_x86_instruction_alu_imm(io_generated_code, l_micro_kernel_config.alu_mov_instruction, i_gp_reg_mapping->gp_reg_lda, (i_xgemm_desc->lda * 4/*l_micro_kernel_config.datatype_size*/)/4);
+      libxsmm_x86_instruction_alu_imm(io_generated_code, l_micro_kernel_config.alu_mov_instruction, i_gp_reg_mapping->gp_reg_ldb, (i_xgemm_desc->ldb * 4/*l_micro_kernel_config.datatype_size*/)/4);
+      libxsmm_x86_instruction_alu_imm(io_generated_code, l_micro_kernel_config.alu_mov_instruction, i_gp_reg_mapping->gp_reg_ldc, (i_xgemm_desc->ldc * 4/*l_micro_kernel_config.datatype_size*/)/4);
 
-      libxsmm_generator_gemm_amx_kernel_nloop(io_generated_code, &l_loop_label_tracker, &l_gp_reg_mapping, &l_micro_kernel_config, i_xgemm_desc, n_blocking_info, m_blocking_info);
+      libxsmm_generator_gemm_amx_kernel_nloop(io_generated_code, io_loop_label_tracker, i_gp_reg_mapping, &l_micro_kernel_config, i_xgemm_desc, n_blocking_info, m_blocking_info);
     }
 
     libxsmm_x86_instruction_tile_control( io_generated_code,
@@ -2184,10 +1706,7 @@ void libxsmm_generator_gemm_amx_kernel( libxsmm_generated_code* io_generated_cod
   }
 
   /* Properly destroy stack frame...  */
-  libxsmm_generator_gemm_amx_destroy_stack_frame( io_generated_code, i_xgemm_desc, &l_gp_reg_mapping, &l_micro_kernel_config );
-
-  /* close asm */
-  libxsmm_x86_instruction_close_stream_v2( io_generated_code, 1 );
+  libxsmm_generator_gemm_destroy_stack_frame( io_generated_code, i_xgemm_desc, i_gp_reg_mapping, &l_micro_kernel_config );
 }
 
 LIBXSMM_API_INTERN

--- a/src/generator_gemm_amx.h
+++ b/src/generator_gemm_amx.h
@@ -93,19 +93,6 @@ void libxsmm_generator_gemm_amx_setup_fusion_infra( libxsmm_generated_code*     
                                                     libxsmm_micro_kernel_config*  i_micro_kernel_config );
 
 LIBXSMM_API_INTERN
-void libxsmm_generator_gemm_amx_setup_stack_frame( libxsmm_generated_code*            io_generated_code,
-                                                  const libxsmm_gemm_descriptor*      i_xgemm_desc,
-                                                  const libxsmm_gp_reg_mapping*       i_gp_reg_mapping,
-                                                  libxsmm_micro_kernel_config*        i_micro_kernel_config,
-                                                  int                                 m_tiles,
-                                                  int                                 n_tiles );
-
-LIBXSMM_API_INTERN
-void libxsmm_generator_gemm_amx_destroy_stack_frame( libxsmm_generated_code*            io_generated_code,
-                                                  const libxsmm_gemm_descriptor*      i_xgemm_desc,
-                                                  const libxsmm_gp_reg_mapping*       i_gp_reg_mapping,
-                                                  const libxsmm_micro_kernel_config*  i_micro_kernel_config );
-LIBXSMM_API_INTERN
 void libxsmm_generator_gemm_init_micro_kernel_config_tileblocking(libxsmm_gemm_descriptor*      i_xgemm_desc,
     libxsmm_micro_kernel_config*  i_micro_kernel_config,
     libxsmm_blocking_info_t*      m_blocking_info,
@@ -129,8 +116,14 @@ void libxsmm_generator_gemm_amx_adjust_n_advancement( libxsmm_generated_code* io
     libxsmm_blasint                     i_n_adjustment );
 
 LIBXSMM_API_INTERN
-void libxsmm_generator_gemm_amx_kernel( libxsmm_generated_code*        io_generated_code,
+void libxsmm_generator_gemm_amx_kernel_wrapper( libxsmm_generated_code*        io_generated_code,
                                         const libxsmm_gemm_descriptor* i_xgemm_desc );
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_amx_kernel( libxsmm_generated_code*            io_generated_code,
+                                                                           libxsmm_loop_label_tracker*    io_loop_label_tracker,
+                                                                           libxsmm_gp_reg_mapping*  i_gp_reg_mapping,
+                                                                           const libxsmm_gemm_descriptor* i_xgemm_desc_const );
 
 LIBXSMM_API_INTERN
 void libxsmm_generator_gemm_amx_kernel_mloop( libxsmm_generated_code*            io_generated_code,

--- a/src/generator_gemm_amx_emu.c
+++ b/src/generator_gemm_amx_emu.c
@@ -1119,47 +1119,9 @@ void libxsmm_generator_gemm_amx_setup_fusion_infra_emu( libxsmm_generated_code* 
   unsigned int reserved_mask_regs = 1;
   unsigned int emulate_cvt2bf16fp32 = (libxsmm_cpuid() < LIBXSMM_X86_AVX512_CPX) ? 1 : 0;
   LIBXSMM_UNUSED(i_gp_reg_mapping);
+  LIBXSMM_UNUSED(i_xgemm_desc);
 
-  i_micro_kernel_config->fused_bcolbias       = 0;
-  i_micro_kernel_config->fused_scolbias       = 0;
-  i_micro_kernel_config->fused_relu           = 0;
-  i_micro_kernel_config->fused_relu_nobitmask = 0;
-  i_micro_kernel_config->fused_relu_bwd       = 0;
-  i_micro_kernel_config->fused_sigmoid        = 0;
-  i_micro_kernel_config->overwrite_C          = 0;
-  i_micro_kernel_config->vnni_format_C        = 0;
   i_micro_kernel_config->emulate_cvt2bf16fp32 = emulate_cvt2bf16fp32;
-
-  /* TODO: Add support fror more fusions  */
-  if ((i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_COLBIAS_ACT) || (i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_COLBIAS_ACT_DECOMPRESS_A) ||
-      (i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_ACT_TRANSFORM_C_NORM_TO_VNNI_EXT_BUFFER)) {
-    if ((i_xgemm_desc->meltw_flags & LIBXSMM_MELTW_FLAG_OVERWRITE_C) > 0) {
-      i_micro_kernel_config->overwrite_C = 1;
-    }
-    if ((i_xgemm_desc->meltw_flags & LIBXSMM_MELTW_FLAG_ACT_RELU) > 0) {
-      i_micro_kernel_config->fused_relu = 1;
-    }
-    if ((i_xgemm_desc->meltw_flags & LIBXSMM_MELTW_FLAG_ACT_RELU_NOBITMASK) > 0) {
-      i_micro_kernel_config->fused_relu_nobitmask = 1;
-    }
-    if ((i_xgemm_desc->meltw_flags & LIBXSMM_MELTW_FLAG_ACT_RELU_BWD) > 0) {
-      i_micro_kernel_config->fused_relu_bwd = 1;
-    }
-    if ((i_xgemm_desc->meltw_flags & LIBXSMM_MELTW_FLAG_ACT_SIGM) > 0) {
-      i_micro_kernel_config->fused_sigmoid = 1;
-    }
-    if ((i_xgemm_desc->meltw_flags & LIBXSMM_MELTW_FLAG_COLBIAS) > 0) {
-      if (i_xgemm_desc->meltw_datatype_aux == LIBXSMM_DATATYPE_BF16) {
-        i_micro_kernel_config->fused_bcolbias = 1;
-      }
-      if (i_xgemm_desc->meltw_datatype_aux == LIBXSMM_DATATYPE_F32) {
-        i_micro_kernel_config->fused_scolbias = 1;
-      }
-    }
-  } else {
-    i_micro_kernel_config->overwrite_C    = 1;
-    i_micro_kernel_config->vnni_format_C  = ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_VNNI_C) > 0) ? 1 : 0;
-  }
 
   if (i_micro_kernel_config->emulate_cvt2bf16fp32 == 1) {
     unsigned int i;
@@ -1290,421 +1252,10 @@ void libxsmm_generator_gemm_amx_setup_fusion_infra_emu( libxsmm_generated_code* 
   i_micro_kernel_config->reserved_mask_regs = reserved_mask_regs;
 }
 
-
 LIBXSMM_API_INTERN
-void libxsmm_generator_gemm_amx_setup_stack_frame_emu( libxsmm_generated_code*            io_generated_code,
-    const libxsmm_gemm_descriptor*      i_xgemm_desc,
-    const libxsmm_gp_reg_mapping*       i_gp_reg_mapping,
-    libxsmm_micro_kernel_config*        i_micro_kernel_config,
-    int                                 m_tiles,
-    int                                 n_tiles ) {
-
-  int is_stride_brgemm  = ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE) > 0) ? 1 : 0;
-  int is_offset_brgemm  = ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET) > 0) ? 1 : 0;
-  int is_address_brgemm = ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS) > 0) ? 1 : 0;
-  int is_brgemm         = ((is_stride_brgemm == 1) || (is_offset_brgemm == 1) || (is_address_brgemm == 1)) ? 1 : 0;
-  int has_scf           = ((LIBXSMM_DATATYPE_I8 == LIBXSMM_GETENUM_INP( i_xgemm_desc->datatype )) && (LIBXSMM_DATATYPE_I8 == LIBXSMM_GETENUM_OUT( i_xgemm_desc->datatype ))) ? 1 : 0;
-  int has_A_pf_ptr      = (i_xgemm_desc->prefetch == LIBXSMM_GEMM_PREFETCH_AL2_AHEAD || i_xgemm_desc->prefetch == LIBXSMM_GEMM_PREFETCH_AL2BL2_VIA_C_AHEAD) ? 1 : 0;
-  int has_B_pf_ptr      = (i_xgemm_desc->prefetch == LIBXSMM_GEMM_PREFETCH_BL2_VIA_C || i_xgemm_desc->prefetch == LIBXSMM_GEMM_PREFETCH_AL2BL2_VIA_C_AHEAD ||
-      i_xgemm_desc->prefetch == LIBXSMM_GEMM_PREFETCH_AL2BL2_VIA_C || i_xgemm_desc->prefetch == LIBXSMM_PREFETCH_AL2CL2BL2_VIA_C ) ? 1 : 0;
-  int has_colbias_act_fused = 0;
-  int has_eltwise_fused     = 0;
-  unsigned int eltwise_struct_ptr_reg = LIBXSMM_X86_GP_REG_R11;
-  unsigned int temp_reg               = LIBXSMM_X86_GP_REG_R10;
-  unsigned int gemm_scratch_size      = 0;
-  unsigned int scratch_pad_size       = 0;
-  i_micro_kernel_config->decompress_A       = 0;
-  i_micro_kernel_config->sparsity_factor_A  = 1;
-  i_micro_kernel_config->vnni_cvt_output_ext_buf = 0;
-  i_micro_kernel_config->norm_to_normT_B_ext_buf = 0;
-  i_micro_kernel_config->stride_b_trans          = 0;
-
-  LIBXSMM_UNUSED(i_gp_reg_mapping);
-  LIBXSMM_UNUSED(m_tiles);
-
-  /* Determine if we have to decompress A...  */
-  if ((i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_DECOMPRESS_A) || (i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_COLBIAS_ACT_DECOMPRESS_A)) {
-    i_micro_kernel_config->decompress_A = 1;
-    i_micro_kernel_config->sparsity_factor_A = i_xgemm_desc->meltw_param;
-  }
-
-  if ((i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_COLBIAS_ACT) || (i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_COLBIAS_ACT_DECOMPRESS_A)) {
-    if ((i_xgemm_desc->meltw_flags & LIBXSMM_MELTW_FLAG_ACT_RELU_BWD) > 0) {
-      i_micro_kernel_config->fused_relu_bwd = 1;
-    }
-    has_colbias_act_fused = 1;
-    if (i_xgemm_desc->meltw_flags == (unsigned int)LIBXSMM_MELTW_FLAG_NONE) {
-      has_colbias_act_fused = 0;
-    }
-  }
-
-  if ((i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_TRANSFORM_C_NORM_TO_VNNI_EXT_BUFFER) ||
-      (i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_ACT_TRANSFORM_C_NORM_TO_VNNI_EXT_BUFFER)) {
-    i_micro_kernel_config->vnni_cvt_output_ext_buf = 1;
-    if ((i_xgemm_desc->meltw_flags & LIBXSMM_MELTW_FLAG_ACT_RELU_BWD) > 0) {
-      i_micro_kernel_config->fused_relu_bwd = 1;
-    }
-  }
-
-  if ((i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_TRANSFORM_B_NORM_TO_NORMT_EXT_BUFFER) ||
-      (i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_COLBIAS_ACT_TRANSFORM_B_NORM_TO_NORMT_EXT_BUFFER)) {
-    i_micro_kernel_config->norm_to_normT_B_ext_buf = 1;
-  }
-
-  has_eltwise_fused = ((has_colbias_act_fused == 1)) ? 1: 0;
-  i_micro_kernel_config->fused_eltwise = has_eltwise_fused;
-  if (i_micro_kernel_config->decompress_A == 1) {
-    has_eltwise_fused = 1;
-    i_micro_kernel_config->fused_eltwise = 1;
-  }
-
-  if (i_micro_kernel_config->vnni_cvt_output_ext_buf == 1) {
-    has_eltwise_fused = 1;
-    i_micro_kernel_config->fused_eltwise = 1;
-  }
-
-  if (i_micro_kernel_config->norm_to_normT_B_ext_buf == 1) {
-    has_eltwise_fused = 1;
-    i_micro_kernel_config->fused_eltwise = 1;
-    i_micro_kernel_config->stride_b_trans = i_xgemm_desc->meltw_ldy;
-  }
-
-  if (i_micro_kernel_config->fused_relu_bwd == 1) {
-    has_eltwise_fused = 1;
-    i_micro_kernel_config->fused_eltwise = 1;
-  }
-
-  libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_RBP );
-  libxsmm_x86_instruction_alu_reg( io_generated_code, i_micro_kernel_config->alu_mov_instruction, LIBXSMM_X86_GP_REG_RSP, LIBXSMM_X86_GP_REG_RBP);
-  libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_sub_instruction, LIBXSMM_X86_GP_REG_RSP, 88 );
-
-  if (is_brgemm == 0) {
-    /* GEMM (A, B, C, [scf, eltwise_struct, Apf, Bpf] */
-    if (has_scf == 1) {
-      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_INT8_SCF, LIBXSMM_X86_GP_REG_RCX );
-      if (has_eltwise_fused == 1) {
-        eltwise_struct_ptr_reg = LIBXSMM_X86_GP_REG_R8;
-        if (has_A_pf_ptr == 1) {
-          libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, LIBXSMM_X86_GP_REG_R9 );
-          if (has_B_pf_ptr == 1) {
-            libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, temp_reg );
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
-          }
-        } else {
-          if (has_B_pf_ptr == 1) {
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R9 );
-          }
-        }
-      } else {
-        if (has_A_pf_ptr == 1) {
-          libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, LIBXSMM_X86_GP_REG_R8 );
-          if (has_B_pf_ptr == 1) {
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R9 );
-          }
-        } else {
-          if (has_B_pf_ptr == 1) {
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R8 );
-          }
-        }
-      }
-    } else {
-      if (has_eltwise_fused == 1) {
-        eltwise_struct_ptr_reg = LIBXSMM_X86_GP_REG_RCX;
-        if (has_A_pf_ptr == 1) {
-          libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, LIBXSMM_X86_GP_REG_R8 );
-          if (has_B_pf_ptr == 1) {
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R9 );
-          }
-        } else {
-          if (has_B_pf_ptr == 1) {
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R8 );
-          }
-        }
-      } else {
-        if (has_A_pf_ptr == 1) {
-          libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, LIBXSMM_X86_GP_REG_RCX );
-          if (has_B_pf_ptr == 1) {
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R8 );
-          }
-        } else {
-          if (has_B_pf_ptr == 1) {
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_RCX );
-          }
-        }
-      }
-    }
-  } else {
-    if (i_micro_kernel_config->decompress_A == 1) {
-      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction, LIBXSMM_X86_GP_REG_RCX, LIBXSMM_X86_GP_REG_UNDEF, 0, 0, temp_reg, 0 );
-      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_BRCOUNT, temp_reg );
-    }
-
-    if ((is_stride_brgemm == 1) || (is_address_brgemm == 1)) {
-      /* BRGEMM_ADDR/STRIDE (A, B, C, cnt, [scf, eltwise_struct, Apf, Bpf] */
-      if (has_scf == 1) {
-        libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_INT8_SCF, LIBXSMM_X86_GP_REG_R8 );
-        if (has_eltwise_fused == 1) {
-          eltwise_struct_ptr_reg = LIBXSMM_X86_GP_REG_R9;
-          if (has_A_pf_ptr == 1) {
-            libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, temp_reg );
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, temp_reg );
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_8, temp_reg );
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
-            }
-          } else {
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, temp_reg );
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
-            }
-          }
-        } else {
-          if (has_A_pf_ptr == 1) {
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, LIBXSMM_X86_GP_REG_R9 );
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, temp_reg );
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
-            }
-          } else {
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R9 );
-            }
-          }
-        }
-      } else {
-        if (has_eltwise_fused == 1) {
-          eltwise_struct_ptr_reg = LIBXSMM_X86_GP_REG_R8;
-          if (has_A_pf_ptr == 1) {
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, LIBXSMM_X86_GP_REG_R9 );
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, temp_reg );
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
-            }
-          } else {
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R9 );
-            }
-          }
-        } else {
-          if (has_A_pf_ptr == 1) {
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, LIBXSMM_X86_GP_REG_R8 );
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R9 );
-            }
-          } else {
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R8 );
-            }
-          }
-        }
-      }
-    } else {
-      /* BRGEMM_OFFS (A, B, C, cnt, A_off, B_off, [scf, eltwise struct, Apf, Bpf] */
-      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_A_OFFS_BRGEMM_PTR, LIBXSMM_X86_GP_REG_R8 );
-      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_B_OFFS_BRGEMM_PTR, LIBXSMM_X86_GP_REG_R9 );
-      if (has_scf == 1) {
-        libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, temp_reg );
-        libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_INT8_SCF, temp_reg );
-        if (has_eltwise_fused == 1) {
-          libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_8, eltwise_struct_ptr_reg );
-          if (has_A_pf_ptr == 1) {
-            libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_9, temp_reg );
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, temp_reg );
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_10, temp_reg );
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
-            }
-          } else {
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_9, temp_reg );
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
-            }
-          }
-        } else {
-          if (has_A_pf_ptr == 1) {
-            libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_8, temp_reg );
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, temp_reg );
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_9, temp_reg );
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
-            }
-          } else {
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_8, temp_reg );
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
-            }
-          }
-        }
-      } else {
-        if (has_eltwise_fused == 1) {
-          libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, eltwise_struct_ptr_reg );
-          if (has_A_pf_ptr == 1) {
-            libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_8, temp_reg );
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, temp_reg );
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_9, temp_reg );
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
-            }
-          } else {
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_8, temp_reg );
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
-            }
-          }
-        } else {
-          if (has_A_pf_ptr == 1) {
-            libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, temp_reg );
-            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, temp_reg );
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_8, temp_reg );
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
-            }
-          } else {
-            if (has_B_pf_ptr == 1) {
-              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, temp_reg );
-              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
-            }
-          }
-        }
-      }
-    }
-  }
-
-  if (has_eltwise_fused == 1) {
-    if (has_colbias_act_fused == 1) {
-      /* TODO: Optimize this copy to operate only in used fileds form struct... */
-      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction, eltwise_struct_ptr_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,   0, temp_reg, 0 );
-      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_BIAS_PTR, temp_reg );
-      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction, eltwise_struct_ptr_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,   8, temp_reg, 0 );
-      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_OUTPUT_PTR, temp_reg );
-    }
-    if (i_micro_kernel_config->decompress_A == 1) {
-      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction, eltwise_struct_ptr_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,   16, temp_reg, 0 );
-      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_BITMAP_PTR, temp_reg );
-      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction, eltwise_struct_ptr_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,   24, temp_reg, 0 );
-      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_DECOMPRESS_BUF, temp_reg );
-    }
-    if (i_micro_kernel_config->vnni_cvt_output_ext_buf == 1) {
-      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction, eltwise_struct_ptr_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,   8, temp_reg, 0 );
-      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_OUTPUT_PTR, temp_reg );
-    }
-    if (i_micro_kernel_config->fused_relu_bwd == 1) {
-      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction, eltwise_struct_ptr_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,   32, temp_reg, 0 );
-      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_RELU_BITMASK_PTR, temp_reg );
-    }
-    if (i_micro_kernel_config->norm_to_normT_B_ext_buf == 1) {
-      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction, eltwise_struct_ptr_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,   16, temp_reg, 0 );
-      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_TRANS_EXT_BUF_B, temp_reg );
-    }
-  }
-
-  /* The stack now looks like this:
-   *      10th param (if applicable)                <-- RBP+40
-   *      9th param (if applicable)                 <-- RBP+32
-   *      8th param (if applicable)                 <-- RBP+24
-   *      7th param (if applicable)                 <-- RBP+16
-   *      Return address                            <-- RBP+8
-   *      Entry/saved RBP                           <-- RBP
-   *      prefetch A ptr                            <-- RBP-8
-   *      prefetch B ptr                            <-- RBP-16
-   *      Offset A array ptr                        <-- RBP-24
-   *      Offset B array ptr                        <-- RBP-32
-   *      Int8 scaling factor                       <-- RBP-40
-   *      GEMM_scratch ptr in stack (to be filled)  <-- RBP-48
-   *      Eltwise bias ptr                          <-- RBP-56
-   *      Eltwise output_ptr                        <-- RBP-64
-   *      Eltwise buf1_ptr                          <-- RBP-72
-   *      Eltwise buf2_ptr                          <-- RBP-80, RSP
-   *
-   */
-
-  /* Now align RSP to 64 byte boundary  */
-  libxsmm_x86_instruction_alu_imm_i64( io_generated_code, i_micro_kernel_config->alu_mov_instruction, temp_reg, 0xFFFFFFFFFFFFFFC0 );
-  libxsmm_x86_instruction_alu_reg( io_generated_code, LIBXSMM_X86_INSTR_ANDQ, temp_reg, LIBXSMM_X86_GP_REG_RSP);
-
-  /* Now alllocate in stack required GEMM scratch if necessary*/
-  if (LIBXSMM_DATATYPE_F32 != LIBXSMM_GETENUM_OUT( i_xgemm_desc->datatype )) {
-    int expand_scratch_factor = (n_tiles == 1) ? 2 : 1;
-    i_micro_kernel_config->emulation_scratch_offset = expand_scratch_factor * i_xgemm_desc->n * i_xgemm_desc->ldc * 4 /*i_micro_kernel_config->datatype_size*/;
-    gemm_scratch_size = expand_scratch_factor * i_xgemm_desc->n * i_xgemm_desc->ldc * 4 /*i_micro_kernel_config->datatype_size*/ + 8 * 32 * 32 + 32 * 64 ;
-    scratch_pad_size  = (gemm_scratch_size % 64 == 0) ? 0 : ((gemm_scratch_size + 63)/64) * 64 - gemm_scratch_size;
-    gemm_scratch_size += scratch_pad_size;
-  }
-
-  if (LIBXSMM_DATATYPE_F32 == LIBXSMM_GETENUM_OUT( i_xgemm_desc->datatype )) {
-    i_micro_kernel_config->emulation_scratch_offset = 0;
-    gemm_scratch_size = 8 * 32 * 32 + 32 * 64 ;
-    scratch_pad_size  = (gemm_scratch_size % 64 == 0) ? 0 : ((gemm_scratch_size + 63)/64) * 64 - gemm_scratch_size;
-    gemm_scratch_size += scratch_pad_size;
-  }
-
-  if (gemm_scratch_size > 0) {
-    libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_sub_instruction, LIBXSMM_X86_GP_REG_RSP, gemm_scratch_size );
-    libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_GEMM_SCRATCH_PTR, LIBXSMM_X86_GP_REG_RSP );
-  }
-
-  /* Now push to RSP the callee-save registers  */
-  libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_RBX );
-  libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_R12 );
-  libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_R13 );
-  libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_R14 );
-  libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_R15 );
-
-  /* The stack at exit of setup looks like this:
-   *
-   *      10th param (if applicable)            <-- RBP+40
-   *      9th param (if applicable)             <-- RBP+32
-   *      8th param (if applicable)             <-- RBP+24
-   *      7th param (if applicable)             <-- RBP+16
-   *      Return address                        <-- RBP+8
-   *      Entry/saved RBP                       <-- RBP
-   *      prefetch A ptr                        <-- RBP-8
-   *      prefetch B ptr                        <-- RBP-16
-   *      Offset A array ptr                    <-- RBP-24
-   *      Offset B array ptr                    <-- RBP-32
-   *      Int8 scaling factor                   <-- RBP-40
-   *      GEMM_scratch ptr in stack             <-- RBP-48
-   *      Eltwise bias ptr                      <-- RBP-56
-   *      Eltwise output_ptr                    <-- RBP-64
-   *      Eltwise buf1_ptr                      <-- RBP-72
-   *      Eltwise buf2_ptr                      <-- RBP-80
-   *      [ Potentianl  pad for 64b align ]
-   *      GEMM scratch, 64b aligned             <-- (RBP-48) contains this address
-   *      Callee-saved registers                <-- RSP
-   *
-   */
-
-}
-
-
-LIBXSMM_API_INTERN
-void libxsmm_generator_gemm_amx_destroy_stack_frame_emu( libxsmm_generated_code*            io_generated_code,
-    const libxsmm_gemm_descriptor*      i_xgemm_desc,
-    const libxsmm_gp_reg_mapping*       i_gp_reg_mapping,
-    libxsmm_micro_kernel_config*        i_micro_kernel_config ) {
-  LIBXSMM_UNUSED(i_xgemm_desc);
-  LIBXSMM_UNUSED(i_gp_reg_mapping);
-
-  libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_R15 );
-  libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_R14 );
-  libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_R13 );
-  libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_R12 );
-  libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_RBX );
-  libxsmm_x86_instruction_alu_reg( io_generated_code, i_micro_kernel_config->alu_mov_instruction, LIBXSMM_X86_GP_REG_RBP, LIBXSMM_X86_GP_REG_RSP);
-  libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_RBP );
-}
-
-LIBXSMM_API_INTERN
-void libxsmm_generator_gemm_amx_kernel_emu( libxsmm_generated_code* io_generated_code, const libxsmm_gemm_descriptor* i_xgemm_desc ) {
-  libxsmm_micro_kernel_config l_micro_kernel_config;
+void libxsmm_generator_gemm_amx_kernel_emu_wrapper( libxsmm_generated_code* io_generated_code, const libxsmm_gemm_descriptor* i_xgemm_desc_const ) {
   libxsmm_loop_label_tracker l_loop_label_tracker;
   libxsmm_gp_reg_mapping l_gp_reg_mapping;
-
-  /* AMX specific blocking info */
-  libxsmm_blocking_info_t m_blocking_info[2], n_blocking_info[2];
-  unsigned int m_blocking, n_blocking, k_blocking, ii = 0, m_tiles, n_tiles, im, in;
-  libxsmm_tile_config tile_config;
-  LIBXSMM_MEMZERO127(&tile_config);
 
   /* define gp register mapping */
   libxsmm_reset_x86_gp_reg_mapping( &l_gp_reg_mapping );
@@ -1717,7 +1268,7 @@ void libxsmm_generator_gemm_amx_kernel_emu( libxsmm_generated_code* io_generated
   l_gp_reg_mapping.gp_reg_a_prefetch = LIBXSMM_X86_GP_REG_RCX;
   l_gp_reg_mapping.gp_reg_b_prefetch = LIBXSMM_X86_GP_REG_R8;
   /* If we are generating the batchreduce kernel, then we rename the registers  */
-  if (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS) {
+  if (i_xgemm_desc_const->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS) {
     l_gp_reg_mapping.gp_reg_a = LIBXSMM_X86_GP_REG_RAX;
     l_gp_reg_mapping.gp_reg_a_ptrs = LIBXSMM_X86_GP_REG_RDI;
     l_gp_reg_mapping.gp_reg_b = LIBXSMM_X86_GP_REG_RBX;
@@ -1727,7 +1278,7 @@ void libxsmm_generator_gemm_amx_kernel_emu( libxsmm_generated_code* io_generated
     l_gp_reg_mapping.gp_reg_a_prefetch = LIBXSMM_X86_GP_REG_R8;
     l_gp_reg_mapping.gp_reg_b_prefetch = LIBXSMM_X86_GP_REG_R9;
     l_gp_reg_mapping.gp_reg_reduce_loop = LIBXSMM_X86_GP_REG_R10;
-  } else if (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET) {
+  } else if (i_xgemm_desc_const->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET) {
     l_gp_reg_mapping.gp_reg_a_base = LIBXSMM_X86_GP_REG_RDI;
     l_gp_reg_mapping.gp_reg_a_offset = LIBXSMM_X86_GP_REG_R8;
     l_gp_reg_mapping.gp_reg_a = LIBXSMM_X86_GP_REG_RAX;
@@ -1737,7 +1288,7 @@ void libxsmm_generator_gemm_amx_kernel_emu( libxsmm_generated_code* io_generated
     l_gp_reg_mapping.gp_reg_c = LIBXSMM_X86_GP_REG_RDX;
     l_gp_reg_mapping.gp_reg_reduce_count = LIBXSMM_X86_GP_REG_RCX;
     l_gp_reg_mapping.gp_reg_reduce_loop = LIBXSMM_X86_GP_REG_R10;
-  } else if (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE) {
+  } else if (i_xgemm_desc_const->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE) {
     l_gp_reg_mapping.gp_reg_a_base = LIBXSMM_X86_GP_REG_RDI;
     l_gp_reg_mapping.gp_reg_a = LIBXSMM_X86_GP_REG_R8;
     l_gp_reg_mapping.gp_reg_b_base = LIBXSMM_X86_GP_REG_RSI;
@@ -1761,9 +1312,33 @@ void libxsmm_generator_gemm_amx_kernel_emu( libxsmm_generated_code* io_generated
   /* define loop_label_tracker */
   libxsmm_reset_loop_label_tracker( &l_loop_label_tracker );
 
+  /* open asm */
+  libxsmm_x86_instruction_open_stream_v2( io_generated_code, 0, 0 );
+
+  /* call Intel AMX kernel */
+  libxsmm_generator_gemm_amx_kernel_emu( io_generated_code, &l_loop_label_tracker, &l_gp_reg_mapping, i_xgemm_desc_const );
+
+  /* close asm */
+  libxsmm_x86_instruction_close_stream_v2( io_generated_code, 0 );
+}
+
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_amx_kernel_emu( libxsmm_generated_code*        io_generated_code,
+                                                                           libxsmm_loop_label_tracker*    io_loop_label_tracker,
+                                                                           libxsmm_gp_reg_mapping*  i_gp_reg_mapping,
+                                                                           const libxsmm_gemm_descriptor* i_xgemm_desc ) {
+  libxsmm_micro_kernel_config l_micro_kernel_config;
+
+  /* AMX specific blocking info */
+  libxsmm_blocking_info_t m_blocking_info[2], n_blocking_info[2];
+  unsigned int m_blocking, n_blocking, k_blocking, ii = 0, m_tiles, n_tiles, im, in;
+  libxsmm_tile_config tile_config;
+  LIBXSMM_MEMZERO127(&tile_config);
+
   /* define the micro kernel code gen properties */
   libxsmm_generator_gemm_init_micro_kernel_config_fullvector( &l_micro_kernel_config, io_generated_code->arch, i_xgemm_desc, 0 );
-  l_micro_kernel_config.io_loop_label_tracker = &l_loop_label_tracker;
+  l_micro_kernel_config.io_loop_label_tracker = io_loop_label_tracker;
 
   /* Here compute the 2D blocking info based on the M and N values  */
   /* For now super simple, rudimentary logic, to be generalized later on  */
@@ -1882,6 +1457,10 @@ void libxsmm_generator_gemm_amx_kernel_emu( libxsmm_generated_code* io_generated
   /* First configure the accumulator tiles 0-4 */
   m_tiles = m_blocking_info[0].tiles;
   n_tiles = n_blocking_info[0].tiles;
+  /* Setup stack frame...  */
+  l_micro_kernel_config.m_tiles = m_blocking_info[0].tiles;
+  l_micro_kernel_config.n_tiles = n_blocking_info[0].tiles;
+
   for (im = 0; im < m_tiles; im++) {
     for (in = 0; in < n_tiles; in++) {
       libxsmm_setup_tile(ii, m_blocking_info[0].sizes[im], n_blocking_info[0].sizes[in], &tile_config);
@@ -1905,54 +1484,46 @@ void libxsmm_generator_gemm_amx_kernel_emu( libxsmm_generated_code* io_generated
     libxsmm_setup_tile(7, k_blocking, n_blocking_info[0].sizes[3], &tile_config);
   }
 
-  /* open asm */
-  libxsmm_x86_instruction_open_stream_v2( io_generated_code, 0, 1 );
-
   /* implementing load from struct */
   if ( (((LIBXSMM_GEMM_FLAG_NO_RESET_TILECONFIG & i_xgemm_desc->flags) == 0) && ((LIBXSMM_GEMM_FLAG_NO_SETUP_TILECONFIG & i_xgemm_desc->flags) == 0)) ||
-       (((LIBXSMM_GEMM_FLAG_NO_RESET_TILECONFIG & i_xgemm_desc->flags) != 0) && ((LIBXSMM_GEMM_FLAG_NO_SETUP_TILECONFIG & i_xgemm_desc->flags) != 0))     ) {
+       (((LIBXSMM_GEMM_FLAG_NO_RESET_TILECONFIG & i_xgemm_desc->flags) != 0) && ((LIBXSMM_GEMM_FLAG_NO_SETUP_TILECONFIG & i_xgemm_desc->flags) != 0))) {
     if ( ((LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI) ||
          ((LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI) ) {
-      /* saving help1 as we are still before callee save handling */
-      libxsmm_x86_instruction_push_reg( io_generated_code, l_gp_reg_mapping.gp_reg_help_1 );
-      /* RDI holds the pointer to the strcut, so lets first move this one into help_1 */
-      libxsmm_x86_instruction_alu_reg( io_generated_code, LIBXSMM_X86_INSTR_MOVQ, l_gp_reg_mapping.gp_reg_param_struct, l_gp_reg_mapping.gp_reg_help_1 );
+      /* RDI holds the pointer to the strcut, so lets first move this one into R15 */
+      libxsmm_x86_instruction_alu_reg( io_generated_code, LIBXSMM_X86_INSTR_MOVQ, i_gp_reg_mapping->gp_reg_param_struct, i_gp_reg_mapping->gp_reg_help_1 );
       /* A pointer */
       libxsmm_x86_instruction_alu_mem( io_generated_code, l_micro_kernel_config.alu_mov_instruction,
-                                       l_gp_reg_mapping.gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 32, LIBXSMM_X86_GP_REG_RDI, 0 );
+                                       i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 32, LIBXSMM_X86_GP_REG_RDI, 0 );
       /* B pointer */
       libxsmm_x86_instruction_alu_mem( io_generated_code, l_micro_kernel_config.alu_mov_instruction,
-                                       l_gp_reg_mapping.gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 64, LIBXSMM_X86_GP_REG_RSI, 0 );
+                                       i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 64, LIBXSMM_X86_GP_REG_RSI, 0 );
       /* C pointer */
       libxsmm_x86_instruction_alu_mem( io_generated_code, l_micro_kernel_config.alu_mov_instruction,
-                                       l_gp_reg_mapping.gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 96, l_gp_reg_mapping.gp_reg_c, 0 );
+                                       i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 96, i_gp_reg_mapping->gp_reg_c, 0 );
       /* batch reduce count & offsett arrays*/
       if ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS) || (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE) || (i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET)) {
         libxsmm_x86_instruction_alu_mem( io_generated_code, l_micro_kernel_config.alu_mov_instruction,
-                                         l_gp_reg_mapping.gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 16, l_gp_reg_mapping.gp_reg_reduce_count, 0 );
+                                         i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 16, i_gp_reg_mapping->gp_reg_reduce_count, 0 );
         if ( i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET ) {
           libxsmm_x86_instruction_alu_mem( io_generated_code, l_micro_kernel_config.alu_mov_instruction,
-                                           l_gp_reg_mapping.gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 40, l_gp_reg_mapping.gp_reg_a_offset, 0 );
+              i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 40, i_gp_reg_mapping->gp_reg_a_offset, 0 );
           libxsmm_x86_instruction_alu_mem( io_generated_code, l_micro_kernel_config.alu_mov_instruction,
-                                           l_gp_reg_mapping.gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 72, l_gp_reg_mapping.gp_reg_b_offset, 0 );
+              i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 72, i_gp_reg_mapping->gp_reg_b_offset, 0 );
         }
       }
-      /* check values for gemm_ext */
-      if ( ((LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI) ) {
-        if ( (i_xgemm_desc->meltw_operation != LIBXSMM_MELTW_OPERATION_NONE) || (i_xgemm_desc->eltw_ap_op != LIBXSMM_MELTW_OPERATION_NONE) ||
-             (i_xgemm_desc->eltw_bp_op != LIBXSMM_MELTW_OPERATION_NONE) || (i_xgemm_desc->eltw_cp_op != LIBXSMM_MELTW_OPERATION_NONE) ) {
-          LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_INVALID_GEMM_CONFIG );
-          return;
-        }
-      }
-      /* restoring help1 */
-      libxsmm_x86_instruction_pop_reg( io_generated_code, l_gp_reg_mapping.gp_reg_help_1 );
     }
   }
 
+  if ( ((LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI) ||
+       ((LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI) ) {
+    libxsmm_generator_gemm_setup_fusion_microkernel_properties_v2(i_xgemm_desc, &l_micro_kernel_config );
+  } else {
+    libxsmm_generator_gemm_setup_fusion_microkernel_properties(i_xgemm_desc, &l_micro_kernel_config );
+  }
+
   /* Setup stack frame...  */
-  libxsmm_generator_gemm_amx_setup_stack_frame_emu( io_generated_code, i_xgemm_desc, &l_gp_reg_mapping, &l_micro_kernel_config, m_tiles, n_tiles );
-  libxsmm_generator_gemm_amx_setup_fusion_infra_emu( io_generated_code, i_xgemm_desc, &l_gp_reg_mapping, &l_micro_kernel_config );
+  libxsmm_generator_gemm_setup_stack_frame( io_generated_code, i_xgemm_desc, i_gp_reg_mapping, &l_micro_kernel_config);
+  libxsmm_generator_gemm_amx_setup_fusion_infra_emu( io_generated_code, i_xgemm_desc, i_gp_reg_mapping, &l_micro_kernel_config );
 
   /* Store tile configuration for later usage...  */
   l_micro_kernel_config.tile_config = tile_config;
@@ -1965,16 +1536,16 @@ void libxsmm_generator_gemm_amx_kernel_emu( libxsmm_generated_code* io_generated
   if ( (((LIBXSMM_GEMM_FLAG_NO_RESET_TILECONFIG & i_xgemm_desc->flags) == 0) && ((LIBXSMM_GEMM_FLAG_NO_SETUP_TILECONFIG & i_xgemm_desc->flags) == 0)) ||
       (((LIBXSMM_GEMM_FLAG_NO_RESET_TILECONFIG & i_xgemm_desc->flags) != 0) && ((LIBXSMM_GEMM_FLAG_NO_SETUP_TILECONFIG & i_xgemm_desc->flags) != 0))     ) {
     /* Set the LD registers for A and B matrices */
-    libxsmm_x86_instruction_alu_imm(io_generated_code, l_micro_kernel_config.alu_mov_instruction, l_gp_reg_mapping.gp_reg_lda, (i_xgemm_desc->lda * 4 /*l_micro_kernel_config.datatype_size*/)/4);
-    libxsmm_x86_instruction_alu_imm(io_generated_code, l_micro_kernel_config.alu_mov_instruction, l_gp_reg_mapping.gp_reg_ldb, (i_xgemm_desc->ldb * 4 /*l_micro_kernel_config.datatype_size*/)/4);
-    libxsmm_x86_instruction_alu_imm(io_generated_code, l_micro_kernel_config.alu_mov_instruction, l_gp_reg_mapping.gp_reg_ldc, (i_xgemm_desc->ldc * 4 /*l_micro_kernel_config.datatype_size*/)/4);
+    libxsmm_x86_instruction_alu_imm(io_generated_code, l_micro_kernel_config.alu_mov_instruction, i_gp_reg_mapping->gp_reg_lda, (i_xgemm_desc->lda * 4 /*l_micro_kernel_config.datatype_size*/)/4);
+    libxsmm_x86_instruction_alu_imm(io_generated_code, l_micro_kernel_config.alu_mov_instruction, i_gp_reg_mapping->gp_reg_ldb, (i_xgemm_desc->ldb * 4 /*l_micro_kernel_config.datatype_size*/)/4);
+    libxsmm_x86_instruction_alu_imm(io_generated_code, l_micro_kernel_config.alu_mov_instruction, i_gp_reg_mapping->gp_reg_ldc, (i_xgemm_desc->ldc * 4 /*l_micro_kernel_config.datatype_size*/)/4);
 
     /* Store this auxiliary info for the emulation */
     l_micro_kernel_config.lda_emu = (i_xgemm_desc->lda * 4 /*l_micro_kernel_config.datatype_size*/)/4;
     l_micro_kernel_config.ldb_emu = (i_xgemm_desc->ldb * 4 /*l_micro_kernel_config.datatype_size*/)/4;
     l_micro_kernel_config.ldc_emu = (i_xgemm_desc->ldc * 4 /*l_micro_kernel_config.datatype_size*/)/4;
 
-    libxsmm_generator_gemm_amx_kernel_nloop_emu(io_generated_code, &l_loop_label_tracker, &l_gp_reg_mapping, &l_micro_kernel_config, i_xgemm_desc, n_blocking_info, m_blocking_info);
+    libxsmm_generator_gemm_amx_kernel_nloop_emu(io_generated_code, io_loop_label_tracker, i_gp_reg_mapping, &l_micro_kernel_config, i_xgemm_desc, n_blocking_info, m_blocking_info);
   }
 
   /* Conditionally perform a tilerelease */
@@ -1984,11 +1555,8 @@ void libxsmm_generator_gemm_amx_kernel_emu( libxsmm_generated_code* io_generated
   }
 
   /* Properly destroy stack frame...  */
-  libxsmm_generator_gemm_amx_destroy_stack_frame_emu( io_generated_code, i_xgemm_desc, &l_gp_reg_mapping, &l_micro_kernel_config );
-  /* close asm */
-  libxsmm_x86_instruction_close_stream_v2( io_generated_code, 1 );
+  libxsmm_generator_gemm_destroy_stack_frame( io_generated_code, i_xgemm_desc, i_gp_reg_mapping, &l_micro_kernel_config );
 }
-
 
 LIBXSMM_API_INTERN
 void libxsmm_generator_gemm_amx_kernel_mloop_emu( libxsmm_generated_code*            io_generated_code,

--- a/src/generator_gemm_amx_emu.h
+++ b/src/generator_gemm_amx_emu.h
@@ -61,23 +61,15 @@ void libxsmm_generator_gemm_amx_setup_fusion_infra_emu( libxsmm_generated_code* 
                                                     const libxsmm_gp_reg_mapping*       i_gp_reg_mapping,
                                                     libxsmm_micro_kernel_config*  i_micro_kernel_config );
 
-LIBXSMM_API_INTERN
-void libxsmm_generator_gemm_amx_setup_stack_frame_emu( libxsmm_generated_code*            io_generated_code,
-                                                  const libxsmm_gemm_descriptor*      i_xgemm_desc,
-                                                  const libxsmm_gp_reg_mapping*       i_gp_reg_mapping,
-                                                  libxsmm_micro_kernel_config*        i_micro_kernel_config,
-                                                  int                                 m_tiles,
-                                                  int                                 n_tiles );
 
 LIBXSMM_API_INTERN
-void libxsmm_generator_gemm_amx_destroy_stack_frame_emu( libxsmm_generated_code*            io_generated_code,
-                                                  const libxsmm_gemm_descriptor*      i_xgemm_desc,
-                                                  const libxsmm_gp_reg_mapping*       i_gp_reg_mapping,
-                                                  libxsmm_micro_kernel_config*        i_micro_kernel_config );
+void libxsmm_generator_gemm_amx_kernel_emu_wrapper( libxsmm_generated_code* io_generated_code, const libxsmm_gemm_descriptor* i_xgemm_desc_const );
 
 LIBXSMM_API_INTERN
 void libxsmm_generator_gemm_amx_kernel_emu( libxsmm_generated_code*        io_generated_code,
-                                        const libxsmm_gemm_descriptor* i_xgemm_desc );
+                                                                           libxsmm_loop_label_tracker*    io_loop_label_tracker,
+                                                                           libxsmm_gp_reg_mapping*  i_gp_reg_mapping,
+                                                                           const libxsmm_gemm_descriptor* i_xgemm_desc );
 
 LIBXSMM_API_INTERN
 void libxsmm_generator_gemm_amx_kernel_mloop_emu( libxsmm_generated_code*            io_generated_code,

--- a/src/generator_gemm_common.c
+++ b/src/generator_gemm_common.c
@@ -6,12 +6,1114 @@
 * Further information: https://github.com/hfp/libxsmm/                        *
 * SPDX-License-Identifier: BSD-3-Clause                                       *
 ******************************************************************************/
-/* Alexander Heinecke (Intel Corp.)
+/* Alexander Heinecke, Evangelos Georganas (Intel Corp.)
 ******************************************************************************/
 #include "generator_gemm_common.h"
 #include "generator_common.h"
 #include "generator_x86_instructions.h"
 #include "libxsmm_main.h"
+#include "generator_common_x86.h"
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_apply_relu_to_vreg( libxsmm_generated_code*             io_generated_code,
+    const libxsmm_micro_kernel_config* i_micro_kernel_config,
+    const unsigned int                 zero_vreg,
+    const unsigned int                 inout_vreg,
+    const unsigned int                 store_bitmask,
+    const unsigned int                 gpr_bitmask,
+    const unsigned int                 store_bitmask_offset,
+    const unsigned int                 is_32_bit_relu,
+    const unsigned int                 aux_gpr,
+    const unsigned int                 aux_vreg) {
+  if (io_generated_code->arch < LIBXSMM_X86_AVX512) {
+    if (is_32_bit_relu == 1) {
+      if (store_bitmask == 1) {
+        libxsmm_x86_instruction_vec_compute_3reg_imm8( io_generated_code, LIBXSMM_X86_INSTR_VCMPPS, i_micro_kernel_config->vector_name, zero_vreg, inout_vreg, aux_vreg, 6 );
+        libxsmm_x86_instruction_vec_compute_3reg_imm8( io_generated_code, LIBXSMM_X86_INSTR_VMOVMSKPS, i_micro_kernel_config->vector_name, aux_vreg, LIBXSMM_X86_VEC_REG_UNDEF, aux_gpr, 0 );
+        libxsmm_x86_instruction_alu_mem( io_generated_code, LIBXSMM_X86_INSTR_MOVB, gpr_bitmask, LIBXSMM_X86_GP_REG_UNDEF, 0, store_bitmask_offset, aux_gpr, 1);
+      }
+      libxsmm_x86_instruction_vec_compute_3reg( io_generated_code, LIBXSMM_X86_INSTR_VMAXPS, i_micro_kernel_config->vector_name, inout_vreg, zero_vreg, inout_vreg );
+    } else {
+      /* shouldn't happen */
+      LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_UNSUP_DATATYPE );
+      return;
+    }
+  } else {
+    if (store_bitmask == 0) {
+      libxsmm_x86_instruction_vec_compute_3reg(  io_generated_code,
+          (is_32_bit_relu == 1) ? LIBXSMM_X86_INSTR_VMAXPS : LIBXSMM_X86_INSTR_VPMAXSW,
+          i_micro_kernel_config->vector_name,
+          inout_vreg,
+          zero_vreg,
+          inout_vreg);
+    } else {
+      unsigned int current_mask_reg = 7;
+      libxsmm_x86_instruction_vec_compute_3reg_imm8( io_generated_code,
+          (is_32_bit_relu == 1) ? LIBXSMM_X86_INSTR_VCMPPS : LIBXSMM_X86_INSTR_VPCMPW,
+          i_micro_kernel_config->vector_name,
+          zero_vreg,
+          inout_vreg,
+          current_mask_reg, 6 );
+      /* Blend output result with zero reg based on relu mask */
+      libxsmm_x86_instruction_vec_compute_3reg_mask( io_generated_code,
+          (is_32_bit_relu == 1) ? LIBXSMM_X86_INSTR_VPBLENDMD : LIBXSMM_X86_INSTR_VPBLENDMW,
+          i_micro_kernel_config->vector_name,
+          inout_vreg,
+          zero_vreg,
+          inout_vreg,
+          current_mask_reg,
+          0 );
+      /* Store bitmask */
+      libxsmm_x86_instruction_mask_move_mem( io_generated_code,
+          (is_32_bit_relu == 1) ? LIBXSMM_X86_INSTR_KMOVW_ST : LIBXSMM_X86_INSTR_KMOVD_ST,
+          gpr_bitmask,
+          LIBXSMM_X86_GP_REG_UNDEF,
+          0,
+          store_bitmask_offset,
+          current_mask_reg );
+    }
+  }
+}
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_apply_sigmoid_to_vreg_from_scratch( libxsmm_generated_code*             io_generated_code,
+    libxsmm_micro_kernel_config*       i_micro_kernel_config_mod,
+    const unsigned int                 scratch_gpr,
+    const unsigned int                 in_vreg,
+    const unsigned int                 out_vreg ) {
+
+  /* Load accumulator from scratch  */
+  libxsmm_x86_instruction_vec_move( io_generated_code,
+      i_micro_kernel_config_mod->instruction_set,
+      LIBXSMM_X86_INSTR_VMOVUPS,
+      scratch_gpr,
+      LIBXSMM_X86_GP_REG_UNDEF, 0,
+      in_vreg * 64,
+      i_micro_kernel_config_mod->vector_name,
+      out_vreg, 0, 1, 0 );
+
+  /* Apply sigmoid  */
+  if (io_generated_code->arch >= LIBXSMM_X86_AVX512) {
+    libxsmm_generator_sigmoid_ps_rational_78_avx512( io_generated_code, out_vreg, i_micro_kernel_config_mod->vec_x2,
+        i_micro_kernel_config_mod->vec_nom, i_micro_kernel_config_mod->vec_denom,
+        i_micro_kernel_config_mod->mask_hi, i_micro_kernel_config_mod->mask_lo,
+        i_micro_kernel_config_mod->vec_c0, i_micro_kernel_config_mod->vec_c1, i_micro_kernel_config_mod->vec_c2, i_micro_kernel_config_mod->vec_c3,
+        i_micro_kernel_config_mod->vec_c1_d, i_micro_kernel_config_mod->vec_c2_d, i_micro_kernel_config_mod->vec_c3_d,
+        i_micro_kernel_config_mod->vec_hi_bound, i_micro_kernel_config_mod->vec_lo_bound, i_micro_kernel_config_mod->vec_ones,
+        i_micro_kernel_config_mod->vec_neg_ones, i_micro_kernel_config_mod->vec_halves );
+  } else {
+    libxsmm_generator_sigmoid_ps_rational_78_avx( io_generated_code, out_vreg, i_micro_kernel_config_mod->vec_x2,
+        i_micro_kernel_config_mod->vec_nom, i_micro_kernel_config_mod->vec_denom,
+        i_micro_kernel_config_mod->vec_c0, i_micro_kernel_config_mod->vec_c1, i_micro_kernel_config_mod->vec_c2, i_micro_kernel_config_mod->vec_c3,
+        i_micro_kernel_config_mod->vec_c1_d, i_micro_kernel_config_mod->vec_c2_d, i_micro_kernel_config_mod->vec_c3_d,
+        i_micro_kernel_config_mod->vec_hi_bound, i_micro_kernel_config_mod->vec_lo_bound, i_micro_kernel_config_mod->vec_ones,
+        i_micro_kernel_config_mod->vec_neg_ones);
+  }
+}
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_restore_2D_regblock_from_scratch( libxsmm_generated_code*             io_generated_code,
+    const libxsmm_micro_kernel_config* i_micro_kernel_config,
+    const unsigned int                 scratch_gpr,
+    const unsigned int                 l_vec_reg_acc_start,
+    const unsigned int                 l_m_blocking,
+    const unsigned int                 i_n_blocking) {
+  unsigned int l_n, l_m;
+  for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
+    for ( l_m = 0; l_m < l_m_blocking; l_m++ ) {
+      libxsmm_x86_instruction_vec_move( io_generated_code,
+          i_micro_kernel_config->instruction_set,
+          LIBXSMM_X86_INSTR_VMOVUPS,
+          scratch_gpr,
+          LIBXSMM_X86_GP_REG_UNDEF, 0,
+          (l_vec_reg_acc_start + l_m + (l_m_blocking * l_n)) * 64,
+          i_micro_kernel_config->vector_name,
+          l_vec_reg_acc_start + l_m + (l_m_blocking * l_n), 0, 0, 0 );
+    }
+  }
+}
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_store_2D_regblock_to_scratch( libxsmm_generated_code*             io_generated_code,
+    const libxsmm_micro_kernel_config* i_micro_kernel_config,
+    const unsigned int                 scratch_gpr,
+    const unsigned int                 l_vec_reg_acc_start,
+    const unsigned int                 l_m_blocking,
+    const unsigned int                 i_n_blocking) {
+  unsigned int l_n, l_m;
+  for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
+    for ( l_m = 0; l_m < l_m_blocking; l_m++ ) {
+      libxsmm_x86_instruction_vec_move( io_generated_code,
+          i_micro_kernel_config->instruction_set,
+          LIBXSMM_X86_INSTR_VMOVUPS,
+          scratch_gpr,
+          LIBXSMM_X86_GP_REG_UNDEF, 0,
+          (l_vec_reg_acc_start + l_m + (l_m_blocking * l_n)) * 64,
+          i_micro_kernel_config->vector_name,
+          l_vec_reg_acc_start + l_m + (l_m_blocking * l_n), 0, 0, 1 );
+    }
+  }
+}
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_dump_2D_block_and_prepare_sigmoid_fusion( libxsmm_generated_code*             io_generated_code,
+    libxsmm_micro_kernel_config*       i_micro_kernel_config,
+    const unsigned int                 l_vec_reg_acc_start,
+    const unsigned int                 l_m_blocking,
+    const unsigned int                 i_n_blocking,
+    const unsigned int                 scratch_gpr,
+    const unsigned int                 aux_gpr) {
+  unsigned int n_avail_vregs = (io_generated_code->arch >= LIBXSMM_X86_AVX512) ? 32 : 16;
+  unsigned int n_avail_masks = (io_generated_code->arch >= LIBXSMM_X86_AVX512) ? 8 : 16;
+  /* First dump the accumulators to scratch and then setup sigmoid coeffcients to be reused */
+  libxsmm_x86_instruction_push_reg( io_generated_code, scratch_gpr);
+  libxsmm_x86_instruction_push_reg( io_generated_code, aux_gpr );
+  libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_GEMM_SCRATCH_PTR, scratch_gpr);
+  libxsmm_generator_gemm_store_2D_regblock_to_scratch( io_generated_code, i_micro_kernel_config,
+      scratch_gpr, l_vec_reg_acc_start, l_m_blocking, i_n_blocking);
+  libxsmm_generator_gemm_prepare_coeffs_sigmoid_ps_rational_78_avx_avx512( io_generated_code, i_micro_kernel_config, n_avail_vregs, n_avail_masks, aux_gpr );
+}
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_prepare_relu_fusion( libxsmm_generated_code*             io_generated_code,
+    const libxsmm_micro_kernel_config* i_micro_kernel_config,
+    const unsigned int                 zero_vreg,
+    const unsigned int                 store_bitmask,
+    const unsigned int                 bitmask_gpr,
+    const unsigned int                 aux_gpr) {
+  /* Zero out register 0 to perform relu */
+  libxsmm_x86_instruction_vec_compute_3reg( io_generated_code,
+      i_micro_kernel_config->vxor_instruction,
+      i_micro_kernel_config->vector_name,
+      zero_vreg, zero_vreg, zero_vreg);
+  if (store_bitmask == 1) {
+    libxsmm_x86_instruction_push_reg( io_generated_code, bitmask_gpr );
+    if (io_generated_code->arch < LIBXSMM_X86_AVX512) {
+      libxsmm_x86_instruction_push_reg( io_generated_code, aux_gpr );
+    }
+    libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_OUTPUT_PTR, bitmask_gpr );
+  }
+}
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_cleanup_relu_fusion( libxsmm_generated_code*             io_generated_code,
+    const unsigned int                 store_bitmask,
+    const unsigned int                 bitmask_gpr,
+    const unsigned int                 aux_gpr) {
+  if (store_bitmask == 1) {
+    if (io_generated_code->arch < LIBXSMM_X86_AVX512) {
+      libxsmm_x86_instruction_pop_reg( io_generated_code, aux_gpr );
+    }
+    libxsmm_x86_instruction_pop_reg( io_generated_code, bitmask_gpr);
+  }
+}
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_cleanup_sigmoid_fusion( libxsmm_generated_code*             io_generated_code,
+    const unsigned int                 scratch_gpr,
+    const unsigned int                 aux_gpr ) {
+  libxsmm_x86_instruction_pop_reg( io_generated_code, aux_gpr );
+  libxsmm_x86_instruction_pop_reg( io_generated_code, scratch_gpr );
+}
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_load_colbias_to_2D_block( libxsmm_generated_code*             io_generated_code,
+    const libxsmm_gp_reg_mapping*      i_gp_reg_mapping,
+    const libxsmm_micro_kernel_config* i_micro_kernel_config,
+    libxsmm_datatype                   colbias_precision,
+    const unsigned int                 l_vec_reg_acc_start,
+    const unsigned int                 l_m_blocking,
+    const unsigned int                 i_n_blocking ) {
+  unsigned int l_n = 0, l_m = 0;
+
+  libxsmm_x86_instruction_push_reg( io_generated_code, i_gp_reg_mapping->gp_reg_help_2 );
+  libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_BIAS_PTR, i_gp_reg_mapping->gp_reg_help_2 );
+  for ( l_m = 0; l_m < l_m_blocking; l_m++ ) {
+    for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
+      if (colbias_precision == LIBXSMM_DATATYPE_BF16) {
+        if (l_n == 0) {
+          /* Load bias vector */
+          /* load 16 bit values into xmm portion of the register */
+          if ( (i_micro_kernel_config->use_masking_a_c != 0) && ( l_m == (l_m_blocking - 1) ) ) {
+            libxsmm_x86_instruction_vec_move( io_generated_code,
+                i_micro_kernel_config->instruction_set,
+                LIBXSMM_X86_INSTR_VMOVDQU16,
+                i_gp_reg_mapping->gp_reg_help_2,
+                LIBXSMM_X86_GP_REG_UNDEF, 0,
+                (l_m * (i_micro_kernel_config->vector_length)) * 2,
+                ( ( i_micro_kernel_config->instruction_set > LIBXSMM_X86_AVX2) && ( i_micro_kernel_config->instruction_set < LIBXSMM_X86_AVX512 ) ) ? 'y' : 'z',
+                l_vec_reg_acc_start + l_m, 2, 1, 0 );
+          } else {
+            libxsmm_x86_instruction_vec_move( io_generated_code,
+                i_micro_kernel_config->instruction_set,
+                i_micro_kernel_config->c_vmove_instruction,
+                i_gp_reg_mapping->gp_reg_help_2,
+                LIBXSMM_X86_GP_REG_UNDEF, 0,
+                (l_m * (i_micro_kernel_config->vector_length)) * 2,
+                ( ( i_micro_kernel_config->instruction_set > LIBXSMM_X86_AVX2) && ( i_micro_kernel_config->instruction_set < LIBXSMM_X86_AVX512 ) ) ? 'x' : 'y',
+                l_vec_reg_acc_start + l_m, 0, 1, 0 );
+          }
+          /* convert 16 bit values into 32 bit (integer convert) */
+          libxsmm_x86_instruction_vec_compute_2reg( io_generated_code,
+              LIBXSMM_X86_INSTR_VPMOVSXWD,
+              i_micro_kernel_config->vector_name,
+              l_vec_reg_acc_start + l_m, l_vec_reg_acc_start + l_m );
+
+          /* shift 16 bits to the left to generate valid FP32 numbers */
+          libxsmm_x86_instruction_vec_compute_2reg_imm8(io_generated_code,
+              LIBXSMM_X86_INSTR_VPSLLD_I,
+              i_micro_kernel_config->vector_name,
+              l_vec_reg_acc_start + l_m,
+              l_vec_reg_acc_start + l_m,
+              16);
+        } else {
+          libxsmm_x86_instruction_vec_compute_2reg( io_generated_code, LIBXSMM_X86_INSTR_VMOVUPS,
+              ( ( i_micro_kernel_config->instruction_set > LIBXSMM_X86_AVX2) && ( i_micro_kernel_config->instruction_set < LIBXSMM_X86_AVX512 ) ) ? 'y' : 'z',
+              l_vec_reg_acc_start + l_m, l_vec_reg_acc_start + l_m + (l_m_blocking * l_n) );
+        }
+      } else if (colbias_precision == LIBXSMM_DATATYPE_F32) {
+        if (l_n == 0) {
+          /* Load bias vector */
+          libxsmm_x86_instruction_vec_move( io_generated_code,
+              i_micro_kernel_config->instruction_set,
+              i_micro_kernel_config->c_vmove_instruction,
+              i_gp_reg_mapping->gp_reg_help_2,
+              LIBXSMM_X86_GP_REG_UNDEF, 0,
+              ((l_m * (i_micro_kernel_config->vector_length))) * 4,
+              i_micro_kernel_config->vector_name,
+              l_vec_reg_acc_start + l_m, ( l_m == (l_m_blocking - 1) ) ? i_micro_kernel_config->use_masking_a_c : 0, 1, 0 );
+        } else {
+          libxsmm_x86_instruction_vec_compute_2reg( io_generated_code, LIBXSMM_X86_INSTR_VMOVUPS, i_micro_kernel_config->vector_name, l_vec_reg_acc_start + l_m, l_vec_reg_acc_start + l_m + (l_m_blocking * l_n) );
+        }
+      } else {
+        /* shouldn't happen */
+        LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_UNSUP_DATATYPE );
+        return;
+      }
+    }
+  }
+  libxsmm_x86_instruction_pop_reg( io_generated_code, i_gp_reg_mapping->gp_reg_help_2 );
+}
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_add_colbias_to_2D_block( libxsmm_generated_code*             io_generated_code,
+    const libxsmm_gp_reg_mapping*      i_gp_reg_mapping,
+    const libxsmm_micro_kernel_config* i_micro_kernel_config,
+    libxsmm_datatype                   colbias_precision,
+    const unsigned int                 l_vec_reg_acc_start,
+    const unsigned int                 l_m_blocking,
+    const unsigned int                 i_n_blocking ) {
+  unsigned int l_n = 0, l_m = 0;
+
+  libxsmm_x86_instruction_push_reg( io_generated_code, i_gp_reg_mapping->gp_reg_help_2 );
+  libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_BIAS_PTR, i_gp_reg_mapping->gp_reg_help_2 );
+  for ( l_m = 0; l_m < l_m_blocking; l_m++ ) {
+    /* Load bias vector */
+    if (colbias_precision == LIBXSMM_DATATYPE_BF16) {
+      /* load 16 bit values into xmm portion of the register */
+      if ( (i_micro_kernel_config->use_masking_a_c != 0) && ( l_m == (l_m_blocking - 1) ) ) {
+        libxsmm_x86_instruction_vec_move( io_generated_code,
+            i_micro_kernel_config->instruction_set,
+            LIBXSMM_X86_INSTR_VMOVDQU16,
+            i_gp_reg_mapping->gp_reg_help_2,
+            LIBXSMM_X86_GP_REG_UNDEF, 0,
+            (l_m * (i_micro_kernel_config->vector_length)) * 2,
+            ( ( i_micro_kernel_config->instruction_set > LIBXSMM_X86_AVX2) && ( i_micro_kernel_config->instruction_set < LIBXSMM_X86_AVX512 ) ) ? 'y' : 'z',
+            0, 2, 1, 0 );
+      } else {
+        libxsmm_x86_instruction_vec_move( io_generated_code,
+            i_micro_kernel_config->instruction_set,
+            i_micro_kernel_config->c_vmove_instruction,
+            i_gp_reg_mapping->gp_reg_help_2,
+            LIBXSMM_X86_GP_REG_UNDEF, 0,
+            (l_m * (i_micro_kernel_config->vector_length)) * 2,
+            ( ( i_micro_kernel_config->instruction_set > LIBXSMM_X86_AVX2) && ( i_micro_kernel_config->instruction_set < LIBXSMM_X86_AVX512 ) ) ? 'x' : 'y',
+            0, 0, 1, 0 );
+      }
+      /* convert 16 bit values into 32 bit (integer convert) */
+      libxsmm_x86_instruction_vec_compute_2reg( io_generated_code,
+          LIBXSMM_X86_INSTR_VPMOVSXWD,
+          i_micro_kernel_config->vector_name,
+          0, 0 );
+
+      /* shift 16 bits to the left to generate valid FP32 numbers */
+      libxsmm_x86_instruction_vec_compute_2reg_imm8(io_generated_code,
+          LIBXSMM_X86_INSTR_VPSLLD_I,
+          i_micro_kernel_config->vector_name,
+          0,
+          0,
+          16);
+    } else if (colbias_precision == LIBXSMM_DATATYPE_F32) {
+      libxsmm_x86_instruction_vec_move( io_generated_code,
+          i_micro_kernel_config->instruction_set,
+          i_micro_kernel_config->c_vmove_instruction,
+          i_gp_reg_mapping->gp_reg_help_2,
+          LIBXSMM_X86_GP_REG_UNDEF, 0,
+          ((l_m * (i_micro_kernel_config->vector_length))) * 4,
+          i_micro_kernel_config->vector_name,
+          0, ( l_m == (l_m_blocking - 1) ) ? i_micro_kernel_config->use_masking_a_c : 0, 1, 0 );
+    } else {
+      /* shouldn't happen */
+      LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_UNSUP_DATATYPE );
+      return;
+    }
+
+    /* Add colbias */
+    for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
+      libxsmm_x86_instruction_vec_compute_3reg( io_generated_code, LIBXSMM_X86_INSTR_VADDPS, i_micro_kernel_config->vector_name,
+          l_vec_reg_acc_start + l_m + (l_m_blocking * l_n), 0, l_vec_reg_acc_start + l_m + (l_m_blocking * l_n) );
+    }
+  }
+  libxsmm_x86_instruction_pop_reg( io_generated_code, i_gp_reg_mapping->gp_reg_help_2 );
+}
+
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_prepare_coeffs_sigmoid_ps_rational_78_avx_avx512( libxsmm_generated_code*                        io_generated_code,
+    libxsmm_micro_kernel_config*        i_micro_kernel_config,
+    unsigned int                        reserved_zmms,
+    unsigned int                        reserved_mask_regs,
+    unsigned int                        temp_reg ) {
+
+    float pade78_sigm_array[16] = { 2027025.0f, 270270.0f, 6930.0f, 36.0f, 945945.0f, 51975.0f,  630.0f, 4.97f, -4.97f,  1.0f, -1.0f, 0.5f, 0.0f, 0.0f, 0.0f, 0.0f };
+    i_micro_kernel_config->vec_x2        = reserved_zmms - 1;
+    i_micro_kernel_config->vec_nom       = reserved_zmms - 2;
+    i_micro_kernel_config->vec_denom     = reserved_zmms - 3;
+    i_micro_kernel_config->vec_c0        = reserved_zmms - 4;
+    i_micro_kernel_config->vec_c1        = reserved_zmms - 5;
+    i_micro_kernel_config->vec_c2        = reserved_zmms - 6;
+    i_micro_kernel_config->vec_c3        = reserved_zmms - 7;
+    i_micro_kernel_config->vec_c1_d      = reserved_zmms - 8;
+    i_micro_kernel_config->vec_c2_d      = reserved_zmms - 9;
+    i_micro_kernel_config->vec_c3_d      = reserved_zmms - 10;
+    i_micro_kernel_config->vec_hi_bound  = reserved_zmms - 11;
+    i_micro_kernel_config->vec_lo_bound  = reserved_zmms - 12;
+    i_micro_kernel_config->vec_ones      = reserved_zmms - 13;
+    i_micro_kernel_config->vec_neg_ones  = reserved_zmms - 14;
+    i_micro_kernel_config->vec_halves    = reserved_zmms - 15;
+
+    libxsmm_x86_instruction_full_vec_load_of_constants ( io_generated_code, (const unsigned char *) pade78_sigm_array, "pade78_sigm_array_", i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_c0);
+    libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_GEMM_SCRATCH_PTR, temp_reg );
+    libxsmm_x86_instruction_vec_move( io_generated_code,
+        i_micro_kernel_config->instruction_set,
+        LIBXSMM_X86_INSTR_VMOVUPS,
+        temp_reg,
+        LIBXSMM_X86_GP_REG_UNDEF, 0, 0,
+        i_micro_kernel_config->vector_name,
+        i_micro_kernel_config->vec_c0, 0, 1, 1 );
+    if (io_generated_code->arch < LIBXSMM_X86_AVX512) {
+      libxsmm_x86_instruction_full_vec_load_of_constants ( io_generated_code, (const unsigned char *) &pade78_sigm_array[8], "pade78_sigm_array2_", i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_c0);
+      libxsmm_x86_instruction_vec_move( io_generated_code,
+          i_micro_kernel_config->instruction_set,
+          LIBXSMM_X86_INSTR_VMOVUPS,
+          temp_reg,
+          LIBXSMM_X86_GP_REG_UNDEF, 0, 32,
+          i_micro_kernel_config->vector_name,
+          i_micro_kernel_config->vec_c0, 0, 1, 1 );
+    }
+
+    libxsmm_x86_instruction_vec_move( io_generated_code, i_micro_kernel_config->instruction_set, LIBXSMM_X86_INSTR_VBROADCASTSS, temp_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,
+        0, i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_c0, 0, 1, 0 );
+    libxsmm_x86_instruction_vec_move( io_generated_code, i_micro_kernel_config->instruction_set, LIBXSMM_X86_INSTR_VBROADCASTSS, temp_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,
+        4, i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_c1, 0, 1, 0 );
+    libxsmm_x86_instruction_vec_move( io_generated_code, i_micro_kernel_config->instruction_set, LIBXSMM_X86_INSTR_VBROADCASTSS, temp_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,
+        8, i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_c2, 0, 1, 0 );
+    libxsmm_x86_instruction_vec_move( io_generated_code, i_micro_kernel_config->instruction_set, LIBXSMM_X86_INSTR_VBROADCASTSS, temp_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,
+        12, i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_c3, 0, 1, 0 );
+    libxsmm_x86_instruction_vec_move( io_generated_code, i_micro_kernel_config->instruction_set, LIBXSMM_X86_INSTR_VBROADCASTSS, temp_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,
+        16, i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_c1_d, 0, 1, 0 );
+    libxsmm_x86_instruction_vec_move( io_generated_code, i_micro_kernel_config->instruction_set, LIBXSMM_X86_INSTR_VBROADCASTSS, temp_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,
+        20, i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_c2_d, 0, 1, 0 );
+    libxsmm_x86_instruction_vec_move( io_generated_code, i_micro_kernel_config->instruction_set, LIBXSMM_X86_INSTR_VBROADCASTSS, temp_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,
+        24, i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_c3_d, 0, 1, 0 );
+    libxsmm_x86_instruction_vec_move( io_generated_code, i_micro_kernel_config->instruction_set, LIBXSMM_X86_INSTR_VBROADCASTSS, temp_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,
+        28, i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_hi_bound, 0, 1, 0 );
+    libxsmm_x86_instruction_vec_move( io_generated_code, i_micro_kernel_config->instruction_set, LIBXSMM_X86_INSTR_VBROADCASTSS, temp_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,
+        32, i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_lo_bound, 0, 1, 0 );
+    libxsmm_x86_instruction_vec_move( io_generated_code, i_micro_kernel_config->instruction_set, LIBXSMM_X86_INSTR_VBROADCASTSS, temp_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,
+        36, i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_ones, 0, 1, 0 );
+    libxsmm_x86_instruction_vec_move( io_generated_code, i_micro_kernel_config->instruction_set, LIBXSMM_X86_INSTR_VBROADCASTSS, temp_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,
+        40, i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_neg_ones, 0, 1, 0 );
+    if (io_generated_code->arch >= LIBXSMM_X86_AVX512) {
+      libxsmm_x86_instruction_vec_move( io_generated_code, i_micro_kernel_config->instruction_set, LIBXSMM_X86_INSTR_VBROADCASTSS, temp_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,
+          44, i_micro_kernel_config->vector_name, i_micro_kernel_config->vec_halves, 0, 1, 0 );
+    }
+
+    i_micro_kernel_config->mask_hi  = reserved_mask_regs - 1;
+    i_micro_kernel_config->mask_lo  = reserved_mask_regs - 2;
+}
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_setup_stack_frame_fill_stack_vars_v2( libxsmm_generated_code*            io_generated_code,
+    const libxsmm_gemm_descriptor*      i_xgemm_desc,
+    libxsmm_micro_kernel_config*        i_micro_kernel_config,
+    const libxsmm_gp_reg_mapping*       i_gp_reg_mapping ) {
+
+  int is_stride_brgemm  = ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE) > 0) ? 1 : 0;
+  int is_offset_brgemm  = ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET) > 0) ? 1 : 0;
+  int is_address_brgemm = ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS) > 0) ? 1 : 0;
+  int is_brgemm         = ((is_stride_brgemm == 1) || (is_offset_brgemm == 1) || (is_address_brgemm == 1)) ? 1 : 0;
+  int has_scf           = ((LIBXSMM_DATATYPE_I8 == LIBXSMM_GETENUM_INP( i_xgemm_desc->datatype )) && (LIBXSMM_DATATYPE_I8 == LIBXSMM_GETENUM_OUT( i_xgemm_desc->datatype ))) ? 1 : 0;
+  int has_A_pf_ptr      = (i_xgemm_desc->prefetch == LIBXSMM_GEMM_PREFETCH_AL2_AHEAD || i_xgemm_desc->prefetch == LIBXSMM_GEMM_PREFETCH_AL2BL2_VIA_C_AHEAD) ? 1 : 0;
+  int has_B_pf_ptr      = (i_xgemm_desc->prefetch == LIBXSMM_GEMM_PREFETCH_BL2_VIA_C || i_xgemm_desc->prefetch == LIBXSMM_GEMM_PREFETCH_AL2BL2_VIA_C_AHEAD ||
+      i_xgemm_desc->prefetch == LIBXSMM_GEMM_PREFETCH_AL2BL2_VIA_C || i_xgemm_desc->prefetch == LIBXSMM_PREFETCH_AL2CL2BL2_VIA_C ) ? 1 : 0;
+  unsigned int temp_reg               = LIBXSMM_X86_GP_REG_R10;
+
+  if (has_scf == 1) {
+    libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction,
+        i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 112, temp_reg, 0 );
+    libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_INT8_SCF, temp_reg );
+  }
+
+  if (has_A_pf_ptr == 1) {
+    libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction,
+        i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 56, temp_reg, 0 );
+    libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, temp_reg );
+  }
+
+  if (has_B_pf_ptr == 1) {
+    libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction,
+        i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 88, temp_reg, 0 );
+    libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
+  }
+
+  if ((is_brgemm == 1) && ( i_micro_kernel_config->decompress_A == 1)) {
+    libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_BRCOUNT, i_gp_reg_mapping->gp_reg_reduce_count );
+  }
+
+  if (is_offset_brgemm == 1) {
+    libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction,
+        i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 40, temp_reg, 0 );
+    libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_A_OFFS_BRGEMM_PTR, temp_reg );
+
+    libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction,
+        i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 72, temp_reg, 0 );
+    libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_B_OFFS_BRGEMM_PTR, temp_reg );
+  }
+
+  if (i_micro_kernel_config->fused_eltwise == 1) {
+    if (i_micro_kernel_config->has_colbias_act_fused == 1) {
+      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction,
+        i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 128, temp_reg, 0 );
+      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_BIAS_PTR, temp_reg );
+      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction,
+        i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 104, temp_reg, 0 );
+      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_OUTPUT_PTR, temp_reg );
+    }
+    if (i_micro_kernel_config->decompress_A == 1) {
+      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction,
+        i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 48, temp_reg, 0 );
+      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_BITMAP_PTR, temp_reg );
+      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction,
+        i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 160, temp_reg, 0 );
+      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_DECOMPRESS_BUF, temp_reg );
+    }
+    if (i_micro_kernel_config->vnni_cvt_output_ext_buf == 1) {
+      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction,
+        i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 104, temp_reg, 0 );
+      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_OUTPUT_PTR, temp_reg );
+    }
+    if (i_micro_kernel_config->fused_relu_bwd == 1) {
+      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction,
+        i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 104, temp_reg, 0 );
+      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_RELU_BITMASK_PTR, temp_reg );
+    }
+    if (i_micro_kernel_config->norm_to_normT_B_ext_buf == 1) {
+      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction,
+        i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 192, temp_reg, 0 );
+      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_TRANS_EXT_BUF_B, temp_reg );
+    }
+  }
+}
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_setup_stack_frame_fill_stack_vars(libxsmm_generated_code*            io_generated_code,
+    const libxsmm_gemm_descriptor*      i_xgemm_desc,
+    libxsmm_micro_kernel_config*        i_micro_kernel_config) {
+
+  int is_stride_brgemm  = ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_STRIDE) > 0) ? 1 : 0;
+  int is_offset_brgemm  = ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_OFFSET) > 0) ? 1 : 0;
+  int is_address_brgemm = ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_BATCH_REDUCE_ADDRESS) > 0) ? 1 : 0;
+  int is_brgemm         = ((is_stride_brgemm == 1) || (is_offset_brgemm == 1) || (is_address_brgemm == 1)) ? 1 : 0;
+  int has_scf           = ((LIBXSMM_DATATYPE_I8 == LIBXSMM_GETENUM_INP( i_xgemm_desc->datatype )) && (LIBXSMM_DATATYPE_I8 == LIBXSMM_GETENUM_OUT( i_xgemm_desc->datatype ))) ? 1 : 0;
+  int has_A_pf_ptr      = (i_xgemm_desc->prefetch == LIBXSMM_GEMM_PREFETCH_AL2_AHEAD || i_xgemm_desc->prefetch == LIBXSMM_GEMM_PREFETCH_AL2BL2_VIA_C_AHEAD) ? 1 : 0;
+  int has_B_pf_ptr      = (i_xgemm_desc->prefetch == LIBXSMM_GEMM_PREFETCH_BL2_VIA_C || i_xgemm_desc->prefetch == LIBXSMM_GEMM_PREFETCH_AL2BL2_VIA_C_AHEAD ||
+      i_xgemm_desc->prefetch == LIBXSMM_GEMM_PREFETCH_AL2BL2_VIA_C || i_xgemm_desc->prefetch == LIBXSMM_PREFETCH_AL2CL2BL2_VIA_C ) ? 1 : 0;
+  unsigned int eltwise_struct_ptr_reg = LIBXSMM_X86_GP_REG_R11;
+  unsigned int temp_reg               = LIBXSMM_X86_GP_REG_R10;
+
+  if (is_brgemm == 0) {
+    /* GEMM (A, B, C, [scf, eltwise_struct, Apf, Bpf] */
+    if (has_scf == 1) {
+      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_INT8_SCF, LIBXSMM_X86_GP_REG_RCX );
+      if (i_micro_kernel_config->fused_eltwise == 1) {
+        eltwise_struct_ptr_reg = LIBXSMM_X86_GP_REG_R8;
+        if (has_A_pf_ptr == 1) {
+          libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, LIBXSMM_X86_GP_REG_R9 );
+          if (has_B_pf_ptr == 1) {
+            libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, temp_reg );
+            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
+          }
+        } else {
+          if (has_B_pf_ptr == 1) {
+            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R9 );
+          }
+        }
+      } else {
+        if (has_A_pf_ptr == 1) {
+          libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, LIBXSMM_X86_GP_REG_R8 );
+          if (has_B_pf_ptr == 1) {
+            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R9 );
+          }
+        } else {
+          if (has_B_pf_ptr == 1) {
+            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R8 );
+          }
+        }
+      }
+    } else {
+      if (i_micro_kernel_config->fused_eltwise == 1) {
+        eltwise_struct_ptr_reg = LIBXSMM_X86_GP_REG_RCX;
+        if (has_A_pf_ptr == 1) {
+          libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, LIBXSMM_X86_GP_REG_R8 );
+          if (has_B_pf_ptr == 1) {
+            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R9 );
+          }
+        } else {
+          if (has_B_pf_ptr == 1) {
+            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R8 );
+          }
+        }
+      } else {
+        if (has_A_pf_ptr == 1) {
+          libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, LIBXSMM_X86_GP_REG_RCX );
+          if (has_B_pf_ptr == 1) {
+            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R8 );
+          }
+        } else {
+          if (has_B_pf_ptr == 1) {
+            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_RCX );
+          }
+        }
+      }
+    }
+  } else {
+    if (i_micro_kernel_config->decompress_A == 1) {
+      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction, LIBXSMM_X86_GP_REG_RCX, LIBXSMM_X86_GP_REG_UNDEF, 0, 0, temp_reg, 0 );
+      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_BRCOUNT, temp_reg );
+    }
+
+    if ((is_stride_brgemm == 1) || (is_address_brgemm == 1)) {
+      /* BRGEMM_ADDR/STRIDE (A, B, C, cnt, [scf, eltwise_struct, Apf, Bpf] */
+      if (has_scf == 1) {
+        libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_INT8_SCF, LIBXSMM_X86_GP_REG_R8 );
+        if (i_micro_kernel_config->fused_eltwise == 1) {
+          eltwise_struct_ptr_reg = LIBXSMM_X86_GP_REG_R9;
+          if (has_A_pf_ptr == 1) {
+            libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, temp_reg );
+            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, temp_reg );
+            if (has_B_pf_ptr == 1) {
+              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_8, temp_reg );
+              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
+            }
+          } else {
+            if (has_B_pf_ptr == 1) {
+              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, temp_reg );
+              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
+            }
+          }
+        } else {
+          if (has_A_pf_ptr == 1) {
+            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, LIBXSMM_X86_GP_REG_R9 );
+            if (has_B_pf_ptr == 1) {
+              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, temp_reg );
+              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
+            }
+          } else {
+            if (has_B_pf_ptr == 1) {
+              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R9 );
+            }
+          }
+        }
+      } else {
+        if (i_micro_kernel_config->fused_eltwise == 1) {
+          eltwise_struct_ptr_reg = LIBXSMM_X86_GP_REG_R8;
+          if (has_A_pf_ptr == 1) {
+            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, LIBXSMM_X86_GP_REG_R9 );
+            if (has_B_pf_ptr == 1) {
+              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, temp_reg );
+              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
+            }
+          } else {
+            if (has_B_pf_ptr == 1) {
+              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R9 );
+            }
+          }
+        } else {
+          if (has_A_pf_ptr == 1) {
+            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, LIBXSMM_X86_GP_REG_R8 );
+            if (has_B_pf_ptr == 1) {
+              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R9 );
+            }
+          } else {
+            if (has_B_pf_ptr == 1) {
+              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, LIBXSMM_X86_GP_REG_R8 );
+            }
+          }
+        }
+      }
+    } else {
+      /* BRGEMM_OFFS (A, B, C, cnt, A_off, B_off, [scf, eltwise struct, Apf, Bpf] */
+      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_A_OFFS_BRGEMM_PTR, LIBXSMM_X86_GP_REG_R8 );
+      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_B_OFFS_BRGEMM_PTR, LIBXSMM_X86_GP_REG_R9 );
+      if (has_scf == 1) {
+        libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, temp_reg );
+        libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_INT8_SCF, temp_reg );
+        if (i_micro_kernel_config->fused_eltwise == 1) {
+          libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_8, eltwise_struct_ptr_reg );
+          if (has_A_pf_ptr == 1) {
+            libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_9, temp_reg );
+            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, temp_reg );
+            if (has_B_pf_ptr == 1) {
+              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_10, temp_reg );
+              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
+            }
+          } else {
+            if (has_B_pf_ptr == 1) {
+              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_9, temp_reg );
+              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
+            }
+          }
+        } else {
+          if (has_A_pf_ptr == 1) {
+            libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_8, temp_reg );
+            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, temp_reg );
+            if (has_B_pf_ptr == 1) {
+              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_9, temp_reg );
+              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
+            }
+          } else {
+            if (has_B_pf_ptr == 1) {
+              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_8, temp_reg );
+              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
+            }
+          }
+        }
+      } else {
+        if (i_micro_kernel_config->fused_eltwise == 1) {
+          libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, eltwise_struct_ptr_reg );
+          if (has_A_pf_ptr == 1) {
+            libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_8, temp_reg );
+            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, temp_reg );
+            if (has_B_pf_ptr == 1) {
+              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_9, temp_reg );
+              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
+            }
+          } else {
+            if (has_B_pf_ptr == 1) {
+              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_8, temp_reg );
+              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
+            }
+          }
+        } else {
+          if (has_A_pf_ptr == 1) {
+            libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, temp_reg );
+            libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFA_PTR, temp_reg );
+            if (has_B_pf_ptr == 1) {
+              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_8, temp_reg );
+              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
+            }
+          } else {
+            if (has_B_pf_ptr == 1) {
+              libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ARG_7, temp_reg );
+              libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_PFB_PTR, temp_reg );
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (i_micro_kernel_config->fused_eltwise == 1) {
+    if (i_micro_kernel_config->has_colbias_act_fused == 1) {
+      /* TODO: Optimize this copy to operate only in used fileds form struct... */
+      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction, eltwise_struct_ptr_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,   0, temp_reg, 0 );
+      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_BIAS_PTR, temp_reg );
+      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction, eltwise_struct_ptr_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,   8, temp_reg, 0 );
+      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_OUTPUT_PTR, temp_reg );
+    }
+    if (i_micro_kernel_config->decompress_A == 1) {
+      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction, eltwise_struct_ptr_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,   16, temp_reg, 0 );
+      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_BITMAP_PTR, temp_reg );
+      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction, eltwise_struct_ptr_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,   24, temp_reg, 0 );
+      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_DECOMPRESS_BUF, temp_reg );
+    }
+    if (i_micro_kernel_config->vnni_cvt_output_ext_buf == 1) {
+      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction, eltwise_struct_ptr_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,   8, temp_reg, 0 );
+      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_OUTPUT_PTR, temp_reg );
+    }
+    if (i_micro_kernel_config->fused_relu_bwd == 1) {
+      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction, eltwise_struct_ptr_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,   32, temp_reg, 0 );
+      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_RELU_BITMASK_PTR, temp_reg );
+    }
+    if (i_micro_kernel_config->norm_to_normT_B_ext_buf == 1) {
+      libxsmm_x86_instruction_alu_mem( io_generated_code, i_micro_kernel_config->alu_mov_instruction, eltwise_struct_ptr_reg, LIBXSMM_X86_GP_REG_UNDEF, 0,   16, temp_reg, 0 );
+      libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_TRANS_EXT_BUF_B, temp_reg );
+    }
+  }
+}
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_setup_stack_frame_allocate_scratch( libxsmm_generated_code*            io_generated_code,
+    const libxsmm_gemm_descriptor*      i_xgemm_desc,
+    libxsmm_micro_kernel_config*        i_micro_kernel_config ) {
+  unsigned int gemm_scratch_size      = 0;
+  unsigned int scratch_pad_size       = 0;
+  int l_emu_amx = 0;
+  const char *const l_env_emu_amx = getenv("EMULATE_AMX");
+  if ( 0 == l_env_emu_amx ) {
+  } else {
+    l_emu_amx = atoi(l_env_emu_amx);
+  }
+
+  if (l_emu_amx > 0) {
+    int expand_scratch_factor = (i_micro_kernel_config->n_tiles == 1) ? 2 : 1;
+    i_micro_kernel_config->emulation_scratch_offset = expand_scratch_factor * i_xgemm_desc->n * i_xgemm_desc->ldc * 4 /*i_micro_kernel_config->datatype_size*/;
+    gemm_scratch_size = expand_scratch_factor * i_xgemm_desc->n * i_xgemm_desc->ldc * 4 /*i_micro_kernel_config->datatype_size*/ + 8 * 32 * 32 + 32 * 64 ;
+    scratch_pad_size  = (gemm_scratch_size % 64 == 0) ? 0 : ((gemm_scratch_size + 63)/64) * 64 - gemm_scratch_size;
+    gemm_scratch_size += scratch_pad_size;
+    if (LIBXSMM_DATATYPE_F32 == LIBXSMM_GETENUM_OUT( i_xgemm_desc->datatype )) {
+        i_micro_kernel_config->emulation_scratch_offset = 0;
+        gemm_scratch_size = 8 * 32 * 32 + 32 * 64 ;
+        scratch_pad_size  = (gemm_scratch_size % 64 == 0) ? 0 : ((gemm_scratch_size + 63)/64) * 64 - gemm_scratch_size;
+        gemm_scratch_size += scratch_pad_size;
+    }
+  } else {
+    if ((io_generated_code->arch >= LIBXSMM_X86_AVX512_SPR)) {
+      int expand_scratch_factor = (i_micro_kernel_config->n_tiles == 1) ? 2 : 1;
+      gemm_scratch_size = LIBXSMM_MAX(32*64, expand_scratch_factor * i_xgemm_desc->n * i_xgemm_desc->ldc * 4/*i_micro_kernel_config->datatype_size*/);
+      scratch_pad_size  = (gemm_scratch_size % 64 == 0) ? 0 : ((gemm_scratch_size + 63)/64) * 64 - gemm_scratch_size;
+      gemm_scratch_size += scratch_pad_size;
+    } else {
+      /* Allocate scratch for stashing 32 zmms  */
+      if ( ((LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI) ) {
+        gemm_scratch_size = 32 * 64;
+        scratch_pad_size  = (gemm_scratch_size % 64 == 0) ? 0 : ((gemm_scratch_size + 63)/64) * 64 - gemm_scratch_size;
+        gemm_scratch_size += scratch_pad_size;
+      }
+    }
+  }
+
+  if (gemm_scratch_size > 0) {
+    libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_sub_instruction, LIBXSMM_X86_GP_REG_RSP, gemm_scratch_size );
+    libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_GEMM_SCRATCH_PTR, LIBXSMM_X86_GP_REG_RSP );
+  }
+}
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_setup_stack_frame( libxsmm_generated_code*            io_generated_code,
+    const libxsmm_gemm_descriptor*      i_xgemm_desc,
+    const libxsmm_gp_reg_mapping*       i_gp_reg_mapping,
+    libxsmm_micro_kernel_config*        i_micro_kernel_config ) {
+  unsigned int temp_reg               = LIBXSMM_X86_GP_REG_R10;
+
+  libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_RBP );
+  libxsmm_x86_instruction_alu_reg( io_generated_code, i_micro_kernel_config->alu_mov_instruction, LIBXSMM_X86_GP_REG_RSP, LIBXSMM_X86_GP_REG_RBP);
+  libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_sub_instruction, LIBXSMM_X86_GP_REG_RSP, 88 );
+
+  if ( ((LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_ABI) ||
+       ((LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI) ) {
+    libxsmm_generator_gemm_setup_stack_frame_fill_stack_vars_v2( io_generated_code, i_xgemm_desc, i_micro_kernel_config, i_gp_reg_mapping );
+  } else {
+    libxsmm_generator_gemm_setup_stack_frame_fill_stack_vars(io_generated_code, i_xgemm_desc, i_micro_kernel_config);
+  }
+
+  /* The stack now looks like this:
+   *      10th param (if applicable)                <-- RBP+80
+   *      9th param (if applicable)                 <-- RBP+72
+   *      8th param (if applicable)                 <-- RBP+64
+   *      7th param (if applicable)                 <-- RBP+56
+   *      Return address                            <-- RBP+48
+   *      Calle SAVED-regs                          <-- RBP[+8,+16,+24,+32,+40]
+   *      Entry/saved RBP                           <-- RBP
+   *      prefetch A ptr                            <-- RBP-8
+   *      prefetch B ptr                            <-- RBP-16
+   *      Offset A array ptr                        <-- RBP-24
+   *      Offset B array ptr                        <-- RBP-32
+   *      Int8 scaling factor                       <-- RBP-40
+   *      GEMM_scratch ptr in stack (to be filled)  <-- RBP-48
+   *      Eltwise bias ptr                          <-- RBP-56
+   *      Eltwise output_ptr                        <-- RBP-64
+   *      Eltwise buf1_ptr                          <-- RBP-72
+   *      Eltwise buf2_ptr                          <-- RBP-80
+   *      Batch-reduce count                        <-- RBP-88, RSP
+   *
+   */
+
+  /* Now align RSP to 64 byte boundary  */
+  libxsmm_x86_instruction_alu_imm_i64( io_generated_code, i_micro_kernel_config->alu_mov_instruction, temp_reg, 0xFFFFFFFFFFFFFFC0 );
+  libxsmm_x86_instruction_alu_reg( io_generated_code, LIBXSMM_X86_INSTR_ANDQ, temp_reg, LIBXSMM_X86_GP_REG_RSP);
+
+  /* Now alllocate in stack required GEMM scratch if necessary*/
+  libxsmm_generator_gemm_setup_stack_frame_allocate_scratch( io_generated_code, i_xgemm_desc, i_micro_kernel_config );
+
+  /* The stack at exit of setup looks like this:
+   *
+   *      10th param (if applicable)            <-- RBP+80
+   *      9th param (if applicable)             <-- RBP+72
+   *      8th param (if applicable)             <-- RBP+64
+   *      7th param (if applicable)             <-- RBP+56
+   *      Return address                        <-- RBP+48
+   *      Calle SAVED-regs                      <-- RBP[+8,+16,+24,+32,+40]
+   *      Entry/saved RBP                       <-- RBP
+   *      prefetch A ptr                        <-- RBP-8
+   *      prefetch B ptr                        <-- RBP-16
+   *      Offset A array ptr                    <-- RBP-24
+   *      Offset B array ptr                    <-- RBP-32
+   *      Int8 scaling factor                   <-- RBP-40
+   *      GEMM_scratch ptr in stack             <-- RBP-48
+   *      Eltwise bias ptr                      <-- RBP-56
+   *      Eltwise output_ptr                    <-- RBP-64
+   *      Eltwise buf1_ptr                      <-- RBP-72
+   *      Eltwise buf2_ptr                      <-- RBP-80
+   *      Batch-reduce count                    <-- RBP-88, RSP
+   *      [ Potentianl  pad for 64b align ]
+   *      GEMM scratch, 64b aligned             <-- (RBP-48) contains this address
+   *
+   */
+
+}
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_destroy_stack_frame( libxsmm_generated_code*            io_generated_code,
+    const libxsmm_gemm_descriptor*      i_xgemm_desc,
+    const libxsmm_gp_reg_mapping*       i_gp_reg_mapping,
+    const libxsmm_micro_kernel_config*  i_micro_kernel_config ) {
+  LIBXSMM_UNUSED(i_xgemm_desc);
+  LIBXSMM_UNUSED(i_gp_reg_mapping);
+  libxsmm_x86_instruction_alu_reg( io_generated_code, i_micro_kernel_config->alu_mov_instruction, LIBXSMM_X86_GP_REG_RBP, LIBXSMM_X86_GP_REG_RSP);
+  libxsmm_x86_instruction_pop_reg( io_generated_code, LIBXSMM_X86_GP_REG_RBP );
+}
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_setup_fusion_microkernel_properties_v2(const libxsmm_gemm_descriptor*      i_xgemm_desc,
+                                                                libxsmm_micro_kernel_config*        i_micro_kernel_config ) {
+  i_micro_kernel_config->fused_bcolbias          = 0;
+  i_micro_kernel_config->fused_scolbias          = 0;
+  i_micro_kernel_config->fused_relu              = 0;
+  i_micro_kernel_config->fused_relu_nobitmask    = 0;
+  i_micro_kernel_config->fused_relu_bwd          = 0;
+  i_micro_kernel_config->fused_sigmoid           = 0;
+  i_micro_kernel_config->overwrite_C             = 1;
+  i_micro_kernel_config->vnni_format_C           = 0;
+  i_micro_kernel_config->decompress_A            = 0;
+  i_micro_kernel_config->sparsity_factor_A       = 1;
+  i_micro_kernel_config->vnni_cvt_output_ext_buf = 0;
+  i_micro_kernel_config->norm_to_normT_B_ext_buf = 0;
+  i_micro_kernel_config->stride_b_trans          = 0;
+  i_micro_kernel_config->fused_eltwise           = 0;
+  i_micro_kernel_config->has_colbias_act_fused   = 0;
+
+  if ( ((LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI) ) {
+    i_micro_kernel_config->overwrite_C = ((i_xgemm_desc->internal_flags_2 & 0x4) > 0) ? 0 : 1;
+
+    if (i_xgemm_desc->eltw_cp_op == LIBXSMM_MELTW_OPERATION_UNARY) {
+      if (i_xgemm_desc->eltw_cp_param == LIBXSMM_MELTW_TYPE_UNARY_RELU) {
+        i_micro_kernel_config->has_colbias_act_fused = 1;
+        if ((i_xgemm_desc->eltw_cp_flags & LIBXSMM_MELTW_FLAG_UNARY_BITMASK_2BYTEMULT) > 0){
+          i_micro_kernel_config->fused_relu = 1;
+        } else {
+          i_micro_kernel_config->fused_relu_nobitmask = 1;
+        }
+      }
+
+      if (i_xgemm_desc->eltw_cp_param == LIBXSMM_MELTW_TYPE_UNARY_SIGMOID) {
+        i_micro_kernel_config->has_colbias_act_fused = 1;
+        i_micro_kernel_config->fused_sigmoid = 1;
+      }
+
+      if (i_xgemm_desc->eltw_cp_param == LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_VNNI) {
+        i_micro_kernel_config->vnni_format_C = 1;
+        if (i_micro_kernel_config->overwrite_C == 0) {
+          i_micro_kernel_config->vnni_cvt_output_ext_buf = 1;
+        }
+      }
+
+      if (i_xgemm_desc->eltw_cp_param == LIBXSMM_MELTW_TYPE_UNARY_RELU_INV) {
+        i_micro_kernel_config->has_colbias_act_fused = 1;
+        i_micro_kernel_config->fused_relu_bwd = 1;
+      }
+    }
+
+    if (i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_BINARY) {
+      if (i_xgemm_desc->meltw_param == LIBXSMM_MELTW_TYPE_BINARY_ADD) {
+        if (((i_xgemm_desc->meltw_flags & LIBXSMM_MELTW_FLAG_BINARY_BCAST_COL_IN_0) > 0 ) ||
+            ((i_xgemm_desc->meltw_flags & LIBXSMM_MELTW_FLAG_BINARY_BCAST_COL_IN_1) > 0 )) {
+          i_micro_kernel_config->has_colbias_act_fused = 1;
+          if (i_xgemm_desc->meltw_datatype_aux == LIBXSMM_DATATYPE_BF16) {
+            i_micro_kernel_config->fused_bcolbias = 1;
+          }
+          if (i_xgemm_desc->meltw_datatype_aux == LIBXSMM_DATATYPE_F32) {
+            i_micro_kernel_config->fused_scolbias = 1;
+          }
+        }
+      }
+    }
+
+    if (i_xgemm_desc->eltw_ap_op == LIBXSMM_MELTW_OPERATION_UNARY) {
+      if ((i_xgemm_desc->internal_flags_2 & 0x1) > 0){
+        if (i_xgemm_desc->eltw_ap_param == LIBXSMM_MELTW_TYPE_UNARY_DECOMPRESS_SPARSE_FACTOR_1) {
+          i_micro_kernel_config->decompress_A = 1;
+          i_micro_kernel_config->sparsity_factor_A = 1;
+        }
+        if (i_xgemm_desc->eltw_ap_param == LIBXSMM_MELTW_TYPE_UNARY_DECOMPRESS_SPARSE_FACTOR_2) {
+          i_micro_kernel_config->decompress_A = 1;
+          i_micro_kernel_config->sparsity_factor_A = 2;
+        }
+        if (i_xgemm_desc->eltw_ap_param == LIBXSMM_MELTW_TYPE_UNARY_DECOMPRESS_SPARSE_FACTOR_4) {
+          i_micro_kernel_config->decompress_A = 1;
+          i_micro_kernel_config->sparsity_factor_A = 4;
+        }
+        if (i_xgemm_desc->eltw_ap_param == LIBXSMM_MELTW_TYPE_UNARY_DECOMPRESS_SPARSE_FACTOR_8) {
+          i_micro_kernel_config->decompress_A = 1;
+          i_micro_kernel_config->sparsity_factor_A = 8;
+        }
+        if (i_xgemm_desc->eltw_ap_param == LIBXSMM_MELTW_TYPE_UNARY_DECOMPRESS_SPARSE_FACTOR_16) {
+          i_micro_kernel_config->decompress_A = 1;
+          i_micro_kernel_config->sparsity_factor_A = 16;
+        }
+        if (i_xgemm_desc->eltw_ap_param == LIBXSMM_MELTW_TYPE_UNARY_DECOMPRESS_SPARSE_FACTOR_32) {
+          i_micro_kernel_config->decompress_A = 1;
+          i_micro_kernel_config->sparsity_factor_A = 32;
+        }
+      }
+    }
+
+    if (i_xgemm_desc->eltw_bp_op == LIBXSMM_MELTW_OPERATION_UNARY) {
+      if (i_xgemm_desc->eltw_bp_param == LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_NORMT) {
+        if ((i_xgemm_desc->internal_flags_2 & 0x2) > 0){
+          i_micro_kernel_config->norm_to_normT_B_ext_buf = 1;
+          i_micro_kernel_config->stride_b_trans = i_xgemm_desc->ldbp;
+        }
+      }
+    }
+
+    i_micro_kernel_config->fused_eltwise = (i_micro_kernel_config->has_colbias_act_fused == 1) ? 1: 0;
+    if (i_micro_kernel_config->decompress_A == 1) {
+      i_micro_kernel_config->fused_eltwise = 1;
+    }
+
+    if (i_micro_kernel_config->vnni_cvt_output_ext_buf == 1) {
+      i_micro_kernel_config->fused_eltwise = 1;
+    }
+
+    if (i_micro_kernel_config->norm_to_normT_B_ext_buf == 1) {
+      i_micro_kernel_config->fused_eltwise = 1;
+    }
+
+    if (i_micro_kernel_config->fused_relu_bwd == 1) {
+      i_micro_kernel_config->fused_eltwise = 1;
+    }
+  }
+}
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_setup_fusion_microkernel_properties(const libxsmm_gemm_descriptor*      i_xgemm_desc,
+                                                                libxsmm_micro_kernel_config*        i_micro_kernel_config ) {
+  i_micro_kernel_config->fused_bcolbias          = 0;
+  i_micro_kernel_config->fused_scolbias          = 0;
+  i_micro_kernel_config->fused_relu              = 0;
+  i_micro_kernel_config->fused_relu_nobitmask    = 0;
+  i_micro_kernel_config->fused_relu_bwd          = 0;
+  i_micro_kernel_config->fused_sigmoid           = 0;
+  i_micro_kernel_config->overwrite_C             = 0;
+  i_micro_kernel_config->vnni_format_C           = 0;
+  i_micro_kernel_config->decompress_A            = 0;
+  i_micro_kernel_config->sparsity_factor_A       = 1;
+  i_micro_kernel_config->vnni_cvt_output_ext_buf = 0;
+  i_micro_kernel_config->norm_to_normT_B_ext_buf = 0;
+  i_micro_kernel_config->stride_b_trans          = 0;
+  i_micro_kernel_config->fused_eltwise           = 0;
+  i_micro_kernel_config->has_colbias_act_fused   = 0;
+
+  if ((i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_COLBIAS_ACT) ||
+      (i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_COLBIAS_ACT_DECOMPRESS_A) ||
+      (i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_ACT_TRANSFORM_C_NORM_TO_VNNI_EXT_BUFFER)) {
+    if ((i_xgemm_desc->meltw_flags & LIBXSMM_MELTW_FLAG_OVERWRITE_C) > 0) {
+      i_micro_kernel_config->overwrite_C = 1;
+    }
+    if ((i_xgemm_desc->meltw_flags & LIBXSMM_MELTW_FLAG_ACT_RELU) > 0) {
+      i_micro_kernel_config->fused_relu = 1;
+    }
+    if ((i_xgemm_desc->meltw_flags & LIBXSMM_MELTW_FLAG_ACT_RELU_NOBITMASK) > 0) {
+      i_micro_kernel_config->fused_relu_nobitmask = 1;
+    }
+    if ((i_xgemm_desc->meltw_flags & LIBXSMM_MELTW_FLAG_ACT_RELU_BWD) > 0) {
+      i_micro_kernel_config->fused_relu_bwd = 1;
+    }
+    if ((i_xgemm_desc->meltw_flags & LIBXSMM_MELTW_FLAG_ACT_SIGM) > 0) {
+      i_micro_kernel_config->fused_sigmoid = 1;
+    }
+    if ((i_xgemm_desc->meltw_flags & LIBXSMM_MELTW_FLAG_COLBIAS) > 0) {
+      if (i_xgemm_desc->meltw_datatype_aux == LIBXSMM_DATATYPE_BF16) {
+        i_micro_kernel_config->fused_bcolbias = 1;
+      }
+      if (i_xgemm_desc->meltw_datatype_aux == LIBXSMM_DATATYPE_F32) {
+        i_micro_kernel_config->fused_scolbias = 1;
+      }
+    }
+  } else {
+    i_micro_kernel_config->overwrite_C    = 1;
+    i_micro_kernel_config->vnni_format_C  = ((i_xgemm_desc->flags & LIBXSMM_GEMM_FLAG_VNNI_C) > 0) ? 1 : 0;
+  }
+
+  /* Determine if we have to decompress A...  */
+  if ((i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_DECOMPRESS_A) || (i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_COLBIAS_ACT_DECOMPRESS_A)) {
+    i_micro_kernel_config->decompress_A = 1;
+    i_micro_kernel_config->sparsity_factor_A = i_xgemm_desc->meltw_param;
+  }
+
+  if ((i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_COLBIAS_ACT) || (i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_COLBIAS_ACT_DECOMPRESS_A)) {
+    if ((i_xgemm_desc->meltw_flags & LIBXSMM_MELTW_FLAG_ACT_RELU_BWD) > 0) {
+      i_micro_kernel_config->fused_relu_bwd = 1;
+    }
+    i_micro_kernel_config->has_colbias_act_fused = 1;
+    if (i_xgemm_desc->meltw_flags == (unsigned int)LIBXSMM_MELTW_FLAG_NONE) {
+      i_micro_kernel_config->has_colbias_act_fused = 0;
+    }
+  }
+
+  if ((i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_TRANSFORM_C_NORM_TO_VNNI_EXT_BUFFER) ||
+      (i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_ACT_TRANSFORM_C_NORM_TO_VNNI_EXT_BUFFER)) {
+    i_micro_kernel_config->vnni_cvt_output_ext_buf = 1;
+    if ((i_xgemm_desc->meltw_flags & LIBXSMM_MELTW_FLAG_ACT_RELU_BWD) > 0) {
+      i_micro_kernel_config->fused_relu_bwd = 1;
+    }
+  }
+
+  if ((i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_TRANSFORM_B_NORM_TO_NORMT_EXT_BUFFER) ||
+      (i_xgemm_desc->meltw_operation == LIBXSMM_MELTW_OPERATION_COLBIAS_ACT_TRANSFORM_B_NORM_TO_NORMT_EXT_BUFFER)) {
+    i_micro_kernel_config->norm_to_normT_B_ext_buf = 1;
+  }
+
+  i_micro_kernel_config->fused_eltwise = (i_micro_kernel_config->has_colbias_act_fused == 1) ? 1: 0;
+  if (i_micro_kernel_config->decompress_A == 1) {
+    i_micro_kernel_config->fused_eltwise = 1;
+  }
+
+  if (i_micro_kernel_config->vnni_cvt_output_ext_buf == 1) {
+    i_micro_kernel_config->fused_eltwise = 1;
+  }
+
+  if (i_micro_kernel_config->norm_to_normT_B_ext_buf == 1) {
+    i_micro_kernel_config->fused_eltwise = 1;
+    i_micro_kernel_config->stride_b_trans = i_xgemm_desc->meltw_ldy;
+  }
+
+  if (i_micro_kernel_config->fused_relu_bwd == 1) {
+    i_micro_kernel_config->fused_eltwise = 1;
+  }
+}
 
 LIBXSMM_API_INTERN
 int libxsmm_generator_gemm_get_rbp_relative_offset( libxsmm_gemm_stack_var stack_var ) {
@@ -72,13 +1174,13 @@ int libxsmm_generator_gemm_get_rbp_relative_offset( libxsmm_gemm_stack_var stack
     case LIBXSMM_GEMM_STACK_VAR_ELT_DECOMPRESS_BUF:
       return -80;
     case LIBXSMM_GEMM_STACK_VAR_ARG_7:
-      return 16;
+      return 56;
     case LIBXSMM_GEMM_STACK_VAR_ARG_8:
-      return 24;
+      return 64;
     case LIBXSMM_GEMM_STACK_VAR_ARG_9:
-      return 32;
+      return 72;
     case LIBXSMM_GEMM_STACK_VAR_ARG_10:
-      return 40;
+      return 80;
     default:
       return 0;
   }
@@ -118,6 +1220,7 @@ void libxsmm_generator_gemm_init_micro_kernel_config_fullvector( libxsmm_micro_k
     const libxsmm_gemm_descriptor* i_xgemm_desc,
     const unsigned int             i_use_masking_a_c ) {
   memset(io_micro_kernel_config, 0, sizeof(*io_micro_kernel_config)); /* avoid warning "maybe used uninitialized" */
+  libxsmm_generator_gemm_setup_fusion_microkernel_properties_v2(i_xgemm_desc, io_micro_kernel_config);
   if ( (i_arch <= LIBXSMM_TARGET_ARCH_GENERIC) || (i_arch > LIBXSMM_X86_ALLFEAT) ) {
     io_micro_kernel_config->instruction_set = LIBXSMM_TARGET_ARCH_GENERIC;
     io_micro_kernel_config->vector_reg_count = 0;
@@ -649,6 +1752,7 @@ void libxsmm_generator_gemm_init_micro_kernel_config_halfvector( libxsmm_micro_k
     const unsigned int             i_arch,
     const libxsmm_gemm_descriptor* i_xgemm_desc,
     const unsigned int             i_use_masking_a_c ) {
+  libxsmm_generator_gemm_setup_fusion_microkernel_properties_v2(i_xgemm_desc, io_micro_kernel_config);
   if ( (i_arch <= LIBXSMM_TARGET_ARCH_GENERIC) || (i_arch > LIBXSMM_X86_ALLFEAT) ) {
     io_micro_kernel_config->instruction_set = LIBXSMM_TARGET_ARCH_GENERIC;
     io_micro_kernel_config->vector_reg_count = 0;
@@ -749,6 +1853,7 @@ void libxsmm_generator_gemm_init_micro_kernel_config_scalar( libxsmm_micro_kerne
     const unsigned int             i_arch,
     const libxsmm_gemm_descriptor* i_xgemm_desc,
     const unsigned int             i_use_masking_a_c ) {
+  libxsmm_generator_gemm_setup_fusion_microkernel_properties_v2(i_xgemm_desc, io_micro_kernel_config);
   if ( ( i_arch <= LIBXSMM_TARGET_ARCH_GENERIC ) || ( i_arch > LIBXSMM_X86_ALLFEAT ) ) {
     io_micro_kernel_config->instruction_set = LIBXSMM_TARGET_ARCH_GENERIC;
     io_micro_kernel_config->vector_reg_count = 0;
@@ -951,8 +2056,67 @@ void libxsmm_generator_gemm_footer_nloop( libxsmm_generated_code*             io
     const libxsmm_gemm_descriptor*     i_xgemm_desc,
     const unsigned int                 i_n_blocking,
     const unsigned int                 i_n_done ) {
-  libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_add_instruction, i_gp_reg_mapping->gp_reg_c,
+  if ( LIBXSMM_DATATYPE_BF16 == LIBXSMM_GETENUM_OUT( i_xgemm_desc->datatype ) ) {
+    if (i_micro_kernel_config->vnni_format_C == 0) {
+      libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_add_instruction, i_gp_reg_mapping->gp_reg_c,
+        (i_n_blocking*(i_xgemm_desc->ldc)*2 /*(i_micro_kernel_config->datatype_size/2)*/) - ((i_xgemm_desc->m) * 2 /*(i_micro_kernel_config->datatype_size/2)*/) );
+    } else {
+      libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_add_instruction, i_gp_reg_mapping->gp_reg_c,
+        (i_n_blocking*(i_xgemm_desc->ldc)*2 /*(i_micro_kernel_config->datatype_size/2)*/) - ((i_xgemm_desc->m) * 2 * 2 /*(i_micro_kernel_config->datatype_size/2)*/) );
+    }
+  } else if ( LIBXSMM_DATATYPE_I8 == LIBXSMM_GETENUM_OUT( i_xgemm_desc->datatype ) ) {
+    libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_add_instruction, i_gp_reg_mapping->gp_reg_c,
+        (i_n_blocking*(i_xgemm_desc->ldc)/**(i_micro_kernel_config->datatype_size/4)*/) - ((i_xgemm_desc->m) /** (i_micro_kernel_config->datatype_size/4)*/) );
+  } else {
+    libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_add_instruction, i_gp_reg_mapping->gp_reg_c,
       (i_n_blocking*(i_xgemm_desc->ldc)*(i_micro_kernel_config->datatype_size_out)) - ((i_xgemm_desc->m)*(i_micro_kernel_config->datatype_size_out)) );
+  }
+
+  /* Also adjust eltwise pointers  */
+  if ((i_micro_kernel_config->fused_relu == 1) || (i_micro_kernel_config->vnni_cvt_output_ext_buf == 1) || (i_micro_kernel_config->fused_relu_bwd == 1) || (i_micro_kernel_config->fused_bcolbias == 1) || (i_micro_kernel_config->fused_scolbias == 1) || (i_micro_kernel_config->overwrite_C == 0)) {
+    libxsmm_x86_instruction_push_reg( io_generated_code, i_gp_reg_mapping->gp_reg_help_0 );
+  }
+
+  if ((i_micro_kernel_config->fused_relu == 1) && (i_micro_kernel_config->overwrite_C == 1) ) {
+    libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_OUTPUT_PTR, i_gp_reg_mapping->gp_reg_help_0 );
+    libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_add_instruction, i_gp_reg_mapping->gp_reg_help_0, (i_n_blocking*i_xgemm_desc->ldc)/8 - ((i_xgemm_desc->m/8) ) );
+    libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_OUTPUT_PTR, i_gp_reg_mapping->gp_reg_help_0 );
+  }
+
+  if (i_micro_kernel_config->vnni_cvt_output_ext_buf == 1) {
+    libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_OUTPUT_PTR, i_gp_reg_mapping->gp_reg_help_0 );
+    libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_add_instruction, i_gp_reg_mapping->gp_reg_help_0, (i_n_blocking*(i_xgemm_desc->ldc)*2/*(i_micro_kernel_config->datatype_size/2)*/) - ((i_xgemm_desc->m) * 2 * 2 /*(i_micro_kernel_config->datatype_size/2)*/)  );
+    libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_OUTPUT_PTR, i_gp_reg_mapping->gp_reg_help_0 );
+  }
+
+  if (i_micro_kernel_config->fused_relu_bwd == 1) {
+    libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_RELU_BITMASK_PTR, i_gp_reg_mapping->gp_reg_help_0 );
+    libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_add_instruction, i_gp_reg_mapping->gp_reg_help_0, (i_n_blocking*i_xgemm_desc->ldc)/8 - ((i_xgemm_desc->m/8) ) );
+    libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_RELU_BITMASK_PTR, i_gp_reg_mapping->gp_reg_help_0 );
+  }
+
+  /* In this case also advance the output ptr */
+  if (i_micro_kernel_config->overwrite_C == 0) {
+    libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_OUTPUT_PTR, i_gp_reg_mapping->gp_reg_help_0 );
+    libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_add_instruction, i_gp_reg_mapping->gp_reg_help_0, (i_n_blocking*(i_xgemm_desc->ldc)*2/*(i_micro_kernel_config->datatype_size/2)*/) - ((i_xgemm_desc->m) * 2 /*(i_micro_kernel_config->datatype_size/2)*/) );
+    libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_OUTPUT_PTR, i_gp_reg_mapping->gp_reg_help_0 );
+  }
+
+  if (i_micro_kernel_config->fused_bcolbias == 1) {
+    libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_BIAS_PTR, i_gp_reg_mapping->gp_reg_help_0 );
+    libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_add_instruction, i_gp_reg_mapping->gp_reg_help_0, -( i_xgemm_desc->m  * 2/*(i_micro_kernel_config->datatype_size/2)*/) );
+    libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_BIAS_PTR, i_gp_reg_mapping->gp_reg_help_0 );
+  }
+
+  if (i_micro_kernel_config->fused_scolbias == 1) {
+    libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_BIAS_PTR, i_gp_reg_mapping->gp_reg_help_0 );
+    libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_add_instruction, i_gp_reg_mapping->gp_reg_help_0, -( i_xgemm_desc->m  * 4/*i_micro_kernel_config->datatype_size*/) );
+    libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_BIAS_PTR, i_gp_reg_mapping->gp_reg_help_0 );
+  }
+
+  if ((i_micro_kernel_config->fused_relu == 1) || (i_micro_kernel_config->vnni_cvt_output_ext_buf == 1) || (i_micro_kernel_config->fused_relu_bwd == 1) || (i_micro_kernel_config->fused_bcolbias == 1) || (i_micro_kernel_config->fused_scolbias == 1) || (i_micro_kernel_config->overwrite_C == 0)) {
+    libxsmm_x86_instruction_pop_reg( io_generated_code, i_gp_reg_mapping->gp_reg_help_0 );
+  }
 
   /* B prefetch */
   if ( i_xgemm_desc->prefetch == LIBXSMM_GEMM_PREFETCH_BL2_VIA_C          ||
@@ -1086,6 +2250,52 @@ void libxsmm_generator_gemm_footer_mloop( libxsmm_generated_code*            io_
   /* advance C pointer */
   libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_add_instruction,
       i_gp_reg_mapping->gp_reg_c, i_m_blocking*(i_micro_kernel_config->datatype_size_out) );
+
+  /* Also adjust eltwise pointers  */
+  if ((i_micro_kernel_config->fused_relu == 1) || (i_micro_kernel_config->vnni_cvt_output_ext_buf == 1) || (i_micro_kernel_config->fused_relu_bwd == 1) || (i_micro_kernel_config->fused_bcolbias == 1) || (i_micro_kernel_config->fused_scolbias == 1) || (i_micro_kernel_config->overwrite_C == 0)) {
+    libxsmm_x86_instruction_push_reg( io_generated_code, i_gp_reg_mapping->gp_reg_help_0 );
+  }
+
+  if ((i_micro_kernel_config->fused_relu == 1) && (i_micro_kernel_config->overwrite_C == 1) ) {
+    libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_OUTPUT_PTR, i_gp_reg_mapping->gp_reg_help_0 );
+    libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_add_instruction, i_gp_reg_mapping->gp_reg_help_0, i_m_blocking/8 );
+    libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_OUTPUT_PTR, i_gp_reg_mapping->gp_reg_help_0 );
+  }
+
+  if (i_micro_kernel_config->vnni_cvt_output_ext_buf == 1) {
+    libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_OUTPUT_PTR, i_gp_reg_mapping->gp_reg_help_0 );
+    libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_add_instruction, i_gp_reg_mapping->gp_reg_help_0, i_m_blocking*2*2/*(i_micro_kernel_config->datatype_size/2)*/ );
+    libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_OUTPUT_PTR, i_gp_reg_mapping->gp_reg_help_0 );
+  }
+
+  if (i_micro_kernel_config->fused_relu_bwd == 1) {
+    libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_RELU_BITMASK_PTR, i_gp_reg_mapping->gp_reg_help_0 );
+    libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_add_instruction, i_gp_reg_mapping->gp_reg_help_0, i_m_blocking/8 );
+    libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_RELU_BITMASK_PTR, i_gp_reg_mapping->gp_reg_help_0 );
+  }
+
+  if (i_micro_kernel_config->overwrite_C == 0) {
+    libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_OUTPUT_PTR, i_gp_reg_mapping->gp_reg_help_0 );
+    libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_add_instruction, i_gp_reg_mapping->gp_reg_help_0, i_m_blocking*2/*(i_micro_kernel_config->datatype_size/2)*/ );
+    libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_OUTPUT_PTR, i_gp_reg_mapping->gp_reg_help_0 );
+  }
+
+  if (i_micro_kernel_config->fused_bcolbias == 1) {
+    libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_BIAS_PTR, i_gp_reg_mapping->gp_reg_help_0 );
+    libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_add_instruction, i_gp_reg_mapping->gp_reg_help_0, i_m_blocking * 2/*(i_micro_kernel_config->datatype_size/2)*/ );
+    libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_BIAS_PTR, i_gp_reg_mapping->gp_reg_help_0 );
+  }
+
+  if (i_micro_kernel_config->fused_scolbias == 1) {
+    libxsmm_generator_gemm_getval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_BIAS_PTR, i_gp_reg_mapping->gp_reg_help_0 );
+    libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_add_instruction, i_gp_reg_mapping->gp_reg_help_0, i_m_blocking * 4 /*i_micro_kernel_config->datatype_size*/ );
+    libxsmm_generator_gemm_setval_stack_var( io_generated_code, i_micro_kernel_config, LIBXSMM_GEMM_STACK_VAR_ELT_BIAS_PTR, i_gp_reg_mapping->gp_reg_help_0 );
+  }
+
+  if ((i_micro_kernel_config->fused_relu == 1) || (i_micro_kernel_config->vnni_cvt_output_ext_buf == 1) || (i_micro_kernel_config->fused_relu_bwd == 1) || (i_micro_kernel_config->fused_bcolbias == 1) || (i_micro_kernel_config->fused_scolbias == 1) || (i_micro_kernel_config->overwrite_C == 0)) {
+    libxsmm_x86_instruction_pop_reg( io_generated_code, i_gp_reg_mapping->gp_reg_help_0 );
+  }
+
 
   /* C prefetch */
 #if 0
@@ -1278,6 +2488,11 @@ void libxsmm_generator_gemm_load_C( libxsmm_generated_code*             io_gener
               16);
         }
       }
+      /* Check if we have to add bias  */
+      if (i_micro_kernel_config->fused_bcolbias == 1) {
+        libxsmm_generator_gemm_add_colbias_to_2D_block( io_generated_code, i_gp_reg_mapping, i_micro_kernel_config,
+            LIBXSMM_DATATYPE_BF16, l_vec_reg_acc_start, l_m_blocking, i_n_blocking );
+      }
     /* pure int8 kernel */
     } else if ( ( ((i_micro_kernel_config->instruction_set >= LIBXSMM_X86_AVX512_CORE) && (i_micro_kernel_config->instruction_set <= LIBXSMM_X86_ALLFEAT)) ||
                   ((i_micro_kernel_config->instruction_set > LIBXSMM_X86_AVX2) && ( i_micro_kernel_config->instruction_set < LIBXSMM_X86_AVX512 ) )
@@ -1349,50 +2564,63 @@ void libxsmm_generator_gemm_load_C( libxsmm_generated_code*             io_gener
         }
 #endif
       }
+      /* Check if we have to add bias  */
+      if (i_micro_kernel_config->fused_scolbias == 1) {
+        libxsmm_generator_gemm_add_colbias_to_2D_block( io_generated_code, i_gp_reg_mapping, i_micro_kernel_config,
+            LIBXSMM_DATATYPE_F32, l_vec_reg_acc_start, l_m_blocking, i_n_blocking );
+      }
     }
   } else {
-    /* overwriting C, so let's xout accumulator */
-    for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
-      for ( l_m = 0; l_m < l_m_blocking; l_m++ ) {
-        /* @TODO: cannot migrate to new encoder as this is also SSE */
-        if ( LIBXSMM_DATATYPE_I8 == LIBXSMM_GETENUM_INP( i_xgemm_desc->datatype ) && LIBXSMM_DATATYPE_I32 == LIBXSMM_GETENUM_OUT( i_xgemm_desc->datatype )){
-          libxsmm_x86_instruction_vec_move( io_generated_code,
-              i_micro_kernel_config->instruction_set,
-              i_micro_kernel_config->c_vmove_instruction,
-              i_gp_reg_mapping->gp_reg_c,
-              LIBXSMM_X86_GP_REG_UNDEF, 0,
-              ((l_n * i_xgemm_desc->ldc) + (l_m * (i_micro_kernel_config->vector_length))) * (i_micro_kernel_config->datatype_size_out),
-              i_micro_kernel_config->vector_name,
-              l_vec_reg_acc_start + l_m + (l_m_blocking * l_n), 0, 1, 0 );
-        } else {
-          if ( io_generated_code->arch >= LIBXSMM_X86_AVX ) {
-            libxsmm_x86_instruction_vec_compute_3reg( io_generated_code,
-                i_micro_kernel_config->vxor_instruction,
+    if (i_micro_kernel_config->fused_scolbias == 1) {
+      libxsmm_generator_gemm_load_colbias_to_2D_block( io_generated_code, i_gp_reg_mapping, i_micro_kernel_config,
+            LIBXSMM_DATATYPE_F32, l_vec_reg_acc_start, l_m_blocking, i_n_blocking );
+    } else if (i_micro_kernel_config->fused_bcolbias == 1) {
+      libxsmm_generator_gemm_load_colbias_to_2D_block( io_generated_code, i_gp_reg_mapping, i_micro_kernel_config,
+            LIBXSMM_DATATYPE_BF16, l_vec_reg_acc_start, l_m_blocking, i_n_blocking );
+    } else {
+      /* overwriting C, so let's xout accumulator */
+      for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
+        for ( l_m = 0; l_m < l_m_blocking; l_m++ ) {
+          /* @TODO: cannot migrate to new encoder as this is also SSE */
+          if ( LIBXSMM_DATATYPE_I8 == LIBXSMM_GETENUM_INP( i_xgemm_desc->datatype ) && LIBXSMM_DATATYPE_I32 == LIBXSMM_GETENUM_OUT( i_xgemm_desc->datatype )){
+            libxsmm_x86_instruction_vec_move( io_generated_code,
+                i_micro_kernel_config->instruction_set,
+                i_micro_kernel_config->c_vmove_instruction,
+                i_gp_reg_mapping->gp_reg_c,
+                LIBXSMM_X86_GP_REG_UNDEF, 0,
+                ((l_n * i_xgemm_desc->ldc) + (l_m * (i_micro_kernel_config->vector_length))) * (i_micro_kernel_config->datatype_size_out),
                 i_micro_kernel_config->vector_name,
-                l_vec_reg_acc_start + l_m + (l_m_blocking * l_n),
-                l_vec_reg_acc_start + l_m + (l_m_blocking * l_n),
-                l_vec_reg_acc_start + l_m + (l_m_blocking * l_n) );
+                l_vec_reg_acc_start + l_m + (l_m_blocking * l_n), 0, 1, 0 );
           } else {
-            libxsmm_x86_instruction_vec_compute_2reg( io_generated_code,
-                i_micro_kernel_config->vxor_instruction,
-                i_micro_kernel_config->vector_name,
-                l_vec_reg_acc_start + l_m + (l_m_blocking * l_n),
-                l_vec_reg_acc_start + l_m + (l_m_blocking * l_n) );
+            if ( io_generated_code->arch >= LIBXSMM_X86_AVX ) {
+              libxsmm_x86_instruction_vec_compute_3reg( io_generated_code,
+                  i_micro_kernel_config->vxor_instruction,
+                  i_micro_kernel_config->vector_name,
+                  l_vec_reg_acc_start + l_m + (l_m_blocking * l_n),
+                  l_vec_reg_acc_start + l_m + (l_m_blocking * l_n),
+                  l_vec_reg_acc_start + l_m + (l_m_blocking * l_n) );
+            } else {
+              libxsmm_x86_instruction_vec_compute_2reg( io_generated_code,
+                  i_micro_kernel_config->vxor_instruction,
+                  i_micro_kernel_config->vector_name,
+                  l_vec_reg_acc_start + l_m + (l_m_blocking * l_n),
+                  l_vec_reg_acc_start + l_m + (l_m_blocking * l_n) );
+            }
           }
         }
-      }
 #if 0
-      if ( i_xgemm_desc->prefetch == LIBXSMM_GEMM_PREFETCH_CL2 ||
-          i_xgemm_desc->prefetch == LIBXSMM_GEMM_PREFETCH_AL2CL2BL2_VIA_C )  {
-        for (l_m = 0; l_m < l_m_blocking; l_m += l_m++ ) {
-          libxsmm_x86_instruction_prefetch( io_generated_code,
-              i_micro_kernel_config->prefetch_instruction,
-              i_gp_reg_mapping->gp_reg_c_prefetch,
-              LIBXSMM_X86_GP_REG_UNDEF, 0,
-              ((l_n * i_xgemm_desc->ldc) + (l_m * (i_micro_kernel_config->vector_length))) * (i_micro_kernel_config->datatype_size_out));
+        if ( i_xgemm_desc->prefetch == LIBXSMM_GEMM_PREFETCH_CL2 ||
+            i_xgemm_desc->prefetch == LIBXSMM_GEMM_PREFETCH_AL2CL2BL2_VIA_C )  {
+          for (l_m = 0; l_m < l_m_blocking; l_m += l_m++ ) {
+            libxsmm_x86_instruction_prefetch( io_generated_code,
+                i_micro_kernel_config->prefetch_instruction,
+                i_gp_reg_mapping->gp_reg_c_prefetch,
+                LIBXSMM_X86_GP_REG_UNDEF, 0,
+                ((l_n * i_xgemm_desc->ldc) + (l_m * (i_micro_kernel_config->vector_length))) * (i_micro_kernel_config->datatype_size_out));
+          }
         }
-      }
 #endif
+      }
     }
   }
 }
@@ -1415,6 +2643,9 @@ void libxsmm_generator_gemm_store_C( libxsmm_generated_code*             io_gene
   unsigned int l_vec_reg_acc_start = i_micro_kernel_config->vector_reg_count - (i_n_blocking * l_m_blocking);
   /* select store instruction */
   unsigned int l_vstore = (LIBXSMM_GEMM_FLAG_ALIGN_C_NTS_HINT == (LIBXSMM_GEMM_FLAG_ALIGN_C_NTS_HINT & i_xgemm_desc->flags)) ? i_micro_kernel_config->c_vmove_nts_instruction : i_micro_kernel_config->c_vmove_instruction;
+  libxsmm_micro_kernel_config l_micro_kernel_config_mod;
+  libxsmm_micro_kernel_config *i_micro_kernel_config_mod = (libxsmm_micro_kernel_config*) &l_micro_kernel_config_mod;
+  memcpy(i_micro_kernel_config_mod, i_micro_kernel_config, sizeof(libxsmm_micro_kernel_config));
 
   /* @TODO fix this test */
 #if !defined(NDEBUG)
@@ -1455,6 +2686,53 @@ void libxsmm_generator_gemm_store_C( libxsmm_generated_code*             io_gene
   if ( ( (i_micro_kernel_config->instruction_set == LIBXSMM_X86_AVX512_CORE) || (i_micro_kernel_config->instruction_set == LIBXSMM_X86_AVX512_CLX) ||
         (i_micro_kernel_config->instruction_set == LIBXSMM_X86_AVX512_VL256_CLX) || (i_micro_kernel_config->instruction_set == LIBXSMM_X86_AVX512_VL256)  ) &&
        ( (LIBXSMM_DATATYPE_BF16 == LIBXSMM_GETENUM_INP( i_xgemm_desc->datatype ) ) && (LIBXSMM_DATATYPE_BF16 == LIBXSMM_GETENUM_OUT( i_xgemm_desc->datatype ) ) ) ) {
+    const unsigned int relu_bitmask_gpr = i_gp_reg_mapping->gp_reg_help_2;
+    const unsigned int scratch_gpr = i_gp_reg_mapping->gp_reg_help_2;
+    const unsigned int aux_gpr = i_gp_reg_mapping->gp_reg_help_1;
+    const unsigned int aux_vreg  = 1;
+    const unsigned int zero_vreg = 0;
+
+    /* Check out if fusion has to be applied  */
+    if ((i_micro_kernel_config->fused_relu_nobitmask == 1) || (i_micro_kernel_config->fused_relu == 1)) {
+      libxsmm_generator_gemm_prepare_relu_fusion( io_generated_code, i_micro_kernel_config,
+          zero_vreg, i_micro_kernel_config->fused_relu, relu_bitmask_gpr, aux_gpr);
+    } else if (i_micro_kernel_config->fused_sigmoid == 1) {
+      libxsmm_generator_gemm_dump_2D_block_and_prepare_sigmoid_fusion( io_generated_code, i_micro_kernel_config_mod,
+          l_vec_reg_acc_start, l_m_blocking, i_n_blocking, scratch_gpr, aux_gpr);
+    }
+
+    for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
+      for ( l_m = 0; l_m < l_m_blocking; l_m++ ) {
+        if ((i_micro_kernel_config->fused_relu_nobitmask == 1) || (i_micro_kernel_config->fused_relu == 1)) {
+          unsigned int bitmask_offset = (io_generated_code->arch < LIBXSMM_X86_AVX512) ? ((l_n * i_xgemm_desc->ldc) + (l_m * 8))/8 : ((l_n * i_xgemm_desc->ldc) + (l_m * 16))/8;
+          libxsmm_generator_gemm_apply_relu_to_vreg( io_generated_code, i_micro_kernel_config,
+              zero_vreg, l_vec_reg_acc_start + l_m + (l_m_blocking * l_n), i_micro_kernel_config->fused_relu, relu_bitmask_gpr, bitmask_offset, 1, aux_gpr, aux_vreg);
+        } else if (i_micro_kernel_config->fused_sigmoid == 1) {
+          unsigned int tmp_vreg = 0;
+          libxsmm_generator_gemm_apply_sigmoid_to_vreg_from_scratch( io_generated_code, i_micro_kernel_config_mod,
+              scratch_gpr, l_vec_reg_acc_start + l_m + (l_m_blocking * l_n), tmp_vreg );
+          /* Store vreg back to scratch */
+          libxsmm_x86_instruction_vec_move( io_generated_code,
+              i_micro_kernel_config->instruction_set,
+              LIBXSMM_X86_INSTR_VMOVUPS,
+              scratch_gpr,
+              LIBXSMM_X86_GP_REG_UNDEF, 0,
+              (l_vec_reg_acc_start + l_m + (l_m_blocking * l_n)) * 64,
+              i_micro_kernel_config->vector_name,
+              tmp_vreg, 0, 0, 1 );
+        }
+      }
+    }
+
+    if ((i_micro_kernel_config->fused_relu_nobitmask == 1) || (i_micro_kernel_config->fused_relu == 1)) {
+      libxsmm_generator_gemm_cleanup_relu_fusion( io_generated_code, i_micro_kernel_config->fused_relu, relu_bitmask_gpr, aux_gpr);
+    } else if (i_micro_kernel_config->fused_sigmoid == 1) {
+      /* Restore accumulators from scratch */
+      libxsmm_generator_gemm_restore_2D_regblock_from_scratch( io_generated_code, i_micro_kernel_config,
+          scratch_gpr, l_vec_reg_acc_start, l_m_blocking, i_n_blocking);
+      libxsmm_generator_gemm_cleanup_sigmoid_fusion( io_generated_code, scratch_gpr, aux_gpr );
+    }
+
     /* init stack with helper variables for SW-based RNE rounding */
     /* push 0x7f800000 on the stack, naninf masking */
     libxsmm_x86_instruction_alu_imm( io_generated_code, LIBXSMM_X86_INSTR_MOVQ, i_gp_reg_mapping->gp_reg_help_2, 0x7f800000);
@@ -1611,7 +2889,23 @@ void libxsmm_generator_gemm_store_C( libxsmm_generated_code*             io_gene
               ) &&
               ( (LIBXSMM_DATATYPE_BF16 == LIBXSMM_GETENUM_INP( i_xgemm_desc->datatype ) ) && (LIBXSMM_DATATYPE_BF16 == LIBXSMM_GETENUM_OUT( i_xgemm_desc->datatype ) ) )
             ) {
+    const unsigned int relu_bitmask_gpr = i_gp_reg_mapping->gp_reg_help_2;
+    const unsigned int scratch_gpr = i_gp_reg_mapping->gp_reg_help_2;
+    const unsigned int aux_gpr = i_gp_reg_mapping->gp_reg_help_1;
+    const unsigned int zero_vreg = 1;
+    const unsigned int aux_vreg  = 2;
+
     /* storing downconverted and rounded C accumulator */
+    /* Check out if fusion has to be applied  */
+    if ((i_micro_kernel_config->fused_relu_nobitmask == 1) || (i_micro_kernel_config->fused_relu == 1)) {
+      libxsmm_generator_gemm_prepare_relu_fusion( io_generated_code, i_micro_kernel_config,
+          zero_vreg, i_micro_kernel_config->fused_relu, relu_bitmask_gpr, aux_gpr);
+    } else if (i_micro_kernel_config->fused_sigmoid == 1) {
+      /* First dump the accumulators to scratch and then setup sigmoid coeffcients to be reused */
+      libxsmm_generator_gemm_dump_2D_block_and_prepare_sigmoid_fusion( io_generated_code, i_micro_kernel_config_mod,
+          l_vec_reg_acc_start, l_m_blocking, i_n_blocking, scratch_gpr, aux_gpr);
+    }
+
     for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
       unsigned int l_m_2_blocking = (l_m_blocking/2)*2;
       l_m = 0;
@@ -1619,7 +2913,16 @@ void libxsmm_generator_gemm_store_C( libxsmm_generated_code*             io_gene
       if ( i_micro_kernel_config->use_masking_a_c != 0 ) {
         for ( l_m = 0 ; l_m < l_m_blocking; l_m++ ) {
           unsigned int reg_X = l_vec_reg_acc_start + l_m + (l_m_blocking * l_n);
-
+          if ((i_micro_kernel_config->fused_relu_nobitmask == 1) || (i_micro_kernel_config->fused_relu == 1)) {
+            unsigned int bitmask_offset = (io_generated_code->arch < LIBXSMM_X86_AVX512) ? ((l_n * i_xgemm_desc->ldc) + (l_m * 8))/8 : ((l_n * i_xgemm_desc->ldc) + (l_m * 16))/8;
+            libxsmm_generator_gemm_apply_relu_to_vreg( io_generated_code, i_micro_kernel_config,
+              zero_vreg, reg_X, i_micro_kernel_config->fused_relu, relu_bitmask_gpr, bitmask_offset, 1, aux_gpr, aux_vreg);
+          } else if  (i_micro_kernel_config->fused_sigmoid == 1) {
+            unsigned int tmp_vreg = 0;
+            libxsmm_generator_gemm_apply_sigmoid_to_vreg_from_scratch( io_generated_code, i_micro_kernel_config_mod,
+                scratch_gpr, reg_X, tmp_vreg );
+            reg_X = tmp_vreg;
+          }
           libxsmm_x86_instruction_vec_compute_2reg( io_generated_code,
               LIBXSMM_X86_INSTR_VCVTNEPS2BF16,
               i_micro_kernel_config->vector_name,
@@ -1651,10 +2954,27 @@ void libxsmm_generator_gemm_store_C( libxsmm_generated_code*             io_gene
           unsigned int reg_X = l_vec_reg_acc_start + l_m + (l_m_blocking * l_n);
           unsigned int reg_X2 = l_vec_reg_acc_start + l_m+1 + (l_m_blocking * l_n);
 
+          if (i_micro_kernel_config->fused_sigmoid == 1) {
+            unsigned int tmp_vreg = 0;
+            unsigned int tmp_vreg2 = 1;
+            libxsmm_generator_gemm_apply_sigmoid_to_vreg_from_scratch( io_generated_code, i_micro_kernel_config_mod,
+                scratch_gpr, reg_X, tmp_vreg );
+            libxsmm_generator_gemm_apply_sigmoid_to_vreg_from_scratch( io_generated_code, i_micro_kernel_config_mod,
+                scratch_gpr, reg_X2, tmp_vreg2 );
+            reg_X  = tmp_vreg;
+            reg_X2 = tmp_vreg2;
+          }
+
           libxsmm_x86_instruction_vec_compute_3reg( io_generated_code,
               LIBXSMM_X86_INSTR_VCVTNE2PS2BF16,
               i_micro_kernel_config->vector_name,
               reg_X, reg_X2, 0 );
+
+          if ((i_micro_kernel_config->fused_relu_nobitmask == 1) || (i_micro_kernel_config->fused_relu == 1)) {
+            unsigned int bitmask_offset = (io_generated_code->arch < LIBXSMM_X86_AVX512) ? ((l_n * i_xgemm_desc->ldc) + (l_m * 8))/8 : ((l_n * i_xgemm_desc->ldc) + (l_m * 16))/8;
+            libxsmm_generator_gemm_apply_relu_to_vreg( io_generated_code, i_micro_kernel_config,
+              zero_vreg, 0, i_micro_kernel_config->fused_relu, relu_bitmask_gpr, bitmask_offset, 0, aux_gpr, aux_vreg);
+          }
 
           libxsmm_x86_instruction_vec_move( io_generated_code,
               i_micro_kernel_config->instruction_set,
@@ -1667,6 +2987,17 @@ void libxsmm_generator_gemm_store_C( libxsmm_generated_code*             io_gene
         }
         for (; l_m < l_m_blocking; l_m++ ) {
           unsigned int reg_X = l_vec_reg_acc_start + l_m + (l_m_blocking * l_n);
+
+          if ((i_micro_kernel_config->fused_relu_nobitmask == 1) || (i_micro_kernel_config->fused_relu == 1)) {
+            unsigned int bitmask_offset = (io_generated_code->arch < LIBXSMM_X86_AVX512) ? ((l_n * i_xgemm_desc->ldc) + (l_m * 8))/8 : ((l_n * i_xgemm_desc->ldc) + (l_m * 16))/8;
+            libxsmm_generator_gemm_apply_relu_to_vreg( io_generated_code, i_micro_kernel_config,
+              zero_vreg, reg_X, i_micro_kernel_config->fused_relu, relu_bitmask_gpr, bitmask_offset, 1, aux_gpr, aux_vreg);
+          } else if (i_micro_kernel_config->fused_sigmoid == 1) {
+            unsigned int tmp_vreg = 0;
+            libxsmm_generator_gemm_apply_sigmoid_to_vreg_from_scratch( io_generated_code, i_micro_kernel_config_mod,
+                scratch_gpr, reg_X, tmp_vreg );
+            reg_X = tmp_vreg;
+          }
 
           libxsmm_x86_instruction_vec_compute_2reg( io_generated_code,
               LIBXSMM_X86_INSTR_VCVTNEPS2BF16,
@@ -1684,6 +3015,13 @@ void libxsmm_generator_gemm_store_C( libxsmm_generated_code*             io_gene
         }
       }
     }
+
+    if ((i_micro_kernel_config->fused_relu_nobitmask == 1) || (i_micro_kernel_config->fused_relu == 1)) {
+      libxsmm_generator_gemm_cleanup_relu_fusion( io_generated_code, i_micro_kernel_config->fused_relu, relu_bitmask_gpr, aux_gpr);
+    } else if (i_micro_kernel_config->fused_sigmoid == 1) {
+      libxsmm_generator_gemm_cleanup_sigmoid_fusion( io_generated_code, scratch_gpr, aux_gpr );
+    }
+
   } else if ( ( (i_micro_kernel_config->instruction_set <= LIBXSMM_X86_ALLFEAT) && (i_micro_kernel_config->instruction_set >= LIBXSMM_X86_AVX512_VL256) ) &&
               ( (LIBXSMM_DATATYPE_I8 == LIBXSMM_GETENUM_INP( i_xgemm_desc->datatype ) ) && (LIBXSMM_DATATYPE_I8 == LIBXSMM_GETENUM_OUT( i_xgemm_desc->datatype ) ) ) ) {
     /* pick the right instrucitons */
@@ -1758,8 +3096,36 @@ void libxsmm_generator_gemm_store_C( libxsmm_generated_code*             io_gene
     }
   } else {
     /* storing C accumulator */
+    const unsigned int relu_bitmask_gpr = i_gp_reg_mapping->gp_reg_help_2;
+    const unsigned int scratch_gpr = i_gp_reg_mapping->gp_reg_help_2;
+    const unsigned int aux_gpr = i_gp_reg_mapping->gp_reg_help_1;
+    const unsigned int zero_vreg = 0;
+    const unsigned int aux_vreg  = 1;
+
+    /* Check out if fusion has to be applied  */
+    if ((i_micro_kernel_config->fused_relu_nobitmask == 1) || (i_micro_kernel_config->fused_relu == 1)) {
+      libxsmm_generator_gemm_prepare_relu_fusion( io_generated_code, i_micro_kernel_config,
+          zero_vreg, i_micro_kernel_config->fused_relu, relu_bitmask_gpr, aux_gpr);
+    } else if (i_micro_kernel_config->fused_sigmoid == 1) {
+      libxsmm_generator_gemm_dump_2D_block_and_prepare_sigmoid_fusion( io_generated_code, i_micro_kernel_config_mod,
+          l_vec_reg_acc_start, l_m_blocking, i_n_blocking, scratch_gpr, aux_gpr);
+    }
+
     for ( l_n = 0; l_n < i_n_blocking; l_n++ ) {
       for ( l_m = 0; l_m < l_m_blocking; l_m++ ) {
+        unsigned int reg_X = l_vec_reg_acc_start + l_m + (l_m_blocking * l_n);
+
+        if ((i_micro_kernel_config->fused_relu_nobitmask == 1) || (i_micro_kernel_config->fused_relu == 1)) {
+          unsigned int bitmask_offset = (io_generated_code->arch < LIBXSMM_X86_AVX512) ? ((l_n * i_xgemm_desc->ldc) + (l_m * 8))/8 : ((l_n * i_xgemm_desc->ldc) + (l_m * 16))/8;
+          libxsmm_generator_gemm_apply_relu_to_vreg( io_generated_code, i_micro_kernel_config,
+              zero_vreg, reg_X, i_micro_kernel_config->fused_relu, relu_bitmask_gpr, bitmask_offset, 1, aux_gpr, aux_vreg);
+        } else if (i_micro_kernel_config->fused_sigmoid == 1) {
+          unsigned int tmp_vreg = 0;
+          libxsmm_generator_gemm_apply_sigmoid_to_vreg_from_scratch( io_generated_code, i_micro_kernel_config_mod,
+              scratch_gpr, reg_X, tmp_vreg );
+          reg_X = tmp_vreg;
+        }
+
         libxsmm_x86_instruction_vec_move( io_generated_code,
             i_micro_kernel_config->instruction_set,
             l_vstore,
@@ -1767,7 +3133,7 @@ void libxsmm_generator_gemm_store_C( libxsmm_generated_code*             io_gene
             LIBXSMM_X86_GP_REG_UNDEF, 0,
             ((l_n * i_xgemm_desc->ldc) + (l_m * (i_micro_kernel_config->vector_length))) * (i_micro_kernel_config->datatype_size_out),
             i_micro_kernel_config->vector_name,
-            l_vec_reg_acc_start + l_m + (l_m_blocking * l_n), ( l_m == (l_m_blocking - 1) ) ? i_micro_kernel_config->use_masking_a_c : 0, 0, 1 );
+            reg_X, ( l_m == (l_m_blocking - 1) ) ? i_micro_kernel_config->use_masking_a_c : 0, 0, 1 );
       }
 
       if ( i_xgemm_desc->prefetch == LIBXSMM_GEMM_PREFETCH_BL2_VIA_C          ||
@@ -1786,6 +3152,12 @@ void libxsmm_generator_gemm_store_C( libxsmm_generated_code*             io_gene
           }
         }
       }
+    }
+
+    if ((i_micro_kernel_config->fused_relu_nobitmask == 1) || (i_micro_kernel_config->fused_relu == 1)) {
+      libxsmm_generator_gemm_cleanup_relu_fusion( io_generated_code, i_micro_kernel_config->fused_relu, relu_bitmask_gpr, aux_gpr );
+    } else if (i_micro_kernel_config->fused_sigmoid == 1) {
+      libxsmm_generator_gemm_cleanup_sigmoid_fusion( io_generated_code, scratch_gpr, aux_gpr );
     }
   }
 }

--- a/src/generator_gemm_common.h
+++ b/src/generator_gemm_common.h
@@ -6,13 +6,137 @@
 * Further information: https://github.com/hfp/libxsmm/                        *
 * SPDX-License-Identifier: BSD-3-Clause                                       *
 ******************************************************************************/
-/* Alexander Heinecke (Intel Corp.)
+/* Alexander Heinecke, Evangelos Georganas (Intel Corp.)
 ******************************************************************************/
 
 #ifndef GENERATOR_GEMM_COMMON_H
 #define GENERATOR_GEMM_COMMON_H
 
 #include "generator_common.h"
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_apply_relu_to_vreg( libxsmm_generated_code*             io_generated_code,
+    const libxsmm_micro_kernel_config* i_micro_kernel_config,
+    const unsigned int                 zero_vreg,
+    const unsigned int                 inout_vreg,
+    const unsigned int                 store_bitmask,
+    const unsigned int                 gpr_bitmask,
+    const unsigned int                 store_bitmask_offset,
+    const unsigned int                 is_32_bit_relu,
+    const unsigned int                 aux_gpr,
+    const unsigned int                 aux_vreg);
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_apply_sigmoid_to_vreg_from_scratch( libxsmm_generated_code*             io_generated_code,
+    libxsmm_micro_kernel_config*       i_micro_kernel_config_mod,
+    const unsigned int                 scratch_gpr,
+    const unsigned int                 in_vreg,
+    const unsigned int                 out_vreg );
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_restore_2D_regblock_from_scratch( libxsmm_generated_code*             io_generated_code,
+    const libxsmm_micro_kernel_config* i_micro_kernel_config,
+    const unsigned int                 scratch_gpr,
+    const unsigned int                 l_vec_reg_acc_start,
+    const unsigned int                 l_m_blocking,
+    const unsigned int                 i_n_blocking);
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_store_2D_regblock_to_scratch( libxsmm_generated_code*             io_generated_code,
+    const libxsmm_micro_kernel_config* i_micro_kernel_config,
+    const unsigned int                 scratch_gpr,
+    const unsigned int                 l_vec_reg_acc_start,
+    const unsigned int                 l_m_blocking,
+    const unsigned int                 i_n_blocking);
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_dump_2D_block_and_prepare_sigmoid_fusion( libxsmm_generated_code*             io_generated_code,
+    libxsmm_micro_kernel_config*       i_micro_kernel_config,
+    const unsigned int                 l_vec_reg_acc_start,
+    const unsigned int                 l_m_blocking,
+    const unsigned int                 i_n_blocking,
+    const unsigned int                 scratch_gpr,
+    const unsigned int                 aux_gpr);
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_prepare_relu_fusion( libxsmm_generated_code*             io_generated_code,
+    const libxsmm_micro_kernel_config* i_micro_kernel_config,
+    const unsigned int                 zero_vreg,
+    const unsigned int                 store_bitmask,
+    const unsigned int                 bitmask_gpr,
+    const unsigned int                 aux_gpr);
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_cleanup_relu_fusion( libxsmm_generated_code*             io_generated_code,
+    const unsigned int                 store_bitmask,
+    const unsigned int                 bitmask_gpr,
+    const unsigned int                 aux_gpr);
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_cleanup_sigmoid_fusion( libxsmm_generated_code*             io_generated_code,
+    const unsigned int                 scratch_gpr,
+    const unsigned int                 aux_gpr );
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_load_colbias_to_2D_block( libxsmm_generated_code*             io_generated_code,
+    const libxsmm_gp_reg_mapping*      i_gp_reg_mapping,
+    const libxsmm_micro_kernel_config* i_micro_kernel_config,
+    libxsmm_datatype                   colbias_precision,
+    const unsigned int                 l_vec_reg_acc_start,
+    const unsigned int                 l_m_blocking,
+    const unsigned int                 i_n_blocking );
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_add_colbias_to_2D_block( libxsmm_generated_code*             io_generated_code,
+    const libxsmm_gp_reg_mapping*      i_gp_reg_mapping,
+    const libxsmm_micro_kernel_config* i_micro_kernel_config,
+    libxsmm_datatype                   colbias_precision,
+    const unsigned int                 l_vec_reg_acc_start,
+    const unsigned int                 l_m_blocking,
+    const unsigned int                 i_n_blocking );
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_prepare_coeffs_sigmoid_ps_rational_78_avx_avx512( libxsmm_generated_code*                        io_generated_code,
+    libxsmm_micro_kernel_config*        i_micro_kernel_config,
+    unsigned int                        reserved_zmms,
+    unsigned int                        reserved_mask_regs,
+    unsigned int                        temp_reg );
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_setup_stack_frame_fill_stack_vars_v2( libxsmm_generated_code*            io_generated_code,
+    const libxsmm_gemm_descriptor*      i_xgemm_desc,
+    libxsmm_micro_kernel_config*        i_micro_kernel_config,
+    const libxsmm_gp_reg_mapping*       i_gp_reg_mapping );
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_setup_stack_frame_fill_stack_vars(libxsmm_generated_code*            io_generated_code,
+    const libxsmm_gemm_descriptor*      i_xgemm_desc,
+    libxsmm_micro_kernel_config*        i_micro_kernel_config);
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_setup_stack_frame_allocate_scratch( libxsmm_generated_code*            io_generated_code,
+    const libxsmm_gemm_descriptor*      i_xgemm_desc,
+    libxsmm_micro_kernel_config*        i_micro_kernel_config );
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_setup_stack_frame( libxsmm_generated_code*            io_generated_code,
+                                                  const libxsmm_gemm_descriptor*      i_xgemm_desc,
+                                                  const libxsmm_gp_reg_mapping*       i_gp_reg_mapping,
+                                                  libxsmm_micro_kernel_config*        i_micro_kernel_config );
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_destroy_stack_frame( libxsmm_generated_code*            io_generated_code,
+                                                  const libxsmm_gemm_descriptor*      i_xgemm_desc,
+                                                  const libxsmm_gp_reg_mapping*       i_gp_reg_mapping,
+                                                  const libxsmm_micro_kernel_config*  i_micro_kernel_config );
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_setup_fusion_microkernel_properties_v2(const libxsmm_gemm_descriptor*      i_xgemm_desc,
+                                                                libxsmm_micro_kernel_config*        i_micro_kernel_config );
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_gemm_setup_fusion_microkernel_properties(const libxsmm_gemm_descriptor*      i_xgemm_desc,
+                                                                libxsmm_micro_kernel_config*        i_micro_kernel_config );
 
 LIBXSMM_API_INTERN
 void libxsmm_generator_gemm_init_micro_kernel_config_fullvector( libxsmm_micro_kernel_config*   io_micro_kernel_config,

--- a/src/generator_gemm_sse_avx_avx2_avx512.c
+++ b/src/generator_gemm_sse_avx_avx2_avx512.c
@@ -209,14 +209,19 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
       libxsmm_x86_instruction_alu_mem( io_generated_code, l_micro_kernel_config.alu_mov_instruction,
                                        i_gp_reg_mapping->gp_reg_help_1, LIBXSMM_X86_GP_REG_UNDEF, 0, 112, i_gp_reg_mapping->gp_reg_scf, 0 );
     }
-    /* check values for gemm_ext */
-    if ( ((LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI) ) {
-      if ( (i_xgemm_desc->meltw_operation != LIBXSMM_MELTW_OPERATION_NONE) || (i_xgemm_desc->eltw_ap_op != LIBXSMM_MELTW_OPERATION_NONE) ||
-           (i_xgemm_desc->eltw_bp_op != LIBXSMM_MELTW_OPERATION_NONE) || (i_xgemm_desc->eltw_cp_op != LIBXSMM_MELTW_OPERATION_NONE) ) {
-        LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_INVALID_GEMM_CONFIG );
-        return;
-      }
+  }
+
+  if ( ((LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI) ) {
+    /* For now disable fusion for < AVX archs  */
+    if ( (io_generated_code->arch < LIBXSMM_X86_AVX) &&
+         ((i_xgemm_desc->meltw_operation != LIBXSMM_MELTW_OPERATION_NONE) ||
+          (i_xgemm_desc->eltw_ap_op != LIBXSMM_MELTW_OPERATION_NONE) ||
+          (i_xgemm_desc->eltw_bp_op != LIBXSMM_MELTW_OPERATION_NONE) ||
+          (i_xgemm_desc->eltw_cp_op != LIBXSMM_MELTW_OPERATION_NONE) ) ) {
+      LIBXSMM_HANDLE_ERROR( io_generated_code, LIBXSMM_ERR_UNSUP_ARCH );
+      return;
     }
+    libxsmm_generator_gemm_setup_stack_frame( io_generated_code, i_xgemm_desc, i_gp_reg_mapping, &l_micro_kernel_config);
   }
 
   /* generate hoisted BF16 emulation mask for AVX512 */
@@ -496,6 +501,10 @@ LIBXSMM_API_INTERN void libxsmm_generator_gemm_sse_avx_avx2_avx512_kernel( libxs
       l_m_blocking = libxsmm_generator_gemm_sse_avx_avx2_avx512_update_m_blocking( &l_micro_kernel_config, i_xgemm_desc, io_generated_code->arch, l_m_blocking );
     }
     libxsmm_generator_gemm_footer_nloop( io_generated_code, io_loop_label_tracker, i_gp_reg_mapping, &l_micro_kernel_config, i_xgemm_desc, l_n_blocking, l_n_done );
+  }
+
+  if ( ((LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI & i_xgemm_desc->flags) == LIBXSMM_GEMM_FLAG_USE_XGEMM_EXT_ABI) ) {
+    libxsmm_generator_gemm_destroy_stack_frame( io_generated_code, i_xgemm_desc, i_gp_reg_mapping, &l_micro_kernel_config );
   }
 }
 

--- a/src/generator_matequation_aarch64.c
+++ b/src/generator_matequation_aarch64.c
@@ -65,63 +65,95 @@ int libxsmm_generator_mateqn_get_fp_relative_offset( libxsmm_meqn_stack_var stac
 
   switch ( stack_var ) {
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR0:
-      return -128;
+      return -256;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR1:
-      return -120;
+      return -248;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR2:
-      return -112;
+      return -240;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR3:
-      return -104;
+      return -232;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR4:
-      return -96;
+      return -224;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR5:
-      return -88;
+      return -216;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR6:
-      return -80;
+      return -208;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR7:
-      return -72;
+      return -200;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR8:
-      return -64;
+      return -192;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR9:
-      return -56;
+      return -184;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR10:
-      return -48;
+      return -176;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR11:
-      return -40;
+      return -168;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR12:
-      return -32;
+      return -160;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR13:
-      return -24;
+      return -152;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR14:
-      return -16;
+      return -144;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR15:
+      return -136;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR16:
+      return -128;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR17:
+      return -120;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR18:
+      return -112;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR19:
+      return -104;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR20:
+      return -96;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR21:
+      return -88;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR22:
+      return -80;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR23:
+      return -72;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR24:
+      return -64;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR25:
+      return -56;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR26:
+      return -48;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR27:
+      return -40;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR28:
+      return -32;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR29:
+      return -24;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR30:
+      return -16;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR31:
       return -8;
     case LIBXSMM_MEQN_STACK_VAR_SCRATCH_PTR:
-      return -136;
+      return -264;
     case LIBXSMM_MEQN_STACK_VAR_ADDR_SCRATCH_PTR:
-      return -144;
+      return -272;
     case LIBXSMM_MEQN_STACK_VAR_OUT_PTR:
-      return -152;
+      return -280;
     case LIBXSMM_MEQN_STACK_VAR_CONST_0:
-      return -160;
+      return -288;
     case LIBXSMM_MEQN_STACK_VAR_CONST_1:
-      return -168;
+      return -296;
     case LIBXSMM_MEQN_STACK_VAR_CONST_2:
-      return -176;
+      return -304;
     case LIBXSMM_MEQN_STACK_VAR_CONST_3:
-      return -184;
+      return -312;
     case LIBXSMM_MEQN_STACK_VAR_CONST_4:
-      return -192;
+      return -320;
     case LIBXSMM_MEQN_STACK_VAR_CONST_5:
-      return -200;
+      return -328;
     case LIBXSMM_MEQN_STACK_VAR_CONST_6:
-      return -208;
+      return -336;
     case LIBXSMM_MEQN_STACK_VAR_CONST_7:
-      return -216;
+      return -344;
     case LIBXSMM_MEQN_STACK_VAR_CONST_8:
-      return -224;
+      return -352;
     case LIBXSMM_MEQN_STACK_VAR_CONST_9:
-      return -232;
+      return -360;
     default:
       return 0;
   }
@@ -205,7 +237,7 @@ void libxsmm_generator_matequation_setup_stack_frame_aarch64( libxsmm_generated_
   libxsmm_aarch64_instruction_alu_compute_shifted_reg( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_ORR_SR, LIBXSMM_AARCH64_GP_REG_XSP, LIBXSMM_AARCH64_GP_REG_XSP, LIBXSMM_AARCH64_GP_REG_X29, 0, LIBXSMM_AARCH64_SHIFTMODE_LSL );
 #endif
   libxsmm_aarch64_instruction_alu_compute_imm12( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_ADD_I, LIBXSMM_AARCH64_GP_REG_XSP, LIBXSMM_AARCH64_GP_REG_X29, 0, 0 );
-  libxsmm_aarch64_instruction_alu_compute_imm12( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_SUB_I, LIBXSMM_AARCH64_GP_REG_XSP, LIBXSMM_AARCH64_GP_REG_XSP, 232, 0 );
+  libxsmm_aarch64_instruction_alu_compute_imm12( io_generated_code, LIBXSMM_AARCH64_INSTR_GP_SUB_I, LIBXSMM_AARCH64_GP_REG_XSP, LIBXSMM_AARCH64_GP_REG_XSP, 360, 0 );
 
   /* The stack at exit of setup looks like this:
    *

--- a/src/generator_matequation_avx_avx512.c
+++ b/src/generator_matequation_avx_avx512.c
@@ -18,6 +18,7 @@
 #include "generator_common.h"
 #include "libxsmm_main.h"
 #include "generator_common_x86.h"
+#include "libxsmm_matrixeqn.h"
 
 LIBXSMM_API_INTERN
 void libxsmm_generator_matequation_init_micro_kernel_config( libxsmm_generated_code*         io_generated_code,
@@ -81,63 +82,95 @@ int libxsmm_generator_mateqn_get_rbp_relative_offset( libxsmm_meqn_stack_var sta
 
   switch ( stack_var ) {
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR0:
-      return -128;
+      return -256;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR1:
-      return -120;
+      return -248;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR2:
-      return -112;
+      return -240;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR3:
-      return -104;
+      return -232;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR4:
-      return -96;
+      return -224;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR5:
-      return -88;
+      return -216;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR6:
-      return -80;
+      return -208;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR7:
-      return -72;
+      return -200;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR8:
-      return -64;
+      return -192;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR9:
-      return -56;
+      return -184;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR10:
-      return -48;
+      return -176;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR11:
-      return -40;
+      return -168;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR12:
-      return -32;
+      return -160;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR13:
-      return -24;
+      return -152;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR14:
-      return -16;
+      return -144;
     case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR15:
+      return -136;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR16:
+      return -128;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR17:
+      return -120;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR18:
+      return -112;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR19:
+      return -104;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR20:
+      return -96;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR21:
+      return -88;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR22:
+      return -80;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR23:
+      return -72;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR24:
+      return -64;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR25:
+      return -56;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR26:
+      return -48;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR27:
+      return -40;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR28:
+      return -32;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR29:
+      return -24;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR30:
+      return -16;
+    case LIBXSMM_MEQN_STACK_VAR_PARAM_STRUCT_PTR31:
       return -8;
     case LIBXSMM_MEQN_STACK_VAR_SCRATCH_PTR:
-      return -136;
+      return -264;
     case LIBXSMM_MEQN_STACK_VAR_ADDR_SCRATCH_PTR:
-      return -144;
+      return -272;
     case LIBXSMM_MEQN_STACK_VAR_OUT_PTR:
-      return -152;
+      return -280;
     case LIBXSMM_MEQN_STACK_VAR_CONST_0:
-      return -160;
+      return -288;
     case LIBXSMM_MEQN_STACK_VAR_CONST_1:
-      return -168;
+      return -296;
     case LIBXSMM_MEQN_STACK_VAR_CONST_2:
-      return -176;
+      return -304;
     case LIBXSMM_MEQN_STACK_VAR_CONST_3:
-      return -184;
+      return -312;
     case LIBXSMM_MEQN_STACK_VAR_CONST_4:
-      return -192;
+      return -320;
     case LIBXSMM_MEQN_STACK_VAR_CONST_5:
-      return -200;
+      return -328;
     case LIBXSMM_MEQN_STACK_VAR_CONST_6:
-      return -208;
+      return -336;
     case LIBXSMM_MEQN_STACK_VAR_CONST_7:
-      return -216;
+      return -344;
     case LIBXSMM_MEQN_STACK_VAR_CONST_8:
-      return -224;
+      return -352;
     case LIBXSMM_MEQN_STACK_VAR_CONST_9:
-      return -232;
+      return -360;
     default:
       return 0;
   }
@@ -216,7 +249,7 @@ void libxsmm_generator_matequation_setup_stack_frame( libxsmm_generated_code*   
   i_micro_kernel_config->skip_pushpops_callee_gp_reg = skip_pushpops_callee_gp_reg;
   libxsmm_x86_instruction_push_reg( io_generated_code, LIBXSMM_X86_GP_REG_RBP );
   libxsmm_x86_instruction_alu_reg( io_generated_code, i_micro_kernel_config->alu_mov_instruction, LIBXSMM_X86_GP_REG_RSP, LIBXSMM_X86_GP_REG_RBP);
-  libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_sub_instruction, LIBXSMM_X86_GP_REG_RSP, 232 );
+  libxsmm_x86_instruction_alu_imm( io_generated_code, i_micro_kernel_config->alu_sub_instruction, LIBXSMM_X86_GP_REG_RSP, 360 );
 
   /* The stack at exit of setup looks like this:
    *
@@ -393,7 +426,36 @@ libxsmm_matrix_eqn_elem* find_op_at_timestamp(libxsmm_matrix_eqn_elem* cur_node,
 }
 
 LIBXSMM_API_INTERN
-int is_eqn_node_breaking_point(libxsmm_matrix_eqn_elem *node) {
+int is_xgemm_node_supporting_fusion(libxsmm_matrix_eqn_elem  *xgemm_node) {
+  int result = 0;
+  if (((xgemm_node->le->tmp.dtype == LIBXSMM_DATATYPE_BF16) && (xgemm_node->ri->tmp.dtype == LIBXSMM_DATATYPE_BF16)) ||
+      ((xgemm_node->le->tmp.dtype == LIBXSMM_DATATYPE_F32) && (xgemm_node->ri->tmp.dtype == LIBXSMM_DATATYPE_F32))) {
+    result = 1;
+  }
+  return result;
+}
+
+LIBXSMM_API_INTERN
+int is_xgemm_node(libxsmm_matrix_eqn_elem  *cur_node) {
+  int result = 0;
+  if ( cur_node->type == LIBXSMM_MATRIX_EQN_NODE_BINARY ) {
+    if ( (cur_node->info.b_op.is_matmul  == 1) ||
+         (cur_node->info.b_op.is_brgemm  == 1)) {
+      result = 1;
+    }
+  } else if ( cur_node->type == LIBXSMM_MATRIX_EQN_NODE_TERNARY ) {
+    if ( (cur_node->info.t_op.is_matmul == 1) ||
+         (cur_node->info.t_op.is_brgemm == 1) ) {
+      result = 1;
+    }
+  } else {
+    result = 0;
+  }
+  return result;
+}
+
+LIBXSMM_API_INTERN
+int is_eqn_node_breaking_point(libxsmm_matrix_eqn_elem *node, libxsmm_matrix_eqn_fusion_knobs *fusion_knobs) {
   int result = 0;
   if (node->type == LIBXSMM_MATRIX_EQN_NODE_UNARY) {
     if ( node->info.u_op.type  == LIBXSMM_MELTW_TYPE_UNARY_TANH ||
@@ -409,16 +471,30 @@ int is_eqn_node_breaking_point(libxsmm_matrix_eqn_elem *node) {
       result = 1;
     }
   }
-  if (node->type == LIBXSMM_MATRIX_EQN_NODE_BINARY) {
-    if ( node->info.b_op.type  == LIBXSMM_MELTW_TYPE_BINARY_MATMUL) {
-      result = 1;
+
+  if (is_xgemm_node(node) > 0) {
+    result = 1;
+  }
+
+  /* Allow to break this in order to enable potential fusion of colbias add in BRGEMM */
+  if ((node->type == LIBXSMM_MATRIX_EQN_NODE_BINARY) && (node->info.b_op.type == LIBXSMM_MELTW_TYPE_BINARY_ADD) && (fusion_knobs->may_fuse_xgemm > 0)) {
+    if (is_xgemm_node(node->le) > 0) {
+      if (is_xgemm_node_supporting_fusion(node->le) > 0) {
+        if ((node->info.b_op.flags & LIBXSMM_MELTW_FLAG_BINARY_BCAST_COL_IN_1) > 0){
+          result = 1;
+        }
+      }
+    } else if (is_xgemm_node(node->ri) > 0) {
+      if (is_xgemm_node_supporting_fusion(node->ri) > 0) {
+        if ((node->info.b_op.flags & LIBXSMM_MELTW_FLAG_BINARY_BCAST_COL_IN_0) > 0){
+          result = 1;
+        }
+      }
+    } else {
+      /* Do nothing  */
     }
   }
-  if (node->type == LIBXSMM_MATRIX_EQN_NODE_TERNARY) {
-    if ( node->info.t_op.type  == LIBXSMM_MELTW_TYPE_TERNARY_MATMUL) {
-      result = 1;
-    }
-  }
+
   return result;
 }
 
@@ -528,31 +604,206 @@ LIBXSMM_API_INTERN int is_ternary_bcast_arg_an_inputarg(libxsmm_bitfield flags, 
 }
 
 LIBXSMM_API_INTERN
-void libxsmm_generator_decompose_equation_tree( libxsmm_matrix_eqn *eqn, libxsmm_matrix_eqn **jiting_queue, unsigned int *queue_size ) {
-  libxsmm_matrix_eqn_elem *root = eqn->eqn_root;
-  unsigned int last_timestamp = eqn->eqn_root->visit_timestamp, timestamp = 0;
+libxsmm_matrix_eqn_fusion_pattern_type find_xgemm_fusion_pattern_with_ancestors(libxsmm_matrix_eqn_elem *xgemm_node) {
+  libxsmm_matrix_eqn_fusion_pattern_type result = LIBXSMM_MATRIX_EQN_FUSION_PATTERN_NONE;
+  if(xgemm_node->up != NULL) {
+    if (xgemm_node->up->type == LIBXSMM_MATRIX_EQN_NODE_BINARY) {
+      libxsmm_matrix_eqn_elem     *sibling_node = NULL;
+      libxsmm_meltw_binary_flags  bcast_flag = LIBXSMM_MELTW_FLAG_BINARY_NONE;
+      if (xgemm_node->up->le == xgemm_node) {
+        sibling_node = xgemm_node->up->ri;
+        bcast_flag = LIBXSMM_MELTW_FLAG_BINARY_BCAST_COL_IN_1;
+      } else {
+        sibling_node = xgemm_node->up->le;
+        bcast_flag = LIBXSMM_MELTW_FLAG_BINARY_BCAST_COL_IN_0;
+      }
+      if ((xgemm_node->up->info.b_op.type == LIBXSMM_MELTW_TYPE_BINARY_ADD) &&
+          (sibling_node->type == LIBXSMM_MATRIX_EQN_NODE_ARG) &&
+          ((xgemm_node->up->info.b_op.flags & bcast_flag) == bcast_flag)) {
+        /* For sure have add  colbias node above */
+        if(xgemm_node->up->up != NULL) {
+          if ((xgemm_node->up->up->type == LIBXSMM_MATRIX_EQN_NODE_UNARY) &&
+              ((xgemm_node->up->up->info.u_op.type == LIBXSMM_MELTW_TYPE_UNARY_RELU) ||
+               (xgemm_node->up->up->info.u_op.type == LIBXSMM_MELTW_TYPE_UNARY_SIGMOID)) ) {
+            result = LIBXSMM_MATRIX_EQN_FUSION_PATTERN_XGEMM_COLBIAS_ADD_UNARY;
+          } else {
+            result = LIBXSMM_MATRIX_EQN_FUSION_PATTERN_XGEMM_COLBIAS_ADD;
+          }
+        } else {
+          result = LIBXSMM_MATRIX_EQN_FUSION_PATTERN_XGEMM_COLBIAS_ADD;
+        }
+      }
+    } else if (xgemm_node->up->type == LIBXSMM_MATRIX_EQN_NODE_UNARY) {
+      if ( (xgemm_node->up->info.u_op.type == LIBXSMM_MELTW_TYPE_UNARY_RELU) ||
+           (xgemm_node->up->info.u_op.type == LIBXSMM_MELTW_TYPE_UNARY_SIGMOID) ) {
+        result = LIBXSMM_MATRIX_EQN_FUSION_PATTERN_XGEMM_UNARY;
+      }
+    } else {
+      /* Do nothing...  */
+    }
+  }
+  return result;
+}
 
-  for (timestamp = 0; timestamp <= last_timestamp; timestamp++) {
+
+LIBXSMM_API_INTERN
+libxsmm_matrix_eqn_fusion_pattern_type find_fusion_pattern_with_ancestors(libxsmm_matrix_eqn_elem *cur_node, libxsmm_matrix_eqn_fusion_knobs *fusion_knobs) {
+  libxsmm_matrix_eqn_fusion_pattern_type result = LIBXSMM_MATRIX_EQN_FUSION_PATTERN_NONE;
+  /* Check for xgemm fusion patterns*/
+  if ((is_xgemm_node(cur_node) > 0) && (fusion_knobs->may_fuse_xgemm > 0) ) {
+    if (is_xgemm_node_supporting_fusion(cur_node) > 0) {
+      result = find_xgemm_fusion_pattern_with_ancestors( cur_node );
+    }
+  }
+  return result;
+}
+
+LIBXSMM_API_INTERN
+int find_in_pos_for_colbias(libxsmm_matrix_eqn_elem *colbias_add_node) {
+  int result = 0;
+  if (colbias_add_node->le->type == LIBXSMM_MATRIX_EQN_NODE_ARG) {
+    result = colbias_add_node->le->info.arg.in_pos;
+  } else {
+    result = colbias_add_node->ri->info.arg.in_pos;
+  }
+  return result;
+}
+
+LIBXSMM_API_INTERN
+libxsmm_datatype find_dtype_for_colbias(libxsmm_matrix_eqn_elem *colbias_add_node) {
+  libxsmm_datatype result = LIBXSMM_DATATYPE_F32;
+  if (colbias_add_node->le->type == LIBXSMM_MATRIX_EQN_NODE_ARG) {
+    result = colbias_add_node->le->info.arg.dtype;
+  } else {
+    result = colbias_add_node->ri->info.arg.dtype;
+  }
+  return result;
+}
+
+LIBXSMM_API_INTERN
+void apply_xgemm_fusion_pattern_transformation(libxsmm_matrix_eqn_fusion_pattern_type fusion_pattern,
+                                               libxsmm_matrix_eqn_elem                *cur_node,
+                                               libxsmm_matrix_eqn_elem                *new_arg_node,
+                                               unsigned int                           *timestamp,
+                                               unsigned int                           last_timestamp ) {
+  if (fusion_pattern == LIBXSMM_MATRIX_EQN_FUSION_PATTERN_XGEMM_COLBIAS_ADD) {
+    /* Collapse parent ADD node and enhance info in GEMM node */
+    if (libxsmm_verbosity < 0) {
+      fprintf( stderr, "Fusing XGEMM with column-bias ADD\n");
+    }
+    cur_node->fusion_info.xgemm.fused_colbias_add_op = 1;
+    cur_node->fusion_info.xgemm.colbias_pos_in_arg = find_in_pos_for_colbias(cur_node->up);
+    cur_node->fusion_info.xgemm.colbias_dtype = find_dtype_for_colbias(cur_node->up);
+    (*timestamp)++;
+    if (*timestamp < last_timestamp) {
+      new_arg_node->up = cur_node->up->up;
+      if (cur_node->up->up->le == cur_node->up) {
+        cur_node->up->up->le = new_arg_node;
+      } else if (cur_node->up->up->ri == cur_node->up) {
+        cur_node->up->up->ri = new_arg_node;
+      } else {
+        cur_node->up->up->r2 = new_arg_node;
+      }
+    }
+  } else if (fusion_pattern == LIBXSMM_MATRIX_EQN_FUSION_PATTERN_XGEMM_COLBIAS_ADD_UNARY) {
+    /* Collapse parent ADD node & UNARY NODE and enhance info in GEMM node */
+    if (cur_node->up->up->info.u_op.type == LIBXSMM_MELTW_TYPE_UNARY_RELU) {
+      cur_node->fusion_info.xgemm.fused_relu_op = 1;
+      if (libxsmm_verbosity < 0) {
+        fprintf( stderr, "Fusing XGEMM with column-bias ADD and unary RELU\n");
+      }
+    }
+    if (cur_node->up->up->info.u_op.type == LIBXSMM_MELTW_TYPE_UNARY_SIGMOID) {
+      cur_node->fusion_info.xgemm.fused_sigmoid_op = 1;
+      if (libxsmm_verbosity < 0) {
+        fprintf( stderr, "Fusing XGEMM with column-bias ADD and unary SIGMOID\n");
+      }
+    }
+    cur_node->fusion_info.xgemm.fused_colbias_add_op = 1;
+    cur_node->fusion_info.xgemm.colbias_pos_in_arg = find_in_pos_for_colbias(cur_node->up);
+    cur_node->fusion_info.xgemm.colbias_dtype = find_dtype_for_colbias(cur_node->up);
+    (*timestamp) += 2;
+    if (*timestamp < last_timestamp) {
+      new_arg_node->up = cur_node->up->up->up;
+      if (cur_node->up->up->up->le == cur_node->up->up) {
+        cur_node->up->up->up->le = new_arg_node;
+      } else if (cur_node->up->up->up->ri == cur_node->up->up)  {
+        cur_node->up->up->up->ri = new_arg_node;
+      } else {
+        cur_node->up->up->up->r2 = new_arg_node;
+      }
+    }
+  } else if (fusion_pattern == LIBXSMM_MATRIX_EQN_FUSION_PATTERN_XGEMM_UNARY) {
+    /* Collapse parent UNARY node and enhance info in GEMM node */
+    if (cur_node->up->info.u_op.type == LIBXSMM_MELTW_TYPE_UNARY_RELU) {
+      cur_node->fusion_info.xgemm.fused_relu_op = 1;
+      if (libxsmm_verbosity < 0) {
+        fprintf( stderr, "Fusing XGEMM with unary RELU\n");
+      }
+    }
+    if (cur_node->up->info.u_op.type == LIBXSMM_MELTW_TYPE_UNARY_SIGMOID) {
+      cur_node->fusion_info.xgemm.fused_sigmoid_op = 1;
+      if (libxsmm_verbosity < 0) {
+        fprintf( stderr, "Fusing XGEMM with unary SIGMOID\n");
+      }
+    }
+    (*timestamp)++;
+    if (*timestamp < last_timestamp) {
+      new_arg_node->up = cur_node->up->up;
+      if (cur_node->up->up->le == cur_node->up) {
+        cur_node->up->up->le = new_arg_node;
+      } else if (cur_node->up->up->ri == cur_node->up)  {
+        cur_node->up->up->ri = new_arg_node;
+      } else {
+        cur_node->up->up->r2 = new_arg_node;
+      }
+    }
+  } else {
+    /* Should not happen  */
+  }
+}
+
+LIBXSMM_API_INTERN
+void apply_fusion_pattern_transformation(libxsmm_matrix_eqn_fusion_pattern_type fusion_pattern,
+                                               libxsmm_matrix_eqn_elem                *cur_node,
+                                               libxsmm_matrix_eqn_elem                *new_arg_node,
+                                               unsigned int                           *timestamp,
+                                               unsigned int                           last_timestamp ) {
+  if (is_xgemm_node(cur_node) > 0) {
+    apply_xgemm_fusion_pattern_transformation(fusion_pattern, cur_node, new_arg_node, timestamp, last_timestamp );
+  }
+}
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_decompose_equation_tree_x86( libxsmm_matrix_eqn *eqn, libxsmm_matrix_eqn **jiting_queue, unsigned int *queue_size, libxsmm_matrix_eqn_fusion_knobs *fusion_knobs) {
+  libxsmm_matrix_eqn_elem *root = eqn->eqn_root;
+  unsigned int last_timestamp = eqn->eqn_root->visit_timestamp;
+  unsigned int timestamp = 0;
+
+  for (timestamp = 0; timestamp <= last_timestamp;) {
     libxsmm_matrix_eqn_elem *cur_node = find_op_at_timestamp(root, timestamp);
-    if ( (timestamp < last_timestamp) && ((is_eqn_node_breaking_point(cur_node) > 0) || (is_eqn_node_breaking_point(cur_node->up) > 0) ||
+    if (timestamp == last_timestamp) {
+      enqueue_equation(eqn, jiting_queue, queue_size);
+    }
+    if ( (timestamp < last_timestamp) && ((is_eqn_node_breaking_point(cur_node, fusion_knobs) > 0) || (is_eqn_node_breaking_point(cur_node->up, fusion_knobs) > 0) ||
                                            ((cur_node->type == LIBXSMM_MATRIX_EQN_NODE_UNARY) && (is_unary_opcode_reduce_to_scalar(cur_node->info.u_op.type) > 0)) ||
                                            ((cur_node->type == LIBXSMM_MATRIX_EQN_NODE_BINARY) && (is_binary_opcode_reduce_to_scalar(cur_node->info.b_op.type) > 0)) ||
                                            ((cur_node->up->type == LIBXSMM_MATRIX_EQN_NODE_UNARY) && (is_unary_with_bcast(cur_node->up->info.u_op.flags) > 0) && (is_unary_bcast_arg_an_inputarg(cur_node->up->info.u_op.flags, cur_node->up) == 0) ) ||
                                            ((cur_node->up->type == LIBXSMM_MATRIX_EQN_NODE_BINARY) && (is_binary_with_bcast(cur_node->up->info.b_op.flags) > 0) && (is_binary_bcast_arg_an_inputarg(cur_node->up->info.b_op.flags, cur_node->up) == 0)) ||
                                            ((cur_node->up->type == LIBXSMM_MATRIX_EQN_NODE_TERNARY) && (is_ternary_with_bcast(cur_node->up->info.t_op.flags) > 0) && (is_ternary_bcast_arg_an_inputarg(cur_node->up->info.t_op.flags, cur_node->up) == 0)))) {
 
-      libxsmm_matrix_eqn_elem       *new_arg_node = (libxsmm_matrix_eqn_elem*) malloc( sizeof(libxsmm_matrix_eqn_elem) );
-      libxsmm_matrix_eqn            *new_eqn      = (libxsmm_matrix_eqn*) malloc( sizeof(libxsmm_matrix_eqn) );
+      libxsmm_matrix_eqn_fusion_pattern_type fusion_pattern = LIBXSMM_MATRIX_EQN_FUSION_PATTERN_NONE;
+      libxsmm_matrix_eqn_elem                *new_arg_node  = (libxsmm_matrix_eqn_elem*) malloc( sizeof(libxsmm_matrix_eqn_elem) );
+      libxsmm_matrix_eqn                     *new_eqn       = (libxsmm_matrix_eqn*) malloc( sizeof(libxsmm_matrix_eqn) );
       union libxsmm_matrix_eqn_info info;
       info.arg.m = cur_node->tmp.m;
       info.arg.n = cur_node->tmp.n;
       info.arg.ld = cur_node->tmp.ld;
-      info.arg.in_pos = -(cur_node->tmp.id + 1);
+      info.arg.in_pos = -(cur_node->tmp.id + 1);  /*(cur_node->tmp.id >= 0) ? -(cur_node->tmp.id + 1) : cur_node->tmp.id;*/
       info.arg.dtype = cur_node->tmp.dtype;
       new_arg_node->le = NULL;
       new_arg_node->ri = NULL;
       new_arg_node->r2 = NULL;
-      new_arg_node->up = cur_node->up;
       new_arg_node->type = LIBXSMM_MATRIX_EQN_NODE_ARG;
       new_arg_node->info = info;
       new_arg_node->reg_score = 0;
@@ -560,21 +811,25 @@ void libxsmm_generator_decompose_equation_tree( libxsmm_matrix_eqn *eqn, libxsmm
       new_arg_node->tmp.m = cur_node->tmp.m;
       new_arg_node->tmp.n = cur_node->tmp.n;
       new_arg_node->tmp.ld = cur_node->tmp.ld;
+      fusion_pattern = find_fusion_pattern_with_ancestors( cur_node, fusion_knobs );
 
-      if (cur_node->up->le == cur_node) {
-        cur_node->up->le = new_arg_node;
-      } else if (cur_node->up->ri == cur_node)  {
-        cur_node->up->ri = new_arg_node;
+      if (fusion_pattern != LIBXSMM_MATRIX_EQN_FUSION_PATTERN_NONE) {
+        apply_fusion_pattern_transformation( fusion_pattern, cur_node, new_arg_node, &timestamp, last_timestamp );
       } else {
-        cur_node->up->r2 = new_arg_node;
+        new_arg_node->up = cur_node->up;
+        if (cur_node->up->le == cur_node) {
+          cur_node->up->le = new_arg_node;
+        } else if (cur_node->up->ri == cur_node)  {
+          cur_node->up->ri = new_arg_node;
+        } else {
+          cur_node->up->r2 = new_arg_node;
+        }
       }
       new_eqn->eqn_root = cur_node;
       new_eqn->is_constructed = 1;
       enqueue_equation(new_eqn, jiting_queue, queue_size);
     }
-    if (timestamp == last_timestamp) {
-      enqueue_equation(eqn, jiting_queue, queue_size);
-    }
+    timestamp++;
   }
 }
 
@@ -612,6 +867,8 @@ void libxsmm_generator_matequation_avx_avx512_kernel( libxsmm_generated_code*   
   unsigned int eqn_tree_id = 0;
   unsigned int temp_reg = LIBXSMM_X86_GP_REG_R8;
   unsigned int all_nodes_f32 = 1;
+  libxsmm_matrix_eqn_fusion_knobs fusion_knobs;
+  memset(&fusion_knobs, 0, sizeof(libxsmm_matrix_eqn_fusion_knobs));
 
   if ( eqn == NULL ) {
     fprintf( stderr, "The requested equation doesn't exist... nothing to JIT,,,\n" );
@@ -655,7 +912,11 @@ void libxsmm_generator_matequation_avx_avx512_kernel( libxsmm_generated_code*   
 
   jiting_queue = (libxsmm_matrix_eqn**) malloc(max_queue_size * sizeof(libxsmm_matrix_eqn*));
 
-  libxsmm_generator_decompose_equation_tree( eqn, jiting_queue, &queue_size );
+  /* Turn on fusion knobs given arch  */
+  if (io_generated_code->arch >= LIBXSMM_X86_AVX) {
+    fusion_knobs.may_fuse_xgemm = 1;
+  }
+  libxsmm_generator_decompose_equation_tree_x86( eqn, jiting_queue, &queue_size, &fusion_knobs);
 
   /* Open asm */
   libxsmm_x86_instruction_open_stream_v2( io_generated_code, l_gp_reg_mapping.gp_reg_param_struct, 1 );
@@ -671,7 +932,25 @@ void libxsmm_generator_matequation_avx_avx512_kernel( libxsmm_generated_code*   
     if (eqn_tree_id == (queue_size - 1)) {
       libxsmm_generator_meqn_getval_stack_var( io_generated_code, LIBXSMM_MEQN_STACK_VAR_OUT_PTR, temp_reg);
     } else {
-      libxsmm_generator_meqn_getaddr_stack_tmp_i( io_generated_code,  cur_eqn->eqn_root->tmp.id * l_kernel_config.tmp_size, temp_reg);
+      if (cur_eqn->eqn_root->tmp.id >= 0) {
+        libxsmm_generator_meqn_getaddr_stack_tmp_i( io_generated_code,  cur_eqn->eqn_root->tmp.id * l_kernel_config.tmp_size, temp_reg);
+      } else {
+        libxsmm_blasint arg_tmp_id = -1-cur_eqn->eqn_root->tmp.id;
+        libxsmm_x86_instruction_alu_mem( io_generated_code,
+            l_kernel_config.alu_mov_instruction,
+            l_gp_reg_mapping.gp_reg_param_struct,
+            LIBXSMM_X86_GP_REG_UNDEF, 0,
+            8,
+            temp_reg,
+            0 );
+        libxsmm_x86_instruction_alu_mem( io_generated_code,
+            l_kernel_config.alu_mov_instruction,
+            temp_reg,
+            LIBXSMM_X86_GP_REG_UNDEF, 0,
+            arg_tmp_id*24,
+            temp_reg,
+            0 );
+      }
       copy_mateqn_desc.datatype = cur_eqn->eqn_root->tmp.dtype;
     }
 
@@ -683,17 +962,22 @@ void libxsmm_generator_matequation_avx_avx512_kernel( libxsmm_generated_code*   
         temp_reg,
         1 );
 
-    if (is_eqn_node_breaking_point(cur_eqn->eqn_root) > 0) {
+    if (is_eqn_node_breaking_point(cur_eqn->eqn_root, &fusion_knobs) > 0) {
       /* For these nodes use strategy via scratch  */
       /* Re assign visit_stamps to current equation tree  */
       libxsmm_generator_matequation_assign_timestamps(cur_eqn);
+      if (eqn_tree_id < queue_size - 1) {
+        if ((cur_eqn->eqn_root->type == LIBXSMM_MATRIX_EQN_NODE_TERNARY) &&
+            ((cur_eqn->eqn_root->info.t_op.is_matmul == 1) || (cur_eqn->eqn_root->info.t_op.is_brgemm == 1))) {
+          copy_mateqn_desc.ldo = cur_eqn->eqn_root->tmp.ld;
+        } else {
+          copy_mateqn_desc.ldo = cur_eqn->eqn_root->tmp.m;
+        }
+      }
 #if 0
-      printf("\nJITing tree with scratch %d\n", eqn_tree_id);
+      printf("\nJITing tree with scratch %d and ldo is %d\n", eqn_tree_id, copy_mateqn_desc.ldo);
       libxsmm_matrix_eqn_trv_dbg_print( cur_eqn->eqn_root, 0);
 #endif
-      if (eqn_tree_id < queue_size - 1) {
-        copy_mateqn_desc.ldo = cur_eqn->eqn_root->tmp.m;
-      }
       l_kernel_config.meltw_kernel_config.vector_name = l_kernel_config.vector_name;
       libxsmm_generator_matequation_tmp_stack_scratch_avx_avx512_kernel(io_generated_code, &copy_mateqn_desc, &l_gp_reg_mapping, &l_kernel_config, &l_loop_label_tracker, cur_eqn);
     } else {
@@ -718,7 +1002,7 @@ void libxsmm_generator_matequation_avx_avx512_kernel( libxsmm_generated_code*   
       libxsmm_generator_reoptimize_eqn(cur_eqn);
       memset(&(l_kernel_config.meltw_kernel_config), 0, sizeof(libxsmm_mateltwise_kernel_config));
 #if 0
-      printf("\nJITing tree with regblocks %d\n", eqn_tree_id);
+      printf("\nJITing tree with regblocks %d and ldo is %d\n", eqn_tree_id, copy_mateqn_desc.ldo);
       libxsmm_matrix_eqn_trv_dbg_print( cur_eqn->eqn_root, 0);
 #endif
       l_kernel_config.meltw_kernel_config.vector_name = l_kernel_config.vector_name;

--- a/src/generator_matequation_avx_avx512.h
+++ b/src/generator_matequation_avx_avx512.h
@@ -23,6 +23,38 @@
 #define BINARY_OP_POOL 1
 
 LIBXSMM_API_INTERN
+void apply_fusion_pattern_transformation(libxsmm_matrix_eqn_fusion_pattern_type fusion_pattern,
+                                               libxsmm_matrix_eqn_elem                *cur_node,
+                                               libxsmm_matrix_eqn_elem                *new_arg_node,
+                                               unsigned int                           *timestamp,
+                                               unsigned int                           last_timestamp );
+
+LIBXSMM_API_INTERN
+void apply_xgemm_fusion_pattern_transformation(libxsmm_matrix_eqn_fusion_pattern_type fusion_pattern,
+                                               libxsmm_matrix_eqn_elem                *cur_node,
+                                               libxsmm_matrix_eqn_elem                *new_arg_node,
+                                               unsigned int                           *timestamp,
+                                               unsigned int                           last_timestamp );
+
+LIBXSMM_API_INTERN
+int find_in_pos_for_colbias(libxsmm_matrix_eqn_elem *colbias_add_node);
+
+LIBXSMM_API_INTERN
+libxsmm_datatype find_dtype_for_colbias(libxsmm_matrix_eqn_elem *colbias_add_node);
+
+LIBXSMM_API_INTERN
+libxsmm_matrix_eqn_fusion_pattern_type find_fusion_pattern_with_ancestors(libxsmm_matrix_eqn_elem *cur_node, libxsmm_matrix_eqn_fusion_knobs *fusion_knobs);
+
+LIBXSMM_API_INTERN
+libxsmm_matrix_eqn_fusion_pattern_type find_xgemm_fusion_pattern_with_ancestors(libxsmm_matrix_eqn_elem *xgemm_node);
+
+LIBXSMM_API_INTERN
+int is_xgemm_node_supporting_fusion(libxsmm_matrix_eqn_elem  *xgemm_node);
+
+LIBXSMM_API_INTERN
+int is_xgemm_node(libxsmm_matrix_eqn_elem  *cur_node);
+
+LIBXSMM_API_INTERN
 void libxsmm_generator_matequation_init_micro_kernel_config( libxsmm_generated_code*         io_generated_code,
     libxsmm_matequation_kernel_config*    io_micro_kernel_config);
 
@@ -68,13 +100,13 @@ LIBXSMM_API_INTERN
 libxsmm_matrix_eqn_elem* find_op_at_timestamp(libxsmm_matrix_eqn_elem* cur_node, libxsmm_blasint timestamp);
 
 LIBXSMM_API_INTERN
-int is_eqn_node_breaking_point(libxsmm_matrix_eqn_elem *node);
+int is_eqn_node_breaking_point(libxsmm_matrix_eqn_elem *node, libxsmm_matrix_eqn_fusion_knobs *fusion_knobs);
 
 LIBXSMM_API_INTERN
 void enqueue_equation(libxsmm_matrix_eqn *eqn, libxsmm_matrix_eqn **jiting_queue, unsigned int *queue_size);
 
 LIBXSMM_API_INTERN
-void libxsmm_generator_decompose_equation_tree( libxsmm_matrix_eqn *eqn, libxsmm_matrix_eqn **jiting_queue, unsigned int *queue_size );
+void libxsmm_generator_decompose_equation_tree_x86( libxsmm_matrix_eqn *eqn, libxsmm_matrix_eqn **jiting_queue, unsigned int *queue_size, libxsmm_matrix_eqn_fusion_knobs *fusion_knobs );
 
 LIBXSMM_API_INTERN
 void libxsmm_generator_assign_new_timestamp(libxsmm_matrix_eqn_elem* cur_node, libxsmm_blasint *current_timestamp );

--- a/src/generator_matequation_regblocks_avx_avx512.c
+++ b/src/generator_matequation_regblocks_avx_avx512.c
@@ -30,7 +30,7 @@ void libxsmm_generator_copy_input_args(libxsmm_generated_code*        io_generat
     libxsmm_matequation_kernel_config   *i_micro_kernel_config,
     libxsmm_matrix_eqn_elem             *cur_node,
     unsigned int                        *arg_id,
-    libxsmm_matrix_eqn_arg              *arg_info,
+    libxsmm_matrix_eqn_arg_v2           *arg_info,
     unsigned int                        input_reg) {
 
   unsigned int temp_reg = i_gp_reg_mapping->temp_reg;
@@ -134,7 +134,7 @@ void libxsmm_generator_mateqn_adjust_args_addr(libxsmm_generated_code*        io
     unsigned int                        i_adjust_instr,
     unsigned int                        i_adjust_amount,
     unsigned int                        i_adjust_type,
-    libxsmm_matrix_eqn_arg              *arg_info) {
+    libxsmm_matrix_eqn_arg_v2           *arg_info) {
 
   unsigned int n_args = i_micro_kernel_config->n_args;
   unsigned int i;
@@ -414,7 +414,7 @@ void libxsmm_generator_mateqn_load_arg_to_2d_reg_block( libxsmm_generated_code* 
   unsigned int temp_reg = i_gp_reg_mapping->temp_reg;
   unsigned int temp_reg2 = i_gp_reg_mapping->temp_reg2;
   unsigned int cur_vreg;
-  libxsmm_matrix_eqn_arg  *arg_info = i_micro_kernel_config->arg_info;
+  libxsmm_matrix_eqn_arg_v2  *arg_info = i_micro_kernel_config->arg_info;
   unsigned int i_start_vreg = get_start_of_register_block(i_micro_kernel_config, i_reg_block_id);
   unsigned int input_reg = 0;
   char vname = (LIBXSMM_TYPESIZE(arg_info[i_arg_id].dtype) * i_vlen == 64) ? 'z' : 'y';
@@ -1384,7 +1384,7 @@ void libxsmm_generator_matequation_tmp_register_block_avx_avx512_kernel( libxsmm
     libxsmm_matequation_kernel_config*      i_micro_kernel_config,
     libxsmm_loop_label_tracker*             io_loop_label_tracker,
     libxsmm_matrix_eqn*                     eqn ) {
-  libxsmm_matrix_eqn_arg              *arg_info;
+  libxsmm_matrix_eqn_arg_v2              *arg_info;
   unsigned int arg_id = 0, i = 0;
   unsigned int m_blocking = 0, n_blocking = 0, cur_n = 0, cur_m = 0, n_microkernel = 0, m_microkernel = 0, adjusted_aux_vars = 0;
   if ( eqn == NULL ) {
@@ -1409,7 +1409,7 @@ void libxsmm_generator_matequation_tmp_register_block_avx_avx512_kernel( libxsmm
       LIBXSMM_X86_GP_REG_R15,
       0 );
 
-  arg_info = (libxsmm_matrix_eqn_arg*) malloc(i_micro_kernel_config->n_args * sizeof(libxsmm_matrix_eqn_arg));
+  arg_info = (libxsmm_matrix_eqn_arg_v2*) malloc(i_micro_kernel_config->n_args * sizeof(libxsmm_matrix_eqn_arg_v2));
   i_micro_kernel_config->contains_binary_op = 0;
   i_micro_kernel_config->contains_ternary_op = 0;
   libxsmm_generator_copy_input_args(io_generated_code, i_gp_reg_mapping, i_micro_kernel_config, eqn->eqn_root, &arg_id, arg_info, LIBXSMM_X86_GP_REG_R15);

--- a/src/generator_matequation_regblocks_avx_avx512.h
+++ b/src/generator_matequation_regblocks_avx_avx512.h
@@ -22,7 +22,7 @@ void libxsmm_generator_copy_input_args(libxsmm_generated_code*        io_generat
     libxsmm_matequation_kernel_config   *i_micro_kernel_config,
     libxsmm_matrix_eqn_elem             *cur_node,
     unsigned int                        *arg_id,
-    libxsmm_matrix_eqn_arg              *arg_info,
+    libxsmm_matrix_eqn_arg_v2           *arg_info,
     unsigned int                        input_reg);
 
 LIBXSMM_API_INTERN
@@ -33,7 +33,7 @@ void libxsmm_generator_mateqn_adjust_args_addr(libxsmm_generated_code*        io
     unsigned int                        i_adjust_instr,
     unsigned int                        i_adjust_amount,
     unsigned int                        i_adjust_type,
-    libxsmm_matrix_eqn_arg              *arg_info);
+    libxsmm_matrix_eqn_arg_v2           *arg_info);
 
 LIBXSMM_API_INTERN
 void libxsmm_configure_mateqn_microkernel_loops( libxsmm_generated_code*                 io_generated_code,

--- a/src/generator_matequation_scratch_avx_avx512.h
+++ b/src/generator_matequation_scratch_avx_avx512.h
@@ -14,6 +14,15 @@
 #include "libxsmm_main.h"
 
 LIBXSMM_API_INTERN
+void libxsmm_generator_matequation_gemm_set_reg_mapping_amx( libxsmm_gemm_descriptor* i_xgemm_desc, libxsmm_gp_reg_mapping*  i_gp_reg_mapping );
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_matequation_gemm_set_reg_mapping( libxsmm_gemm_descriptor* i_xgemm_desc, libxsmm_gp_reg_mapping*  i_gp_reg_mapping );
+
+LIBXSMM_API_INTERN
+void libxsmm_generator_matequation_gemm_set_descriptor(libxsmm_generated_code*   io_generated_code, libxsmm_matrix_eqn_elem *cur_op,  libxsmm_gemm_descriptor **out_desc );
+
+LIBXSMM_API_INTERN
 void libxsmm_generator_matequation_create_unary_descriptor(libxsmm_descriptor_blob *blob,
     libxsmm_matrix_eqn_elem *cur_op,
     libxsmm_meltw_descriptor **desc,

--- a/src/libxsmm_matrixeqn.c
+++ b/src/libxsmm_matrixeqn.c
@@ -107,7 +107,7 @@ LIBXSMM_API_INTERN libxsmm_blasint can_overwrite_unary_input(libxsmm_matrix_eqn_
 LIBXSMM_API_INTERN libxsmm_blasint can_overwrite_binary_input(libxsmm_matrix_eqn_elem* cur_node);
 LIBXSMM_API_INTERN libxsmm_blasint can_overwrite_binary_input(libxsmm_matrix_eqn_elem* cur_node) {
   libxsmm_blasint result = 1;
-  if (cur_node->info.b_op.type == LIBXSMM_MELTW_TYPE_BINARY_MATMUL) {
+  if ((cur_node->info.b_op.is_matmul == 1) || (cur_node->info.b_op.is_brgemm == 1)) {
     result = 0;
   }
   if (((cur_node->le->tmp.dtype == LIBXSMM_DATATYPE_BF16) || (cur_node->ri->tmp.dtype == LIBXSMM_DATATYPE_BF16)) && (cur_node->tmp.dtype == LIBXSMM_DATATYPE_F32)) {
@@ -116,7 +116,6 @@ LIBXSMM_API_INTERN libxsmm_blasint can_overwrite_binary_input(libxsmm_matrix_eqn
   return result;
 }
 
-LIBXSMM_API_INTERN void libxsmm_matrix_eqn_trv_dbg_print( libxsmm_matrix_eqn_elem* cur_node, libxsmm_blasint indent );
 LIBXSMM_API_INTERN void libxsmm_matrix_eqn_trv_dbg_print( libxsmm_matrix_eqn_elem* cur_node, libxsmm_blasint indent ) {
   libxsmm_blasint i;
   libxsmm_blasint tree_print_indent = 4;
@@ -347,7 +346,8 @@ LIBXSMM_API_INTERN void libxsmm_matrix_eqn_exec_plan_configure_binary_tmp(libxsm
 LIBXSMM_API_INTERN void libxsmm_matrix_eqn_exec_plan_configure_binary_tmp(libxsmm_matrix_eqn_elem* cur_node) {
   cur_node->tmp.m  = cur_node->le->tmp.m;
   cur_node->tmp.ld  = cur_node->le->tmp.m;
-  if (cur_node->info.b_op.type == LIBXSMM_MELTW_TYPE_BINARY_MATMUL) {
+  if ((cur_node->info.b_op.is_matmul == 1) ||
+      (cur_node->info.b_op.is_brgemm == 1)) {
     cur_node->tmp.n  = cur_node->ri->tmp.n;
   } else {
     cur_node->tmp.n  = cur_node->le->tmp.n;
@@ -360,7 +360,8 @@ LIBXSMM_API_INTERN void libxsmm_matrix_eqn_exec_plan_configure_ternary_tmp(libxs
   cur_node->tmp.m  = cur_node->r2->tmp.m;
   cur_node->tmp.n  = cur_node->r2->tmp.n;
   cur_node->tmp.ld  = cur_node->r2->tmp.m;
-  if (cur_node->info.t_op.type == LIBXSMM_MELTW_TYPE_TERNARY_MATMUL) {
+  if ((cur_node->info.t_op.is_matmul == 1) ||
+      (cur_node->info.t_op.is_brgemm == 1)) {
     cur_node->tmp.m  = cur_node->r2->tmp.m;
     cur_node->tmp.n  = cur_node->r2->tmp.n;
     cur_node->tmp.ld  = cur_node->r2->tmp.ld;
@@ -398,7 +399,7 @@ LIBXSMM_API_INTERN void libxsmm_matrix_eqn_exec_plan_visit_unary_node(libxsmm_ma
       cur_node->tmp.id = cur_node->le->tmp.id;
     } else {
       cur_node->tmp.id = reserve_tmp_storage( n_max_tmp, tmp_storage_pool );
-      tmp_storage_pool[cur_node->le->tmp.id] = 0;
+      if (cur_node->le->tmp.id >= 0) tmp_storage_pool[cur_node->le->tmp.id] = 0;
     }
     cur_node->tree_max_comp_tsize = LIBXSMM_MAX( LIBXSMM_TYPESIZE(cur_node->info.u_op.dtype), cur_node->le->tree_max_comp_tsize );
   }
@@ -413,8 +414,8 @@ LIBXSMM_API_INTERN void libxsmm_matrix_eqn_exec_plan_visit_binary_node(libxsmm_m
   cur_node->n_args = cur_node->le->n_args + cur_node->ri->n_args;
   cur_node->max_tmp_size = LIBXSMM_MAX(cur_node->le->max_tmp_size, cur_node->ri->max_tmp_size);
   /* Max tmp size has to be adjusted if it is a MATMUL op  */
-  if (cur_node->info.b_op.type == LIBXSMM_MELTW_TYPE_BINARY_MATMUL) {
-    libxsmm_blasint matmul_out_size = cur_node->le->tmp.ld * cur_node->ri->tmp.n;
+  if ((cur_node->info.b_op.is_matmul == 1) || (cur_node->info.b_op.is_brgemm == 1)) {
+    libxsmm_blasint matmul_out_size = cur_node->le->tmp.m * cur_node->ri->tmp.n;
     cur_node->max_tmp_size = LIBXSMM_MAX(matmul_out_size, cur_node->max_tmp_size);
   }
   /* When assigning the tmp output storage, we have three cases in the binary:
@@ -427,11 +428,11 @@ LIBXSMM_API_INTERN void libxsmm_matrix_eqn_exec_plan_visit_binary_node(libxsmm_m
   } else if ( (cur_node->le->type != LIBXSMM_MATRIX_EQN_NODE_ARG) && (cur_node->ri->type != LIBXSMM_MATRIX_EQN_NODE_ARG) ) {
     if (can_overwrite_binary_input(cur_node) > 0) {
       cur_node->tmp.id = cur_node->le->tmp.id;
-      tmp_storage_pool[cur_node->ri->tmp.id] = 0;
+      if (cur_node->ri->tmp.id >= 0) tmp_storage_pool[cur_node->ri->tmp.id] = 0;
     } else {
       cur_node->tmp.id = reserve_tmp_storage( n_max_tmp, tmp_storage_pool );
-      tmp_storage_pool[cur_node->le->tmp.id] = 0;
-      tmp_storage_pool[cur_node->ri->tmp.id] = 0;
+      if (cur_node->le->tmp.id >= 0) tmp_storage_pool[cur_node->le->tmp.id] = 0;
+      if (cur_node->ri->tmp.id >= 0) tmp_storage_pool[cur_node->ri->tmp.id] = 0;
     }
     cur_node->tree_max_comp_tsize = LIBXSMM_MAX( LIBXSMM_TYPESIZE( cur_node->info.b_op.dtype ), LIBXSMM_MAX( cur_node->ri->tree_max_comp_tsize, cur_node->le->tree_max_comp_tsize ));
   } else {
@@ -440,7 +441,7 @@ LIBXSMM_API_INTERN void libxsmm_matrix_eqn_exec_plan_visit_binary_node(libxsmm_m
         cur_node->tmp.id = cur_node->le->tmp.id;
       } else {
         cur_node->tmp.id = reserve_tmp_storage( n_max_tmp, tmp_storage_pool );
-        tmp_storage_pool[cur_node->le->tmp.id] = 0;
+        if (cur_node->le->tmp.id >= 0) tmp_storage_pool[cur_node->le->tmp.id] = 0;
       }
       cur_node->tree_max_comp_tsize = LIBXSMM_MAX( LIBXSMM_TYPESIZE(cur_node->info.b_op.dtype), cur_node->le->tree_max_comp_tsize );
     } else {
@@ -448,7 +449,7 @@ LIBXSMM_API_INTERN void libxsmm_matrix_eqn_exec_plan_visit_binary_node(libxsmm_m
         cur_node->tmp.id = cur_node->ri->tmp.id;
       } else {
         cur_node->tmp.id = reserve_tmp_storage( n_max_tmp, tmp_storage_pool );
-        tmp_storage_pool[cur_node->ri->tmp.id] = 0;
+        if (cur_node->ri->tmp.id >= 0) tmp_storage_pool[cur_node->ri->tmp.id] = 0;
       }
       cur_node->tree_max_comp_tsize = LIBXSMM_MAX( LIBXSMM_TYPESIZE(cur_node->info.b_op.dtype), cur_node->ri->tree_max_comp_tsize );
     }
@@ -465,60 +466,76 @@ LIBXSMM_API_INTERN void libxsmm_matrix_eqn_exec_plan_visit_ternary_node(libxsmm_
   cur_node->n_args = cur_node->le->n_args + cur_node->ri->n_args + cur_node->r2->n_args;
   cur_node->max_tmp_size = LIBXSMM_MAX( LIBXSMM_MAX(cur_node->le->max_tmp_size, cur_node->ri->max_tmp_size), cur_node->r2->max_tmp_size);
   if ( (cur_node->le->type == LIBXSMM_MATRIX_EQN_NODE_ARG) && (cur_node->ri->type == LIBXSMM_MATRIX_EQN_NODE_ARG) && (cur_node->r2->type == LIBXSMM_MATRIX_EQN_NODE_ARG) ) {
-    cur_node->tmp.id = reserve_tmp_storage( n_max_tmp, tmp_storage_pool );
+    if ((use_r2_as_output > 0) && ((cur_node->info.t_op.is_brgemm == 1) || (cur_node->info.t_op.is_matmul == 1))) {
+      cur_node->tmp.id = -(cur_node->r2->info.arg.in_pos + 1);
+    } else {
+      cur_node->tmp.id = reserve_tmp_storage( n_max_tmp, tmp_storage_pool );
+    }
     cur_node->tree_max_comp_tsize = LIBXSMM_TYPESIZE( cur_node->info.t_op.dtype );
   } else if ( (cur_node->le->type != LIBXSMM_MATRIX_EQN_NODE_ARG) && (cur_node->ri->type != LIBXSMM_MATRIX_EQN_NODE_ARG) && (cur_node->r2->type != LIBXSMM_MATRIX_EQN_NODE_ARG) ) {
     if (use_r2_as_output > 0 ) {
       cur_node->tmp.id = cur_node->r2->tmp.id;
-      tmp_storage_pool[cur_node->le->tmp.id] = 0;
-      tmp_storage_pool[cur_node->ri->tmp.id] = 0;
+      if (cur_node->le->tmp.id >= 0) tmp_storage_pool[cur_node->le->tmp.id] = 0;
+      if (cur_node->ri->tmp.id >= 0) tmp_storage_pool[cur_node->ri->tmp.id] = 0;
     } else {
       cur_node->tmp.id = reserve_tmp_storage( n_max_tmp, tmp_storage_pool );
-      tmp_storage_pool[cur_node->le->tmp.id] = 0;
-      tmp_storage_pool[cur_node->ri->tmp.id] = 0;
-      tmp_storage_pool[cur_node->r2->tmp.id] = 0;
+      if (cur_node->le->tmp.id >= 0) tmp_storage_pool[cur_node->le->tmp.id] = 0;
+      if (cur_node->ri->tmp.id >= 0) tmp_storage_pool[cur_node->ri->tmp.id] = 0;
+      if (cur_node->r2->tmp.id >= 0) tmp_storage_pool[cur_node->r2->tmp.id] = 0;
     }
     cur_node->tree_max_comp_tsize = LIBXSMM_MAX( LIBXSMM_TYPESIZE( cur_node->info.t_op.dtype ), LIBXSMM_MAX( cur_node->r2->tree_max_comp_tsize, LIBXSMM_MAX( cur_node->ri->tree_max_comp_tsize, cur_node->le->tree_max_comp_tsize )));
   } else if ( (cur_node->le->type == LIBXSMM_MATRIX_EQN_NODE_ARG) && (cur_node->ri->type != LIBXSMM_MATRIX_EQN_NODE_ARG) && (cur_node->r2->type != LIBXSMM_MATRIX_EQN_NODE_ARG) ) {
     if (use_r2_as_output > 0 ) {
       cur_node->tmp.id = cur_node->r2->tmp.id;
-      tmp_storage_pool[cur_node->ri->tmp.id] = 0;
+      if (cur_node->ri->tmp.id >= 0) tmp_storage_pool[cur_node->ri->tmp.id] = 0;
     } else {
       cur_node->tmp.id = reserve_tmp_storage( n_max_tmp, tmp_storage_pool );
-      tmp_storage_pool[cur_node->ri->tmp.id] = 0;
-      tmp_storage_pool[cur_node->r2->tmp.id] = 0;
+      if (cur_node->ri->tmp.id >= 0) tmp_storage_pool[cur_node->ri->tmp.id] = 0;
+      if (cur_node->r2->tmp.id >= 0) tmp_storage_pool[cur_node->r2->tmp.id] = 0;
     }
     cur_node->tree_max_comp_tsize = LIBXSMM_MAX( LIBXSMM_TYPESIZE( cur_node->info.t_op.dtype ), LIBXSMM_MAX( cur_node->r2->tree_max_comp_tsize, LIBXSMM_MAX( cur_node->ri->tree_max_comp_tsize, 1 )));
   } else if ( (cur_node->le->type != LIBXSMM_MATRIX_EQN_NODE_ARG) && (cur_node->ri->type == LIBXSMM_MATRIX_EQN_NODE_ARG) && (cur_node->r2->type != LIBXSMM_MATRIX_EQN_NODE_ARG) ) {
     if (use_r2_as_output > 0 ) {
       cur_node->tmp.id = cur_node->r2->tmp.id;
-      tmp_storage_pool[cur_node->le->tmp.id] = 0;
+      if (cur_node->le->tmp.id >= 0) tmp_storage_pool[cur_node->le->tmp.id] = 0;
     } else {
       cur_node->tmp.id = reserve_tmp_storage( n_max_tmp, tmp_storage_pool );
-      tmp_storage_pool[cur_node->le->tmp.id] = 0;
-      tmp_storage_pool[cur_node->r2->tmp.id] = 0;
+      if (cur_node->le->tmp.id >= 0) tmp_storage_pool[cur_node->le->tmp.id] = 0;
+      if (cur_node->r2->tmp.id >= 0) tmp_storage_pool[cur_node->r2->tmp.id] = 0;
     }
     cur_node->tree_max_comp_tsize = LIBXSMM_MAX( LIBXSMM_TYPESIZE( cur_node->info.t_op.dtype ), LIBXSMM_MAX( cur_node->r2->tree_max_comp_tsize, LIBXSMM_MAX( 1, cur_node->le->tree_max_comp_tsize )));
   } else if ( (cur_node->le->type != LIBXSMM_MATRIX_EQN_NODE_ARG) && (cur_node->ri->type != LIBXSMM_MATRIX_EQN_NODE_ARG) && (cur_node->r2->type == LIBXSMM_MATRIX_EQN_NODE_ARG) ) {
-    cur_node->tmp.id = reserve_tmp_storage( n_max_tmp, tmp_storage_pool );
-    tmp_storage_pool[cur_node->le->tmp.id] = 0;
-    tmp_storage_pool[cur_node->ri->tmp.id] = 0;
+    if ((use_r2_as_output > 0) && ((cur_node->info.t_op.is_brgemm == 1) || (cur_node->info.t_op.is_matmul == 1))) {
+      cur_node->tmp.id = -(cur_node->r2->info.arg.in_pos + 1);
+    } else {
+      cur_node->tmp.id = reserve_tmp_storage( n_max_tmp, tmp_storage_pool );
+    }
+    if (cur_node->le->tmp.id >= 0) tmp_storage_pool[cur_node->le->tmp.id] = 0;
+    if (cur_node->ri->tmp.id >= 0) tmp_storage_pool[cur_node->ri->tmp.id] = 0;
     cur_node->tree_max_comp_tsize = LIBXSMM_MAX( LIBXSMM_TYPESIZE( cur_node->info.t_op.dtype ), LIBXSMM_MAX( 1, LIBXSMM_MAX( cur_node->ri->tree_max_comp_tsize, cur_node->le->tree_max_comp_tsize )));
   } else if ( (cur_node->le->type == LIBXSMM_MATRIX_EQN_NODE_ARG) && (cur_node->ri->type == LIBXSMM_MATRIX_EQN_NODE_ARG) && (cur_node->r2->type != LIBXSMM_MATRIX_EQN_NODE_ARG) ) {
     if (use_r2_as_output > 0 ) {
       cur_node->tmp.id = cur_node->r2->tmp.id;
     } else {
       cur_node->tmp.id = reserve_tmp_storage( n_max_tmp, tmp_storage_pool );
-      tmp_storage_pool[cur_node->r2->tmp.id] = 0;
+      if (cur_node->r2->tmp.id >= 0) tmp_storage_pool[cur_node->r2->tmp.id] = 0;
     }
     cur_node->tree_max_comp_tsize = LIBXSMM_MAX( LIBXSMM_TYPESIZE( cur_node->info.t_op.dtype ), LIBXSMM_MAX( cur_node->r2->tree_max_comp_tsize, LIBXSMM_MAX( 1, 1 )));
   } else if ( (cur_node->le->type != LIBXSMM_MATRIX_EQN_NODE_ARG) && (cur_node->ri->type == LIBXSMM_MATRIX_EQN_NODE_ARG) && (cur_node->r2->type == LIBXSMM_MATRIX_EQN_NODE_ARG) ) {
-    cur_node->tmp.id = reserve_tmp_storage( n_max_tmp, tmp_storage_pool );
-    tmp_storage_pool[cur_node->le->tmp.id] = 0;
+    if ((use_r2_as_output > 0) && ((cur_node->info.t_op.is_brgemm == 1) || (cur_node->info.t_op.is_matmul == 1))) {
+      cur_node->tmp.id = -(cur_node->r2->info.arg.in_pos + 1);
+    } else {
+      cur_node->tmp.id = reserve_tmp_storage( n_max_tmp, tmp_storage_pool );
+    }
+    if (cur_node->le->tmp.id >= 0) tmp_storage_pool[cur_node->le->tmp.id] = 0;
     cur_node->tree_max_comp_tsize = LIBXSMM_MAX( LIBXSMM_TYPESIZE( cur_node->info.t_op.dtype ), LIBXSMM_MAX( 1, LIBXSMM_MAX( 1, cur_node->le->tree_max_comp_tsize )));
   } else if ( (cur_node->le->type == LIBXSMM_MATRIX_EQN_NODE_ARG) && (cur_node->ri->type != LIBXSMM_MATRIX_EQN_NODE_ARG) && (cur_node->r2->type == LIBXSMM_MATRIX_EQN_NODE_ARG) ) {
-    cur_node->tmp.id = reserve_tmp_storage( n_max_tmp, tmp_storage_pool );
-    tmp_storage_pool[cur_node->ri->tmp.id] = 0;
+    if ((use_r2_as_output > 0) && ((cur_node->info.t_op.is_brgemm == 1) || (cur_node->info.t_op.is_matmul == 1))) {
+      cur_node->tmp.id = -(cur_node->r2->info.arg.in_pos + 1);
+    } else {
+      cur_node->tmp.id = reserve_tmp_storage( n_max_tmp, tmp_storage_pool );
+    }
+    if (cur_node->ri->tmp.id >= 0) tmp_storage_pool[cur_node->ri->tmp.id] = 0;
     cur_node->tree_max_comp_tsize = LIBXSMM_MAX( LIBXSMM_TYPESIZE( cur_node->info.t_op.dtype ), LIBXSMM_MAX( 1, LIBXSMM_MAX( cur_node->ri->tree_max_comp_tsize, 1)));
   }
   libxsmm_matrix_eqn_exec_plan_configure_ternary_tmp( cur_node );
@@ -548,15 +565,15 @@ LIBXSMM_API_INTERN void libxsmm_matrix_eqn_reassign_children_bcast_tmp(libxsmm_m
     if ((cur_node->le->type != LIBXSMM_MATRIX_EQN_NODE_ARG) && (get_bcast_type_ternary(cur_node->info.t_op.flags, LEFT) != LIBXSMM_MATRIX_EQN_BCAST_TYPE_NONE)) {
       cur_node->le->tmp.id = eqn->eqn_root->reg_score;
       eqn->eqn_root->reg_score = eqn->eqn_root->reg_score + 1;
-     }
+    }
     if ((cur_node->ri->type != LIBXSMM_MATRIX_EQN_NODE_ARG) && (get_bcast_type_ternary(cur_node->info.t_op.flags, RIGHT) != LIBXSMM_MATRIX_EQN_BCAST_TYPE_NONE)) {
       cur_node->ri->tmp.id = eqn->eqn_root->reg_score;
       eqn->eqn_root->reg_score = eqn->eqn_root->reg_score + 1;
-     }
+    }
     if ((cur_node->r2->type != LIBXSMM_MATRIX_EQN_NODE_ARG) && (get_bcast_type_ternary(cur_node->info.t_op.flags, RIGHT2) != LIBXSMM_MATRIX_EQN_BCAST_TYPE_NONE)) {
       cur_node->r2->tmp.id = eqn->eqn_root->reg_score;
       eqn->eqn_root->reg_score = eqn->eqn_root->reg_score + 1;
-     }
+    }
     libxsmm_matrix_eqn_reassign_children_bcast_tmp(eqn, cur_node->le);
     libxsmm_matrix_eqn_reassign_children_bcast_tmp(eqn, cur_node->ri);
     libxsmm_matrix_eqn_reassign_children_bcast_tmp(eqn, cur_node->r2);
@@ -714,6 +731,10 @@ LIBXSMM_API_INTERN void libxsmm_matrix_eqn_adjust_tmp_sizes( libxsmm_matrix_eqn_
       cur_node->tmp.m = 1;
       cur_node->tmp.n = 1;
       cur_node->tmp.ld = 1;
+    } else if ((cur_node->info.b_op.is_matmul == 1) || (cur_node->info.b_op.is_brgemm == 1)) {
+      cur_node->tmp.m = cur_node->le->tmp.m;
+      cur_node->tmp.n = cur_node->ri->tmp.n;
+      cur_node->tmp.ld = cur_node->le->tmp.m;
     } else {
       cur_node->tmp.m = LIBXSMM_MAX(cur_node->le->tmp.m, cur_node->ri->tmp.m);
       cur_node->tmp.n = LIBXSMM_MAX(cur_node->le->tmp.n, cur_node->ri->tmp.n);
@@ -723,9 +744,15 @@ LIBXSMM_API_INTERN void libxsmm_matrix_eqn_adjust_tmp_sizes( libxsmm_matrix_eqn_
     libxsmm_matrix_eqn_adjust_tmp_sizes( cur_node->le );
     libxsmm_matrix_eqn_adjust_tmp_sizes( cur_node->ri);
     libxsmm_matrix_eqn_adjust_tmp_sizes( cur_node->r2);
-    cur_node->tmp.m = LIBXSMM_MAX(cur_node->r2->tmp.m, LIBXSMM_MAX(cur_node->le->tmp.m, cur_node->ri->tmp.m));
-    cur_node->tmp.n = LIBXSMM_MAX(cur_node->r2->tmp.n, LIBXSMM_MAX(cur_node->le->tmp.n, cur_node->ri->tmp.n));
-    cur_node->tmp.ld = LIBXSMM_MAX( cur_node->r2->tmp.m, LIBXSMM_MAX(cur_node->le->tmp.m, cur_node->ri->tmp.m));
+    if ((cur_node->info.t_op.is_matmul == 1) || (cur_node->info.t_op.is_brgemm == 1)) {
+      cur_node->tmp.m = cur_node->r2->tmp.m;
+      cur_node->tmp.n = cur_node->r2->tmp.n;
+      cur_node->tmp.ld = cur_node->r2->tmp.ld;
+    } else {
+      cur_node->tmp.m = LIBXSMM_MAX(cur_node->r2->tmp.m, LIBXSMM_MAX(cur_node->le->tmp.m, cur_node->ri->tmp.m));
+      cur_node->tmp.n = LIBXSMM_MAX(cur_node->r2->tmp.n, LIBXSMM_MAX(cur_node->le->tmp.n, cur_node->ri->tmp.n));
+      cur_node->tmp.ld = LIBXSMM_MAX( cur_node->r2->tmp.m, LIBXSMM_MAX(cur_node->le->tmp.m, cur_node->ri->tmp.m));
+    }
   }
 }
 
@@ -1154,9 +1181,9 @@ LIBXSMM_API int libxsmm_matrix_eqn_push_back_arg( const libxsmm_blasint idx, con
   return 0;
 }
 
-
-LIBXSMM_API int libxsmm_matrix_eqn_push_back_arg_v2( const libxsmm_blasint idx, const libxsmm_meqn_arg_shape arg_shape, const libxsmm_blasint in_pos, const libxsmm_blasint offs_in_pos ) {
+LIBXSMM_API int libxsmm_matrix_eqn_push_back_arg_v2( const libxsmm_matrix_eqn_arg_metadata arg_metadata, const libxsmm_meqn_arg_shape arg_shape, libxsmm_matrix_arg_attributes arg_attr ) {
   union libxsmm_matrix_eqn_info info;
+  libxsmm_blasint idx = arg_metadata.eqn_idx;
 
   if ( libxsmm_matrix_eqns[idx] == NULL ) {
     fprintf( stderr, "the requested equation doesn't exist!\n" );
@@ -1170,9 +1197,9 @@ LIBXSMM_API int libxsmm_matrix_eqn_push_back_arg_v2( const libxsmm_blasint idx, 
   info.arg.m = arg_shape.m;
   info.arg.n = arg_shape.n;
   info.arg.ld = ( arg_shape.ld != NULL) ? *(arg_shape.ld) : arg_shape.m;
-  info.arg.in_pos = in_pos;
-  info.arg.offs_in_pos = offs_in_pos;
+  info.arg.in_pos = arg_metadata.in_arg_pos;
   info.arg.dtype = arg_shape.type;
+  info.arg.arg_attr = arg_attr;
   libxsmm_matrix_eqns[idx]->eqn_cur = libxsmm_matrix_eqn_add_node( libxsmm_matrix_eqns[idx]->eqn_cur, LIBXSMM_MATRIX_EQN_NODE_ARG, info );
 #if 0
   printf("added arg node: %lld %i %i %i %i %i %i\n", libxsmm_matrix_eqns[idx]->eqn_cur, M, N, ld, in_pos, offs_in_pos, dtype );
@@ -1212,8 +1239,9 @@ LIBXSMM_API int libxsmm_matrix_eqn_push_back_unary_op( const libxsmm_blasint idx
 }
 
 
-LIBXSMM_API int libxsmm_matrix_eqn_push_back_unary_op_v2( const libxsmm_blasint idx, const libxsmm_meltw_unary_type unary_type, const libxsmm_datatype dtype, const libxsmm_bitfield unary_flags ) {
+LIBXSMM_API int libxsmm_matrix_eqn_push_back_unary_op_v2(const libxsmm_matrix_eqn_op_metadata op_metadata, const libxsmm_meltw_unary_type type, const libxsmm_datatype dtype, const libxsmm_bitfield flags) {
   union libxsmm_matrix_eqn_info info;
+  libxsmm_blasint idx = op_metadata.eqn_idx;
 
   if ( libxsmm_matrix_eqns[idx] == NULL ) {
     fprintf( stderr, "the requested equation doesn't exist!\n" );
@@ -1224,9 +1252,10 @@ LIBXSMM_API int libxsmm_matrix_eqn_push_back_unary_op_v2( const libxsmm_blasint 
     return 2;
   }
 
-  info.u_op.type  = unary_type;
-  info.u_op.flags = unary_flags;
+  info.u_op.type  = type;
+  info.u_op.flags = flags;
   info.u_op.dtype = dtype;
+  info.u_op.op_arg_pos = op_metadata.op_arg_pos;
   libxsmm_matrix_eqns[idx]->eqn_cur = libxsmm_matrix_eqn_add_node( libxsmm_matrix_eqns[idx]->eqn_cur, LIBXSMM_MATRIX_EQN_NODE_UNARY, info );
 #if 0
   printf("added unary node: %lld %i %i %i\n", libxsmm_matrix_eqns[idx]->eqn_cur, type, flags, dtype );
@@ -1237,7 +1266,6 @@ LIBXSMM_API int libxsmm_matrix_eqn_push_back_unary_op_v2( const libxsmm_blasint 
 
   return 0;
 }
-
 
 LIBXSMM_API int libxsmm_matrix_eqn_push_back_binary_op( const libxsmm_blasint idx, const libxsmm_meltw_binary_type type, const libxsmm_meltw_binary_flags flags, const libxsmm_datatype dtype ) {
   union libxsmm_matrix_eqn_info info;
@@ -1254,6 +1282,8 @@ LIBXSMM_API int libxsmm_matrix_eqn_push_back_binary_op( const libxsmm_blasint id
   info.b_op.type  = type;
   info.b_op.flags = (libxsmm_bitfield)flags;
   info.b_op.dtype = dtype;
+  info.b_op.is_matmul  = 0;
+  info.b_op.is_brgemm  = 0;
   libxsmm_matrix_eqns[idx]->eqn_cur = libxsmm_matrix_eqn_add_node( libxsmm_matrix_eqns[idx]->eqn_cur, LIBXSMM_MATRIX_EQN_NODE_BINARY, info );
 #if 0
   printf("added binary node: %lld %i %i %i\n", libxsmm_matrix_eqns[idx]->eqn_cur, type, flags, dtype );
@@ -1265,9 +1295,26 @@ LIBXSMM_API int libxsmm_matrix_eqn_push_back_binary_op( const libxsmm_blasint id
   return 0;
 }
 
-
-LIBXSMM_API int libxsmm_matrix_eqn_push_back_binary_op_v2( const libxsmm_blasint idx, const libxsmm_meltw_binary_type binary_type, const libxsmm_datatype dtype, const libxsmm_bitfield binary_flags ) {
+LIBXSMM_API int libxsmm_matrix_eqn_push_back_binary_op_v2(const libxsmm_matrix_eqn_op_metadata op_metadata, const libxsmm_meltw_binary_type type, const libxsmm_datatype dtype, const libxsmm_bitfield flags) {
   union libxsmm_matrix_eqn_info info;
+  libxsmm_blasint idx = op_metadata.eqn_idx;
+  unsigned int is_brgemm = ((type ==  LIBXSMM_MELTW_TYPE_BINARY_BRGEMM) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_BINARY_BRGEMM_B_TRANS) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_BINARY_BRGEMM_A_TRANS) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_BINARY_BRGEMM_A_TRANS_B_TRANS) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_BINARY_BRGEMM_A_VNNI) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_BINARY_BRGEMM_A_VNNI_B_TRANS) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_BINARY_BRGEMM_A_VNNI_TRANS) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_BINARY_BRGEMM_A_VNNI_TRANS_B_TRANS)) ? 1 : 0;
+
+  unsigned int is_matmul = ((type ==  LIBXSMM_MELTW_TYPE_BINARY_MATMUL) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_BINARY_MATMUL_B_TRANS) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_BINARY_MATMUL_A_TRANS) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_BINARY_MATMUL_A_TRANS_B_TRANS) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_BINARY_MATMUL_A_VNNI) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_BINARY_MATMUL_A_VNNI_B_TRANS) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_BINARY_MATMUL_A_VNNI_TRANS) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_BINARY_MATMUL_A_VNNI_TRANS_B_TRANS)) ? 1 : 0;
 
   if ( libxsmm_matrix_eqns[idx] == NULL ) {
     fprintf( stderr, "the requested equation doesn't exist!\n" );
@@ -1278,9 +1325,12 @@ LIBXSMM_API int libxsmm_matrix_eqn_push_back_binary_op_v2( const libxsmm_blasint
     return 2;
   }
 
-  info.b_op.type  = binary_type;
-  info.b_op.flags = binary_flags;
+  info.b_op.type  = type;
+  info.b_op.flags = flags;
   info.b_op.dtype = dtype;
+  info.b_op.op_arg_pos = op_metadata.op_arg_pos;
+  info.b_op.is_matmul  = is_matmul;
+  info.b_op.is_brgemm  = is_brgemm;
   libxsmm_matrix_eqns[idx]->eqn_cur = libxsmm_matrix_eqn_add_node( libxsmm_matrix_eqns[idx]->eqn_cur, LIBXSMM_MATRIX_EQN_NODE_BINARY, info );
 #if 0
   printf("added binary node: %lld %i %i %i\n", libxsmm_matrix_eqns[idx]->eqn_cur, type, flags, dtype );
@@ -1308,6 +1358,9 @@ LIBXSMM_API int libxsmm_matrix_eqn_push_back_ternary_op( const libxsmm_blasint i
   info.t_op.type  = type;
   info.t_op.flags = (libxsmm_bitfield)flags;
   info.t_op.dtype = dtype;
+  info.t_op.is_matmul  = 0;
+  info.t_op.is_brgemm  = 0;
+
   libxsmm_matrix_eqns[idx]->eqn_cur = libxsmm_matrix_eqn_add_node( libxsmm_matrix_eqns[idx]->eqn_cur, LIBXSMM_MATRIX_EQN_NODE_TERNARY, info );
 #if 0
   printf("added ternary node: %lld %i %i %i\n", libxsmm_matrix_eqns[idx]->eqn_cur, type, flags, dtype );
@@ -1319,9 +1372,26 @@ LIBXSMM_API int libxsmm_matrix_eqn_push_back_ternary_op( const libxsmm_blasint i
   return 0;
 }
 
-
-LIBXSMM_API int libxsmm_matrix_eqn_push_back_ternary_op_v2( const libxsmm_blasint idx, const libxsmm_meltw_ternary_type ternary_type, const libxsmm_datatype dtype, const libxsmm_bitfield ternary_flags ) {
+LIBXSMM_API int libxsmm_matrix_eqn_push_back_ternary_op_v2(const libxsmm_matrix_eqn_op_metadata op_metadata, const libxsmm_meltw_ternary_type type, const libxsmm_datatype dtype, const libxsmm_bitfield flags) {
   union libxsmm_matrix_eqn_info info;
+  libxsmm_blasint idx = op_metadata.eqn_idx;
+  unsigned int is_brgemm = ((type ==  LIBXSMM_MELTW_TYPE_TERNARY_BRGEMM) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_TERNARY_BRGEMM_B_TRANS) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_TERNARY_BRGEMM_A_TRANS) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_TERNARY_BRGEMM_A_TRANS_B_TRANS) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_TERNARY_BRGEMM_A_VNNI) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_TERNARY_BRGEMM_A_VNNI_B_TRANS) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_TERNARY_BRGEMM_A_VNNI_TRANS) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_TERNARY_BRGEMM_A_VNNI_TRANS_B_TRANS)) ? 1 : 0;
+
+  unsigned int is_matmul = ((type ==  LIBXSMM_MELTW_TYPE_TERNARY_MATMUL) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_TERNARY_MATMUL_B_TRANS) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_TERNARY_MATMUL_A_TRANS) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_TERNARY_MATMUL_A_TRANS_B_TRANS) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_TERNARY_MATMUL_A_VNNI) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_TERNARY_MATMUL_A_VNNI_B_TRANS) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_TERNARY_MATMUL_A_VNNI_TRANS) ||
+                            (type ==  LIBXSMM_MELTW_TYPE_TERNARY_MATMUL_A_VNNI_TRANS_B_TRANS)) ? 1 : 0;
 
   if ( libxsmm_matrix_eqns[idx] == NULL ) {
     fprintf( stderr, "the requested equation doesn't exist!\n" );
@@ -1332,9 +1402,12 @@ LIBXSMM_API int libxsmm_matrix_eqn_push_back_ternary_op_v2( const libxsmm_blasin
     return 2;
   }
 
-  info.t_op.type  = ternary_type;
-  info.t_op.flags = ternary_flags;
+  info.t_op.type  = type;
+  info.t_op.flags = flags;
   info.t_op.dtype = dtype;
+  info.t_op.op_arg_pos = op_metadata.op_arg_pos;
+  info.t_op.is_matmul  = is_matmul;
+  info.t_op.is_brgemm  = is_brgemm;
   libxsmm_matrix_eqns[idx]->eqn_cur = libxsmm_matrix_eqn_add_node( libxsmm_matrix_eqns[idx]->eqn_cur, LIBXSMM_MATRIX_EQN_NODE_TERNARY, info );
 #if 0
   printf("added ternary node: %lld %i %i %i\n", libxsmm_matrix_eqns[idx]->eqn_cur, type, flags, dtype );
@@ -1345,7 +1418,6 @@ LIBXSMM_API int libxsmm_matrix_eqn_push_back_ternary_op_v2( const libxsmm_blasin
 
   return 0;
 }
-
 
 LIBXSMM_API void libxsmm_matrix_eqn_tree_print( const libxsmm_blasint idx ) {
   if ( libxsmm_matrix_eqns[idx] == NULL ) {

--- a/src/libxsmm_matrixeqn.h
+++ b/src/libxsmm_matrixeqn.h
@@ -31,6 +31,13 @@ LIBXSMM_EXTERN_C typedef enum libxsmm_matrix_eqn_node_type {
   LIBXSMM_MATRIX_EQN_NODE_ARG     = 8
 } libxsmm_matrix_eqn_node_type;
 
+LIBXSMM_EXTERN_C typedef enum libxsmm_matrix_eqn_fusion_pattern_type {
+  LIBXSMM_MATRIX_EQN_FUSION_PATTERN_NONE                    = 0,
+  LIBXSMM_MATRIX_EQN_FUSION_PATTERN_XGEMM_UNARY             = 1,
+  LIBXSMM_MATRIX_EQN_FUSION_PATTERN_XGEMM_COLBIAS_ADD       = 2,
+  LIBXSMM_MATRIX_EQN_FUSION_PATTERN_XGEMM_COLBIAS_ADD_UNARY = 3
+} libxsmm_matrix_eqn_fusion_pattern_type;
+
 LIBXSMM_EXTERN_C typedef enum libxsmm_matrix_eqn_bcast_type {
   LIBXSMM_MATRIX_EQN_BCAST_TYPE_NONE   = 0,
   LIBXSMM_MATRIX_EQN_BCAST_TYPE_ROW    = 1,
@@ -42,18 +49,25 @@ LIBXSMM_EXTERN_C typedef struct LIBXSMM_RETARGETABLE LIBXSMM_MAY_ALIAS libxsmm_m
   libxsmm_meltw_unary_type  type;
   libxsmm_bitfield          flags;
   libxsmm_datatype          dtype;
+  libxsmm_blasint           op_arg_pos;
 } libxsmm_matrix_eqn_unary_op;
 
 LIBXSMM_EXTERN_C typedef struct LIBXSMM_RETARGETABLE LIBXSMM_MAY_ALIAS libxsmm_matrix_eqn_binary_op {
-  libxsmm_meltw_binary_type  type;
-  libxsmm_bitfield           flags;
-  libxsmm_datatype           dtype;
+  libxsmm_meltw_binary_type         type;
+  libxsmm_bitfield                  flags;
+  libxsmm_datatype                  dtype;
+  libxsmm_blasint                   op_arg_pos;
+  libxsmm_blasint                   is_matmul;
+  libxsmm_blasint                   is_brgemm;
 } libxsmm_matrix_eqn_binary_op;
 
 LIBXSMM_EXTERN_C typedef struct LIBXSMM_RETARGETABLE LIBXSMM_MAY_ALIAS libxsmm_matrix_eqn_ternary_op {
-  libxsmm_meltw_ternary_type  type;
-  libxsmm_bitfield            flags;
-  libxsmm_datatype            dtype;
+  libxsmm_meltw_ternary_type        type;
+  libxsmm_bitfield                  flags;
+  libxsmm_datatype                  dtype;
+  libxsmm_blasint                   op_arg_pos;
+  libxsmm_blasint                   is_matmul;
+  libxsmm_blasint                   is_brgemm;
 } libxsmm_matrix_eqn_ternary_op;
 
 LIBXSMM_EXTERN_C typedef struct LIBXSMM_RETARGETABLE LIBXSMM_MAY_ALIAS libxsmm_matrix_eqn_arg {
@@ -65,6 +79,17 @@ LIBXSMM_EXTERN_C typedef struct LIBXSMM_RETARGETABLE LIBXSMM_MAY_ALIAS libxsmm_m
   libxsmm_datatype dtype;
   libxsmm_matrix_eqn_bcast_type  bcast_type;
 } libxsmm_matrix_eqn_arg;
+
+LIBXSMM_EXTERN_C typedef struct LIBXSMM_RETARGETABLE LIBXSMM_MAY_ALIAS libxsmm_matrix_eqn_arg_v2 {
+  libxsmm_blasint  m;
+  libxsmm_blasint  n;
+  libxsmm_blasint  ld;
+  libxsmm_blasint  in_pos;
+  libxsmm_blasint  offs_in_pos;
+  libxsmm_datatype dtype;
+  libxsmm_matrix_eqn_bcast_type   bcast_type;
+  libxsmm_matrix_arg_attributes   arg_attr;
+} libxsmm_matrix_eqn_arg_v2;
 
 LIBXSMM_EXTERN_C typedef struct LIBXSMM_RETARGETABLE LIBXSMM_MAY_ALIAS libxsmm_matrix_eqn_tmp_info {
   libxsmm_blasint  id;
@@ -89,8 +114,24 @@ LIBXSMM_EXTERN_C typedef union LIBXSMM_RETARGETABLE libxsmm_matrix_eqn_info {
   libxsmm_matrix_eqn_unary_op   u_op;
   libxsmm_matrix_eqn_binary_op  b_op;
   libxsmm_matrix_eqn_ternary_op t_op;
-  libxsmm_matrix_eqn_arg        arg;
+  libxsmm_matrix_eqn_arg_v2     arg;
 } libxsmm_matrix_eqn_info;
+
+LIBXSMM_EXTERN_C typedef struct LIBXSMM_RETARGETABLE libxsmm_matrix_eqn_xgemm_fusion_info {
+  libxsmm_blasint   fused_sigmoid_op;
+  libxsmm_blasint   fused_relu_op;
+  libxsmm_blasint   fused_colbias_add_op;
+  libxsmm_blasint   colbias_pos_in_arg;
+  libxsmm_datatype  colbias_dtype;
+} libxsmm_matrix_eqn_xgemm_fusion_info;
+
+LIBXSMM_EXTERN_C typedef struct LIBXSMM_RETARGETABLE libxsmm_matrix_eqn_fusion_knobs {
+  libxsmm_blasint   may_fuse_xgemm;
+} libxsmm_matrix_eqn_fusion_knobs;
+
+LIBXSMM_EXTERN_C typedef union LIBXSMM_RETARGETABLE libxsmm_matrix_eqn_fusion_info {
+  libxsmm_matrix_eqn_xgemm_fusion_info   xgemm;
+} libxsmm_matrix_eqn_fusion_info;
 
 LIBXSMM_EXTERN_C typedef struct LIBXSMM_RETARGETABLE LIBXSMM_MAY_ALIAS libxsmm_matrix_eqn_elem {
   struct libxsmm_matrix_eqn_elem* le;
@@ -105,6 +146,7 @@ LIBXSMM_EXTERN_C typedef struct LIBXSMM_RETARGETABLE LIBXSMM_MAY_ALIAS libxsmm_m
   libxsmm_blasint                 max_tmp_size;
   libxsmm_blasint                 n_args;
   libxsmm_blasint                 tree_max_comp_tsize;
+  libxsmm_matrix_eqn_fusion_info  fusion_info;
 } libxsmm_matrix_eqn_elem;
 
 LIBXSMM_EXTERN_C typedef struct LIBXSMM_RETARGETABLE LIBXSMM_MAY_ALIAS libxsmm_matrix_eqn {
@@ -143,6 +185,6 @@ libxsmm_matrix_eqn_bcast_type get_bcast_type_ternary(libxsmm_bitfield flags, uns
 LIBXSMM_API_INTERN void libxsmm_matrix_eqn_reassign_bcast_tmp(libxsmm_matrix_eqn *eqn);
 LIBXSMM_API_INTERN void libxsmm_matrix_eqn_reassign_children_bcast_tmp(libxsmm_matrix_eqn *eqn, libxsmm_matrix_eqn_elem* cur_node);
 
-
+LIBXSMM_API_INTERN void libxsmm_matrix_eqn_trv_dbg_print( libxsmm_matrix_eqn_elem* cur_node, libxsmm_blasint indent );
 #endif /*LIBXSMM_MATRIXEQN_H*/
 

--- a/src/template/libxsmm.h
+++ b/src/template/libxsmm.h
@@ -554,10 +554,12 @@ LIBXSMM_API int libxsmm_matrix_eqn_push_back_arg( const libxsmm_blasint idx, con
 LIBXSMM_API int libxsmm_matrix_eqn_push_back_unary_op( const libxsmm_blasint idx, const libxsmm_meltw_unary_type type, const libxsmm_meltw_unary_flags flags, const libxsmm_datatype dtype );
 LIBXSMM_API int libxsmm_matrix_eqn_push_back_binary_op( const libxsmm_blasint idx, const libxsmm_meltw_binary_type type, const libxsmm_meltw_binary_flags flags, const libxsmm_datatype dtype );
 LIBXSMM_API int libxsmm_matrix_eqn_push_back_ternary_op( const libxsmm_blasint idx, const libxsmm_meltw_ternary_type type, const libxsmm_meltw_ternary_flags flags, const libxsmm_datatype dtype );
-LIBXSMM_API int libxsmm_matrix_eqn_push_back_arg_v2( const libxsmm_blasint idx, const libxsmm_meqn_arg_shape arg_shape, const libxsmm_blasint in_pos, const libxsmm_blasint offs_in_pos );
-LIBXSMM_API int libxsmm_matrix_eqn_push_back_unary_op_v2( const libxsmm_blasint idx, const libxsmm_meltw_unary_type unary_type, const libxsmm_datatype dtype, const libxsmm_bitfield unary_flags );
-LIBXSMM_API int libxsmm_matrix_eqn_push_back_binary_op_v2( const libxsmm_blasint idx, const libxsmm_meltw_binary_type binary_type, const libxsmm_datatype dtype, const libxsmm_bitfield binary_flags );
-LIBXSMM_API int libxsmm_matrix_eqn_push_back_ternary_op_v2( const libxsmm_blasint idx, const libxsmm_meltw_ternary_type ternary_type, const libxsmm_datatype dtype, const libxsmm_bitfield ternary_flags );
+
+LIBXSMM_API int libxsmm_matrix_eqn_push_back_arg_v2( const libxsmm_matrix_eqn_arg_metadata arg_metadata, const libxsmm_meqn_arg_shape arg_shape, libxsmm_matrix_arg_attributes arg_attr);
+LIBXSMM_API int libxsmm_matrix_eqn_push_back_unary_op_v2( const libxsmm_matrix_eqn_op_metadata op_metadata, const libxsmm_meltw_unary_type type, const libxsmm_datatype dtype, const libxsmm_bitfield flags);
+LIBXSMM_API int libxsmm_matrix_eqn_push_back_binary_op_v2( const libxsmm_matrix_eqn_op_metadata op_metadata, const libxsmm_meltw_binary_type type, const libxsmm_datatype dtype, const libxsmm_bitfield flags);
+LIBXSMM_API int libxsmm_matrix_eqn_push_back_ternary_op_v2( const libxsmm_matrix_eqn_op_metadata op_metadata, const libxsmm_meltw_ternary_type type, const libxsmm_datatype dtype, const libxsmm_bitfield flags);
+
 LIBXSMM_API void libxsmm_matrix_eqn_tree_print( const libxsmm_blasint idx );
 LIBXSMM_API void libxsmm_matrix_eqn_rpn_print( const libxsmm_blasint idx );
 LIBXSMM_API libxsmm_matrix_eqn_function libxsmm_dispatch_matrix_eqn_desc( const libxsmm_meqn_descriptor* descriptor );

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-master-1.17-2100
+enable_gemm_in_eqs-1.17-2209


### PR DESCRIPTION
* first commit for the new GEMM frontend:
- defintion
- taking away the variadic arguments

* added defintion for new dispatch frontend

* reworked gemm and gemm_ext API

* added datetype for A and B

* added 2 new options to the descriptor to use the new GEMM frontends

* some more defintions

* added implementation for simple v2 frontend

* got the simple f64/f32 v2 frontend enabled

* working BRGEMM under the new GEMM ABI, tested with FP64

* split entry point into x86 SIMD GEMM kernel such that new xgemm abi can
be used to call GEMM and BRGEMM from equations

* added initial support for gemm_ext ABI (erroring out in the moment any
kind of fusion is attempted)

* adjust filenames of dumps to refelct new ABIs and descriptor fields

* Checkpoint

* Minor ammend

* Some refactoring

* Added new API for eqs with matmul/brgemm

* SOme minor ammends

* Got in some basic bf16 testing

* Fixed spurious condition

* Refactored amx gemm for eqn integration

* Enhanced struct in stack for equations

* Changed order of calle saved regs in sack management

* Factored out the callee save management from stack frame logistics

* Added amx support in matmul in eqs

* Some refactoring in stack setup for gemm

* More refactoring in fusion infra

* Added more testers

* Started enabling new api for fused gemms

* replaced LIBXSMM_GEMM_PRECISION with LIBXSMM_DATATYPE -> the entire code
base uses now LIBXSMM_DATATYPE

* attempt to fix FORTRAN frontend

* more unused variable fixes

* added support for the new BRGEMM frontend for aarch64

* Added some basic fusion framework in equations

* added support for the new BRGEMM frontend for SPR AMX, tested with
BF16F32 kernel

* Got fusion in equations working

* made the new and slim dispatch for F32 and F64 the default in tests and
inside of LIBXSMM

* fixed abi file due to the removel of libxsmm_bsgemm and libxsmm_wigemm

* more abi fixes

* Guard fusion in equations

* Moving around code block to allow reuses

* Some more refactoring

* FIxed CI issue

* Second attempt

* Ammend

* Added new functions to push/pop gprs on x86

* fixed matrix equation driver incl. GEMM

* Now eqs deal with brcount as tertiary

* Added f32 mateq fused gemm tester

* Got in some f32 avx512 gemms fusion in eqs

* Added missing include

* Revert "Added missing include"

This reverts commit 2eea0dc4dcf5860330e716763ea4682a2ffb62d6.

* FIxed include

* Revert "FIxed include"

This reverts commit a6ff54eef026bfcf49c6039eb70d551dcd458efe.

* FIxed CI issue

* Added missing congif inits

* Moved guarding internally for fusion properties

* Proper init of ocerwrite C

* Added more fusion options in the matequation tester

* Started adding infra to test fused xgemms

* Enhanced tester

* Added also norm-checking

* MOdularized reference fused xgemm

* Some formatting

* Enriched tester

* Added bf16 colbias fusion

* Addded some more Bf16 fusion

* Got rest of fusions working

* Porting amx_emu to new infra

* Fixed datatype size

* Got emu in eqs working

* FIxed some CI issues

* Refactored colbias fusion in gemm

* Refactored fusion functions for xgemm to avoid code duplication

* More refactoring and fixed relu tester

* Fixed CI issue

* Got sigmoid in

* Enabled more fusion

* Complete matmul infra in eqs

* Added xgemm fusion diagnotics in equations

* Removed debug mssg

* Added some basic infra

* Minor ammend

* Added alignment

* Added fully TPP'ed code

* Got in some fusion

* Added some legwork for bwd

* Added basic bwd pass

* Added unified transpose kernel in bwd cnn tpp

* Added suport for external wt transpose

* Got in correct fallback bwd kernel

* Ammend

* Fully TPP-ized bwd f32 cnn

* Added basic upd cnn_tpp

* TPPed reduction

* Fully TPPized UPD cnn_tpp

* Rfactored code generation routines

* Rename cnn files

* Reduce call ammend

* Added some diagnostics

* Some MB=1 tuning

* Fixed some xompilation issues

* Some more fixes

* Minot ammend

* Added option for zeroing rim in fwd cnn tpp

* Added new v2 APIs for mateqs

* proper fusion init

* Driver ammend

* Rmoved cnn_tpp

* Added constness in the v2 API

Co-authored-by: egeorgan <evangelos.georganas@intel.com>


